### PR TITLE
Improve header processor to handle house format

### DIFF
--- a/lib/processors/remove_headers.rb
+++ b/lib/processors/remove_headers.rb
@@ -2,41 +2,40 @@ require_relative "base"
 
 module Processors
   class RemoveHeaders < Base
-    HEADER_FORMAT = /[A-Z]{3}\d{5}/
+    HOUSE_HEADER_FORMAT = /^\s*†?HR \d+/
     LINE_NUMBER_FORMAT = /^\s*\d+\s*$/
+    SENATE_HEADER_FORMAT = /^\s*[A-Z]{3}\d{5}/
 
     def processed_text
       lines = text.lines
+      acceptable_lines = []
 
-      if !(lines.first =~ HEADER_FORMAT)
-        text
-      else
-        # Construct a regular expression out of the header
-        # to handle whitespace variations
-        header = lines.first.gsub(/ +/, '\s+')
+      line_index = 0
+      while line_index < lines.count
+        if is_a_header?(lines[line_index])
+          # we found a header!
+          # now let's look for a line number immediately following it
 
-        acceptable_lines = []
-
-        line_index = 0
-        while line_index < lines.count
-          if(lines[line_index] =~ /^#{header}$/)
-            # found a header!
-            # now let's look for a line number immediately following it
-
-            if(lines[line_index+1] =~ LINE_NUMBER_FORMAT)
-              # the next line only contains a line number.
-              # Jump ahead to skip it.
-              line_index += 1
-            end
-          else
-            acceptable_lines << lines[line_index]
+          if lines[line_index+1].match(LINE_NUMBER_FORMAT)
+            # the next line only contains a line number.
+            # Jump ahead to skip it.
+            line_index += 1
           end
-
-          line_index += 1
+        else
+          acceptable_lines << lines[line_index]
         end
 
-        acceptable_lines.join
+        line_index += 1
       end
+
+      acceptable_lines.join
+    end
+
+    private
+
+    def is_a_header?(line)
+      line.match(SENATE_HEADER_FORMAT) ||
+        line.match(HOUSE_HEADER_FORMAT)
     end
   end
 end

--- a/output/megans_law.txt
+++ b/output/megans_law.txt
@@ -51,8 +51,6 @@ this Act is as follows:
       the registration and notification to the public and
       law enforcement officers of convicted sex offenders.
 
-       †HR 515 EAS
-                             3
           (4) Law enforcement reports indicate that known
       child-sex offenders are traveling internationally.
           (5) The commercial sexual exploitation of minors
@@ -79,8 +77,6 @@ this Act is as follows:
       wise provided, the term ‘‘covered sex offender’’ means
 
 
-      †HR 515 EAS
-                             4
      an individual who is a sex offender by reason of hav-
      ing been convicted of a sex offense against a minor.
           (4) DESTINATION COUNTRY  .—The term ‘‘destina-
@@ -107,8 +103,6 @@ this Act is as follows:
      term ‘‘National Sex Offender Registry’’ means the Na-
      tional Sex Offender Registry established by section
 
-      †HR 515 EAS
-                             5
      119 of the Adam Walsh Child Protection and Safety
      Act of 2006 (42 U.S.C. 16919).
           (9) SEX OFFENDER UNDER SORNA      .—The term
@@ -135,8 +129,6 @@ this Act is as follows:
           limitations contained in subparagraphs (B) and
           (C) of section 111(5) of the Adam Walsh Child
 
-      †HR 515 EAS
-                             6
           Protection and Safety Act of 2006 (42 U.S.C.
           16911(5)) shall apply with respect to a sex of-
           fense against a minor for purposes of this Act to
@@ -163,8 +155,6 @@ ter’’, to carry out the activities specified in subsection (e).
           partment of Justice; and
 
 
-      †HR 515 EAS
-                             7
                (B) share all relevant information relating
           to the individual with other Federal, State, and
           local agencies and entities, as appropriate.
@@ -191,8 +181,6 @@ lowing:
       managers in U.S. Immigration and Customs Enforce-
       ment or U.S. Customs and Border Protection.
 
-      †HR 515 EAS
-                             8
       (e) CTIVITIES.—
           (1) IN GENERAL  .—In carrying out this section,
       the Center shall, using all relevant databases, systems
@@ -219,8 +207,6 @@ lowing:
           ty Act of 2006 (42 U.S.C. 16901 et seq.).
 
 
-      †HR 515 EAS
-                             9
           (2) PROVISION OF INFORMATION TO CENTER     .—
      Twenty-four hours before the intended travel, or there-
      after, not later than 72 hours after the intended trav-
@@ -247,8 +233,6 @@ lowing:
           offender to the destination country if—
 
 
-      †HR 515 EAS
-                             10
                    (i) the Center becomes aware that a sex
                offender is traveling outside of the United
                States within 24 hours of intended travel,
@@ -275,8 +259,6 @@ lowing:
           means as are determined appropriate by the
 
 
-      †HR 515 EAS
-                            11
           Center, including through U.S. Immigration and
           Customs Enforcement attaches.
           (4) M EMORANDUM OF AGREEMENT      .—Not later
@@ -303,8 +285,6 @@ lowing:
           retary of State, the Secretary of Homeland Secu-
           rity, and the Attorney General that the process
 
-      †HR 515 EAS
-                             12
           developed and reported to the appropriate con-
           gressional committees under section 9 has been
           successfully implemented.
@@ -331,8 +311,6 @@ lowing:
                (A) IN GENERAL .—The Center shall—
 
 
-      †HR 515 EAS
-                             13
                     (i) establish a mechanism to receive
                complaints from individuals affected by er-
                roneous notifications under this section;
@@ -359,8 +337,6 @@ lowing:
                     (iii) submit an additional written no-
                tification to the individual explaining why
 
-      †HR 515 EAS
-                             14
                a notification or information regarding the
                individual was erroneously transmitted to
                the destination country and describing the
@@ -387,8 +363,6 @@ lowing:
       review process to ensure that there is appropriate co-
       ordination and collaboration, including consistent
 
-      †HR 515 EAS
-                             15
       procedures governing the activities authorized under
       this Act, in carrying out this Act.
           (9) INFORMATION REQUIRED    .—The Center shall
@@ -415,8 +389,6 @@ ice’s National Sex Offender Targeting Center may—
       agencies and entities, as appropriate;
 
 
-      †HR 515 EAS
-                             16
           (3) receive incoming notifications concerning in-
       dividuals seeking to enter the United States who have
       committed offenses of a sexual nature and shall share
@@ -443,8 +415,6 @@ tional Sex Offender Targeting Center shall—
           (2) provide the Angel Watch Center a determina-
       tion of compliance with title I of the Adam Walsh
 
-      †HR 515 EAS
-                             17
       Child Protection and Safety Act of 2006 (42 U.S.C.
       16901 et seq.) for the list of individuals transmitted
       under section 4(e)(1)(C);
@@ -471,8 +441,6 @@ be transmitted through such means as are determined ap-
 propriate by the United States Marshals Service’s National
 Sex Offender Targeting Center, including through the
 
-      †HR 515 EAS
-                            18
 INTERPOL notification system and through Federal Bu-
 reau of Investigation Legal attaches.
      (f) C OLLECTION OF   D ATA.—The Attorney General
@@ -499,8 +467,6 @@ shall collect all relevant data, including—
 
 
 
-      †HR 515 EAS
-                             19
                (A) establish a mechanism to receive com-
           plaints from individuals affected by erroneous
           notifications under this section;
@@ -527,8 +493,6 @@ shall collect all relevant data, including—
           tion to the individual explaining why a notifica-
           tion or information regarding the individual
 
-      †HR 515 EAS
-                             20
           was erroneously transmitted to the destination
           country and describing the actions that the
           United States Marshals Service’s National Sex
@@ -555,8 +519,6 @@ fender’’ means—
 
 
 
-      †HR 515 EAS
-                           21
          (2) a person required to register under the sex of-
      fender registration program of any jurisdiction or in-
      cluded in the National Sex Offender Registry.
@@ -583,8 +545,6 @@ is amended—
      ‘‘(c)IME AND M ANNER .—A sex offender shall provide
 and update information required under subsection (a), in-
 
-      †HR 515 EAS
-                           22
 cluding information relating to intended travel outside the
 United States required under paragraph (7) of that sub-
 section, in conformity with any time and manner require-
@@ -611,8 +571,6 @@ shall be fined under this title, imprisoned not more than
 10 years, or both.’’; and
 
 
-      †HR 515 EAS
-                              23
            (3) in subsections (c) and (d), as redesignated,
       by striking ‘‘subsection (a)’’ each place it appears and
       inserting ‘‘subsection (a) or (b)’’.
@@ -639,8 +597,6 @@ Center, the INTERPOL notification system, and such other
 means as may be appropriate, including notification by the
 United States to other countries relating to the travel of
 
-      †HR 515 EAS
-                           24
 sex offenders from the United States, reciprocal notification
 by other countries to the United States relating to the travel
 of sex offenders to the United States, and mechanisms to
@@ -667,8 +623,6 @@ appropriate action under subsection (b).
           ‘‘(1)N GENERAL  .—Except as provided under
      paragraph (2), the Secretary of State shall not issue
 
-      †HR 515 EAS
-                             25
       a passport to a covered sex offender unless the pass-
       port contains a unique identifier, and may revoke a
       passport previously issued without such an identifier
@@ -695,8 +649,6 @@ appropriate action under subsection (b).
           Offenders; and
 
 
-      †HR 515 EAS
-                              26
                 ‘‘(B) is currently required to register under
            the sex offender registration program of any ju-
            risdiction;
@@ -723,8 +675,6 @@ Megan’s Law to Prevent Child Exploitation and Other Sex-
 ual Crimes Through Advanced Notification of Traveling
 Sex Offenders has been successfully implemented.’’.
 
-      †HR 515 EAS
-                            27
  SEC. 9. IMPLEMENTATION PLAN.
      (a) IN  GENERAL .—Not later than 90 days after the
 date of enactment of this Act, the Secretary of Homeland
@@ -751,8 +701,6 @@ sional committees’’ means—
      House of Representatives;
           (3) the Committee on Homeland Security and
      Governmental Affairs of the Senate;
-      †HR 515 EAS
-                             28
           (4) the Committee on Homeland Security of the
       House of Representatives;
           (5) the Committee on the Judiciary of the Sen-
@@ -779,8 +727,6 @@ tion relating to any person pursuant to any authority of
 the Department of Justice, the Department of Homeland
 Security, or any other department or agency.
 
-      †HR 515 EAS
-                           29
      Amend the title so as to read: ‘‘An Act to protect
 children and others from sexual abuse and exploitation,
 including sex trafficking and sex tourism, by providing
@@ -808,8 +754,6 @@ other purposes.’’.
 
 
 
-  †HR 515 EAS
-       114
       1TH
       ST
       ESSIONESS

--- a/output/north_korea_sanctions.txt
+++ b/output/north_korea_sanctions.txt
@@ -68,8 +68,6 @@ this Act is as follows:
                   (B) has willfully violated multiple United
 
              Nations Security Council resolutions calling for
-      †HR 757 EAS
-                             3
           North Korea to cease development, testing, and
           production of weapons of mass destruction.
           (2) Based on its past actions, including the
@@ -96,8 +94,6 @@ this Act is as follows:
           ment’’); and
 
 
-      †HR 757 EAS
-                             4
                (B) committed provocations against South
           Korea—
                    (i) by sinking the warship Cheonan
@@ -124,8 +120,6 @@ this Act is as follows:
           (6) North Korea has prioritized weapons pro-
      grams and the procurement of luxury goods—
 
-      †HR 757 EAS
-                             5
                (A) in defiance of United Nations Security
           Council Resolutions 1695 (2006), 1718 (2006),
           1874 (2009), 2087 (2013), and 2094 (2013); and
@@ -152,8 +146,6 @@ this Act is as follows:
       Korea poses an imminent threat to—
 
 
-      †HR 757 EAS
-                             6
                (A) the security of the United States and its
           allies;
                (B) the global economy;
@@ -180,8 +172,6 @@ this Act is as follows:
       Korea; and
 
 
-      †HR 757 EAS
-                             7
           (4) to reaffirm the purposes set forth in section
       4 of the North Korean Human Rights Act of 2004 (22
       U.S.C. 7802).
@@ -208,8 +198,6 @@ this Act is as follows:
           tional sanctions with respect to North Korea), or
           Executive Order 13694 (50 U.S.C. 1701 note; re-
 
-      †HR 757 EAS
-                             8
           lating to blocking the property of certain persons
           engaging in significant malicious cyber-enabled
           activities), to the extent that such Executive
@@ -236,8 +224,6 @@ this Act is as follows:
 
 
 
-      †HR 757 EAS
-                             9
           (2) A PPLICABLE   UNITED  NATIONS   SECURITY
      COUNCIL RESOLUTION   .—The term ‘‘applicable United
      Nations Security Council resolution’’ means—
@@ -264,8 +250,6 @@ this Act is as follows:
                (B) the Committee on Foreign Affairs, the
           Committee on Financial Services, and the Com-
 
-      †HR 757 EAS
-                            10
           mittee on Ways and Means of the House of Rep-
           resentatives.
           (4) D  ESIGNATED   PERSON .—The term ‘‘des-
@@ -292,8 +276,6 @@ this Act is as follows:
           ulations; and
 
 
-      †HR 757 EAS
-                             11
                (B) includes the items listed in Supplement
           No. 1 to part 746 of such title, and any similar
           items.
@@ -320,8 +302,6 @@ this Act is as follows:
 
 
 
-      †HR 757 EAS
-                             12
           (12) SIGNIFICANT ACTIVITIES UNDERMINING CY    -
       BERSECURITY .—The term ‘‘significant activities un-
       dermining cybersecurity’’ includes—
@@ -348,8 +328,6 @@ this Act is as follows:
           the United States or of any jurisdiction within
 
 
-      †HR 757 EAS
-                           13
           the United States, including a foreign branch of
           such an entity.
  TITLE I—INVESTIGATIONS, PRO-
@@ -376,8 +354,6 @@ Korea, Congress finds that it is necessary—
           (4) to deny the Government of North Korea ac-
      cess to the funds it uses to develop or obtain nuclear
 
-      †HR 757 EAS
-                             14
       weapons, ballistic missiles, cyberwarfare capabilities,
       and luxury goods instead of providing for the needs
       of the people of North Korea; and
@@ -404,8 +380,6 @@ tigators, attorneys, and technical personnel—
            (2) to coordinate and ensure the effective enforce-
       ment of this Act.
 
-      †HR 757 EAS
-                           15
  SEC. 103. REPORTING REQUIREMENTS.
      (a) P RESIDENTIAL  BRIEFINGS TO   CONGRESS .—Not
 later than 180 days after the date of the enactment of this
@@ -432,8 +406,6 @@ in section 208, the President shall designate under this sub-
 section any person that the President determines—
           (1) knowingly, directly or indirectly, imports,
      exports, or reexports to, into, or from North Korea
-      †HR 757 EAS
-                             16
       any goods, services, or technology controlled for export
       by the United States because of the use of such goods,
       services, or technology for weapons of mass destruc-
@@ -460,8 +432,6 @@ section any person that the President determines—
       ment of North Korea;
 
 
-      †HR 757 EAS
-                             17
           (6) knowingly, directly or indirectly, engages in
       money laundering, the counterfeiting of goods or cur-
       rency, bulk cash smuggling, or narcotics trafficking
@@ -488,8 +458,6 @@ section any person that the President determines—
       of North Korea;
 
 
-      †HR 757 EAS
-                            18
           (9) knowingly, directly or indirectly, imports,
      exports, or reexports to, into, or from North Korea
      any arms or related materiel; or
@@ -516,8 +484,6 @@ section any person that the President determines—
               North Korea or any person acting for or on
               behalf of that official; or
 
-      †HR 757 EAS
-                             19
                     (iii) the use of any proceeds of any ac-
                tivity described in clause (i) or (ii); or
                (C) knowingly and materially assisted,
@@ -544,8 +510,6 @@ section any person that the President determines—
                (D) prohibit any transfers of credit or pay-
           ments between financial institutions or by,
 
-      †HR 757 EAS
-                             20
           through, or to any financial institution, to the
           extent that such transfers or payments—
                    (i) are subject to the jurisdiction of the
@@ -572,8 +536,6 @@ property are blocked pursuant to this section.
       (e) TRANSACTION   LICENSING .—The President shall
 deny or revoke any license for any transaction that the
 
-      †HR 757 EAS
-                            21
 President determines to lack sufficient financial controls to
 ensure that such transaction will not facilitate any activity
 described in subsection (a) or (b).
@@ -600,8 +562,6 @@ Code, is amended by adding at the end the following:
  FEITURE   STATUTE .—Section 983(i)(2)(D) of title 18,
 United States Code, is amended to read as follows:
 
-      †HR 757 EAS
-                          22
              ‘‘(D) the Trading with the Enemy Act (50
          U.S.C. 4301 et seq.), the International Emer-
          gency Economic Powers Act (50 U.S.C. 1701 et
@@ -628,8 +588,6 @@ United States Code, is amended—
          (1) The Under Secretary of the Treasury for Ter-
      rorism and Financial Intelligence, who is responsible
 
-     †HR 757 EAS
-                             23
       for safeguarding the financial system against illicit
       use, money laundering, terrorist financing, and the
       proliferation of weapons of mass destruction, and has
@@ -656,8 +614,6 @@ United States Code, is amended—
                     (i) in reference to North Korea’s dis-
                tribution of high-quality counterfeit United
 
-      †HR 757 EAS
-                             24
                States currency, that ‘‘North Korea is con-
                tinuing to try to pass a supernote into the
                international financial system’’; and
@@ -684,8 +640,6 @@ United States Code, is amended—
           system from ongoing and substantial money
 
 
-      †HR 757 EAS
-                             25
           laundering and terrorist financing risks ema-
           nating from North Korea;
                (D) urged all jurisdictions to advise their
@@ -712,8 +666,6 @@ United States Code, is amended—
                tions related to proliferation; and
 
 
-      †HR 757 EAS
-                           26
                   (ii) guidance on the implementation of
               such sanctions;
               (B) decided that United Nations member
@@ -740,8 +692,6 @@ United States Code, is amended—
  TION OF NORTH  K OREA AS A J URISDICTION OF PRIMARY
  MONEY  LAUNDERING  CONCERN .—Congress—
 
-      †HR 757 EAS
-                            27
           (1) acknowledges the efforts of the United Na-
      tions Security Council to impose limitations on, and
      to require the enhanced monitoring of, transactions
@@ -768,8 +718,6 @@ United States Code, is amended—
           (1) N GENERAL  .—Not later than 180 days after
      the date of the enactment of this Act, the Secretary of
 
-      †HR 757 EAS
-                            28
      the Treasury, in consultation with the Secretary of
      State and the Attorney General, and in accordance
      with section 5318A of title 31, United States Code,
@@ -796,8 +744,6 @@ United States Code, is amended—
           contains the reasons for such determination.
 
 
-      †HR 757 EAS
-                            29
               (B) F  ORM .—The report submitted under
           subparagraph (A) shall be submitted in unclassi-
           fied form, but may include a classified annex.
@@ -824,8 +770,6 @@ United States Code, is amended—
               (A) finds that officials of the United States
           and representatives of the United Nations Panel
 
-      †HR 757 EAS
-                             30
           of Experts established pursuant to United Na-
           tions Security Council Resolution 1874 (2009),
           which monitors and facilitates implementation
@@ -852,8 +796,6 @@ United States Code, is amended—
                (A) the enforcement of applicable United
           Nations Security Council resolutions; and
 
-      †HR 757 EAS
-                             31
                (B) the protection of the international fi-
           nancial system.
           (7) The report of the Panel of Experts expressed
@@ -880,8 +822,6 @@ United States Code, is amended—
       having materially contributed to the proliferation of
       weapons of mass destruction.
 
-      †HR 757 EAS
-                             32
           (11) The Foreign Trade Bank of North Korea
       has been designated by the Secretary of the Treasury
       for facilitating transactions on behalf of persons
@@ -908,8 +848,6 @@ including—
       unacceptable risks of facilitating money laundering
 
 
-      †HR 757 EAS
-                            33
      and illicit activity by the Government of North
      Korea;
           (3) the blocking by all member states, in accord-
@@ -936,8 +874,6 @@ including—
 direct the Secretary of State, in coordination with other
 Federal departments and agencies, as appropriate, to de-
 
-      †HR 757 EAS
-                             34
 velop a strategy to improve international implementation
 and enforcement of United Nations North Korea-specific
 sanctions. The strategy should include elements—
@@ -964,8 +900,6 @@ sanctions. The strategy should include elements—
       forcement; and
 
 
-      †HR 757 EAS
-                           35
           (6) to increase outreach to the people of North
      Korea, and to support the engagement of independent,
      non-governmental journalistic, humanitarian, and
@@ -992,8 +926,6 @@ the Government of North Korea.
      the Government of North Korea.
 
 
-      †HR 757 EAS
-                             36
           (2) A  PPLICABILITY.—The prohibition under
       paragraph (1) with respect to a government shall ter-
       minate on the date that is 1 year after the date on
@@ -1020,8 +952,6 @@ purposes.
       (a) N G ENERAL .—Except as provided in this section,
 the head of an executive agency may not procure, or enter
 
-      †HR 757 EAS
-                            37
 into any contract for the procurement of, any goods or serv-
 ices from any person designated under section 104(a).
      (b) FEDERAL  ACQUISITION R EGULATION .—
@@ -1048,8 +978,6 @@ ices from any person designated under section 104(a).
      certification under subsection (b).
 
 
-      †HR 757 EAS
-                            38
           (2) C ONTRACT TERMINATION   ; SUSPENSION .—If
      the head of an executive agency determines that a per-
      son has submitted a false certification under sub-
@@ -1076,8 +1004,6 @@ instrumentality designated under section 301(b) of such Act
 (19 U.S.C. 2511(b)).
 
 
-      †HR 757 EAS
-                            39
      (e) R ULE OF  CONSTRUCTION  .—Nothing in this sub-
 section may be construed to limit the use of other remedies
 available to the head of an executive agency or any other
@@ -1104,8 +1030,6 @@ identified by the President under subsection (a).
      (c) SEIZURE AND  FORFEITURE  .—A vessel, aircraft, or
 conveyance used to facilitate any of the activities described
 
-      †HR 757 EAS
-                             40
 in section 104(a) under the jurisdiction of the United States
 may be seized and forfeited under—
           (1) chapter 46 of title 18, United States Code; or
@@ -1132,8 +1056,6 @@ every 90 days, should include—
       able information on circumstances of arrest and de-
       tention, duration, legal proceedings, and conditions
 
-      †HR 757 EAS
-                             41
       under which a United States citizen has been, or con-
       tinues to be, detained by North Korean authorities,
       including present-day cases and cases occurring dur-
@@ -1160,8 +1082,6 @@ every 90 days, should include—
 
 
 
-      †HR 757 EAS
-                            42
  SEC. 208. EXEMPTIONS, WAIVERS, AND REMOVALS OF DES-
              IGNATION.
      (a) EXEMPTIONS .—The following activities shall be ex-
@@ -1188,8 +1108,6 @@ empt from sanctions under sections 104, 206, 209, and 304:
      Korea.
      (b) HUMANITARIAN  W AIVER.—
 
-      †HR 757 EAS
-                            43
           (1) IN GENERAL .—The President may waive, for
      renewable periods of between 30 days and 1 year, the
      application of the sanctions authorized under section
@@ -1216,8 +1134,6 @@ empt from sanctions under sections 104, 206, 209, and 304:
      manitarian organization shall not be subject to sanc-
 
 
-      †HR 757 EAS
-                             44
       tions under section 104, 204, 205, 206, 209(b), or
       304(b) for—
                (A) engaging in a financial transaction re-
@@ -1244,8 +1160,6 @@ mittees a written determination that the waiver—
       ests of the United States; or
 
 
-      †HR 757 EAS
-                           45
           (2) will further the enforcement of this Act or is
      for an important law enforcement purpose.
      (d) FINANCIAL  SERVICES FOR   H UMANITARIAN AND
@@ -1272,8 +1186,6 @@ an exemption or waiver under this section.
           (2) NFORMATION  .—The report required under
      paragraph (1) shall include—
 
-      †HR 757 EAS
-                             46
                (A) the identity and nationality of persons
           that have knowingly engaged in, directed, or pro-
           vided material support to conduct significant ac-
@@ -1300,8 +1212,6 @@ an exemption or waiver under this section.
           under paragraph (1) shall be submitted not later
 
 
-      †HR 757 EAS
-                             47
           than 90 days after the date of the enactment of
           this Act, and every 180 days thereafter.
                (B) F ORM .—The report required under
@@ -1328,8 +1238,6 @@ note; relating to blocking the property of certain persons
 engaging in significant malicious cyber-enabled activities),
 as such Executive Orders are in effect on the day before
 
-      †HR 757 EAS
-                             48
 the date of the enactment of this Act, shall remain in effect
 until the date that is 30 days after the date on which the
 President submits to Congress a certification that the Gov-
@@ -1356,8 +1264,6 @@ President—
       United States, the Government of South Korea, and
       the Government of Japan;
 
-      †HR 757 EAS
-                             49
           (2) should ensure that the mechanisms specifi-
       cally address North Korea’s nuclear, ballistic, and
       conventional weapons programs, its human rights
@@ -1384,8 +1290,6 @@ tees referred to in subsection (a)(4) shall include—
       tives.
 
 
-      †HR 757 EAS
-                           50
       TITLE III—PROMOTION OF
                HUMAN RIGHTS
  SEC. 301. INFORMATION TECHNOLOGY.
@@ -1412,8 +1316,6 @@ a United States strategy to promote initiatives to enhance
 international awareness of and to address the human rights
 situation in North Korea.
 
-      †HR 757 EAS
-                             51
       (b) INFORMATION  .—The report required under sub-
 section (a) should include—
           (1) a list of countries that forcibly repatriate ref-
@@ -1440,8 +1342,6 @@ section (a) should include—
       human rights situation in North Korea, including
 
 
-      †HR 757 EAS
-                             52
       forced labor, trafficking, and repatriation of citizens
       of North Korea; and
           (3) opportunities to coordinate and collaborate
@@ -1468,8 +1368,6 @@ North Korea, to the extent information is available—
       treatment of prisoners; and
 
 
-      †HR 757 EAS
-                            53
           (7) imagery, to include satellite imagery of the
      camp, in a format that, if published, would not com-
      promise the sources and methods used by the United
@@ -1496,8 +1394,6 @@ Assistance Act of 1961 (22 U.S.C. 2151n(d) and 2304(b)).
           North Korea or any person acting for or on be-
 
 
-      †HR 757 EAS
-                            54
           half of that Government in the most recent year
           ending before the submission of the report.
           (2) C ONSIDERATION .—In preparing the report
@@ -1524,8 +1420,6 @@ Assistance Act of 1961 (22 U.S.C. 2151n(d) and 2304(b)).
           ance Act of 1961 (22 U.S.C. 2151n(d) and
           2304(b)).
 
-      †HR 757 EAS
-                            55
                (B) F ORM .—The report required under
           paragraph (1) shall be submitted in unclassified
           form, but may include a classified annex.
@@ -1552,8 +1446,6 @@ that the President should—
           (2) fully cooperate with the prosecution of any
      individual listed in the report required under sub-
 
-      †HR 757 EAS
-                           56
      section (a)(1) before any international tribunal that
      may be established to prosecute persons responsible for
      severe human rights abuses or censorship in North
@@ -1580,8 +1472,6 @@ made progress toward—
      Council resolutions;
 
 
-      †HR 757 EAS
-                             57
           (4) taking steps toward accounting for and repa-
       triating the citizens of other countries—
                (A) abducted or unlawfully held captive by
@@ -1608,8 +1498,6 @@ ditions described in subsection (a) during the previous year.
 II, or III (or any amendment made by such titles) shall
 terminate on the date on which the President determines
 
-      †HR 757 EAS
-                             58
 and certifies to the appropriate congressional committees
 that the Government of North Korea has—
           (1) met the requirements set forth in section 401;
@@ -1636,8 +1524,6 @@ that the Government of North Korea has—
                     (ii) detained in violation of the Agree-
                ment Concerning a Military Armistice in
 
-      †HR 757 EAS
-                            59
               Korea, signed at Panmunjom July 27, 1953
               (commonly referred to as the ‘‘Korean War
               Armistice Agreement’’).
@@ -1664,8 +1550,6 @@ carry out the provisions of this Act (which may include reg-
 ulatory exceptions), including under section 205 of the
 
 
-      †HR 757 EAS
-                             60
 International Emergency Economic Powers Act (50 U.S.C.
 1704).
       (b) RULE OF  CONSTRUCTION  .—Nothing in this Act, or
@@ -1692,8 +1576,6 @@ in addition to all other elements mandated by previous law.
 
 
 
-      †HR 757 EAS
-                             61
  SEC. 406. EFFECTIVE DATE.
       Except as otherwise provided in this Act, this Act and
 the amendments made by this Act shall take effect on the
@@ -1720,8 +1602,6 @@ date of the enactment of this Act.
 
 
 
-     †HR 757 EAS
-       114
       2TH
       D
       ESSIONESS

--- a/output/patient-protection.txt
+++ b/output/patient-protection.txt
@@ -62,8 +62,6 @@ Act is as follows:
 
 
 
-      HR 3590 EAS/PP
-                                3
 
                      ‘SUBPART I— GENERAL REFORM
     ‘‘Sec. 2704. Prohibition of preexisting condition exclusions or other discrimi-
@@ -115,8 +113,6 @@ Sec. 1341. Transitional reinsurance program for individual and small group
 Sec. 1342. Establishment of risk corridors for plans in individual and small
                group markets.
 
-   HR 3590 EAS/PP
-                                 4
 Sec. 1343. Risk adjustment.
 
           Subtitle E—Affordable Coverage Choices for All Americans
@@ -166,8 +162,6 @@ Sec. 1558. Protections for employees.
 Sec. 1559. Oversight.
 Sec. 1560. Rules of construction.
 
-   HR 3590 EAS/PP
-                                     5
 Sec. 1561. Health information technology enrollment standards and protocols.
 Sec. 1562. Conforming amendments.
 Sec. 1563. Sense of the Senate promoting fiscal responsibility.
@@ -215,8 +209,6 @@ Sec. 2503. Providing adequate pharmacy reimbursement.
     Subtitle G—Medicaid Disproportionate Share Hospital (DSH) Payments
 Sec. 2551. Disproportionate share hospital payments.
 
-   HR 3590 EAS/PP
-                                  6
       Subtitle H—Improved Coordination for Dual Eligible Beneficiaries
 Sec. 2601. 5-year period for demonstration projects.
 Sec. 2602. Providing Federal coverage and payment coordination for dual eligible
@@ -264,8 +256,6 @@ Sec. 3006. Plans for a Value-Based purchasing program for skilled nursing facili
 Sec. 3007. Value-based payment modifier under the physician fee schedule.
 Sec. 3008. Payment adjustment for conditions acquired in hospitals.
 
-   HR 3590 EAS/PP
-                                 7
     PART II—N   ATIONAL STRATEGY TO  IMPROVE  H EALTH C ARE QUALITY
 
 Sec. 3011. National strategy.
@@ -318,8 +308,6 @@ Sec. 3125. Temporary improvements to the Medicare inpatient hospital payment
 Sec. 3126. Improvements to the demonstration project on community health inte-
                gration models in certain rural counties.
 
-   HR 3590 EAS/PP
-                                     8
 Sec. 3127. MedPAC study on adequacy of Medicare payments for health care pro-
                  viders serving in rural areas.
 Sec. 3128. Technical correction related to critical access hospital services.
@@ -371,8 +359,6 @@ Sec. 3307. Improving formulary requirements for prescription drug plans and
                  drugs.
 Sec. 3308. Reducing part D premium subsidy for high-income beneficiaries.
 
-   HR 3590 EAS/PP
-                                     9
 Sec. 3309. Elimination of cost sharing for certain dual eligible individuals.
 Sec. 3310. Reducing wasteful dispensing of outpatient prescription drugs in long-
                   term care facilities under prescription drug plans and MA–PD
@@ -421,8 +407,6 @@ Sec. 4004. Education and outreach campaign regarding preventive benefits.
           Subtitle B—Increasing Access to Clinical Preventive Services
 Sec. 4101. School-based health centers.
 Sec. 4102. Oral healthcare prevention activities.
-   HR 3590 EAS/PP
-                                    10
 Sec. 4103. Medicare coverage of annual wellness visit providing a personalized
                   prevention plan.
 Sec. 4104. Removal of barriers to preventive services in Medicare.
@@ -469,8 +453,6 @@ Sec. 5206. Grants for State and local programs.
 Sec. 5207. Funding for National Health Service Corps.
 Sec. 5208. Nurse-managed health clinics.
 
-   HR 3590 EAS/PP
-                                     11
 Sec. 5209. Elimination of cap on commissioned corps.
 Sec. 5210. Establishing a Ready Reserve Corps.
     Subtitle D—Enhancing Health Care Workforce Education and Training
@@ -521,8 +503,6 @@ Sec. 5603. Reauthorization of the Wakefield Emergency Medical Services for Chil-
 Sec. 5604. Co-locating primary and specialty care in community-based mental
                   health settings.
 
-   HR 3590 EAS/PP
-                                  12
 Sec. 5605. Key National indicators.
                         Subtitle H—General Provisions
 Sec. 5701. Reports.
@@ -570,8 +550,6 @@ Sec. 6301. Patient-Centered Outcomes Research.
 Sec. 6302. Federal coordinating council for comparative effectiveness research.
 
 
-   HR 3590 EAS/PP
-                                     13
    Subtitle E—Medicare, Medicaid, and CHIP Program Integrity Provisions
 Sec. 6401. Provider screening and other enrollment requirements under Medicare,
                   Medicaid, and CHIP.
@@ -623,8 +601,6 @@ Sec. 6702. Definitions.
 Sec. 6703. Elder Justice.
 
 
-   HR 3590 EAS/PP
-                                    14
          Subtitle I—Sense of the Senate Regarding Medical Malpractice
 Sec. 6801. Sense of the Senate regarding medical malpractice.
       TITLE VII—IMPROVING ACCESS TO INNOVATIVE MEDICAL
@@ -672,8 +648,6 @@ Sec. 9016. Modification of section 833 treatment of certain health organizations
 Sec. 9017. Excise tax on elective cosmetic medical procedures.
 
 
-   HR 3590 EAS/PP
-                                 15
                         Subtitle B—Other Provisions
 Sec. 9021. Exclusion of health benefits provided by Indian tribal governments.
 Sec. 9022. Establishment of simple cafeteria plans for small businesses.
@@ -723,8 +697,6 @@ Sec. 10309. Revisions to hospital readmissions reduction program.
 Sec. 10310. Repeal of physician payment update.
 Sec. 10311. Revisions to extension of ambulance add-ons.
 
-   HR 3590 EAS/PP
-                                     16
 Sec. 10312. Certain payment rules for long-term care hospital services and mora-
                   torium on the establishment of certain hospitals and facilities.
 Sec. 10313. Revisions to the extension for the rural community hospital dem-
@@ -778,8 +750,6 @@ Sec. 10413. Young women’s breast health awareness and support of young women
 Sec. 10501. Amendments to the Public Health Service Act, the Social Security
                   Act, and title V of this Act.
 
-   HR 3590 EAS/PP
-                                     17
 Sec. 10502. Infrastructure to Expand Access to Care.
 Sec. 10503. Community Health Centers and the National Health Service Corps
                   Fund.
@@ -826,8 +796,6 @@ Sec. 10909. Expansion of adoption credit and adoption assistance programs.
 
 
 
-   HR 3590 EAS/PP
-                         18
 TITLE I—QUALITY, AFFORDABLE
      HEALTH CARE FOR ALL AMER-
      ICANS
@@ -853,8 +821,6 @@ SEC. 1001. AMENDMENTS TO THE PUBLIC HEALTH SERVICE
 
 
 
-     HR 3590 EAS/PP
-                             19
             ‘‘Subpart II—Improving Coverage
  ‘‘SEC. 2711. NO LIFETIME OR ANNUAL LIMITS.
       ‘‘(a)NIG ENERAL .—A group health plan and a health
@@ -881,8 +847,6 @@ not rescind such plan or coverage with respect to an enrollee
 once the enrollee is covered under such plan or coverage in-
 volved, except that this section shall not apply to a covered
 individual who has performed an act or practice that con-
-      HR 3590 EAS/PP
-                             20
 stitutes fraud or makes an intentional misrepresentation of
 material fact as prohibited by the terms of the plan or cov-
 erage. Such plan or coverage may not be cancelled except
@@ -909,8 +873,6 @@ shall not impose any cost sharing requirements for—
       Administration.
 
 
-      HR 3590 EAS/PP
-                             21
           ‘‘(4) with respect to women, such additional pre-
       ventive care and screenings not described in para-
       graph (1) as provided for in comprehensive guidelines
@@ -937,8 +899,6 @@ are not recommended by such Task Force.
       described in subsection (a) is effective with respect to
 
 
-      HR 3590 EAS/PP
-                             22
       the service described in such recommendation or
       guideline.
           ‘‘(2) MINIMUM .—The interval described in para-
@@ -965,8 +925,6 @@ be made available under subsection (a).
 tion shall be construed to modify the definition of ‘depend-
 
 
-      HR 3590 EAS/PP
-                             23
 ent’ as used in the Internal Revenue Code of 1986 with re-
 spect to the tax treatment of the cost of coverage.
  ‘‘SEC. 2715. DEVELOPMENT AND UTILIZATION OF UNIFORM
@@ -993,8 +951,6 @@ mary of benefits and coverage developed under subsection
 (a) shall provide for the following:
 
 
-      HR 3590 EAS/PP
-                             24
           ‘‘(1) APPEARANCE  .—The standards shall ensure
       that the summary of benefits and coverage is pre-
       sented in a uniform format that does not exceed 4
@@ -1021,8 +977,6 @@ mary of benefits and coverage developed under subsection
                     ‘‘(ii) other benefits, as identified by the
                Secretary;
 
-      HR 3590 EAS/PP
-                             25
                ‘‘(C) the exceptions, reductions, and limita-
           tions on coverage;
                ‘‘(D) the cost-sharing provisions, including
@@ -1049,8 +1003,6 @@ mary of benefits and coverage developed under subsection
           mary of the policy or certificate and that the
           coverage document itself should be consulted to
 
-      HR 3590 EAS/PP
-                            26
           determine the governing contractual provisions;
           and
               ‘‘(I) a contact number for the consumer to
@@ -1077,8 +1029,6 @@ the standards developed under this section.
           the time of issuance of the policy or delivery of
           the certificate.
 
-      HR 3590 EAS/PP
-                             27
           ‘‘(2) OMPLIANCE  .—An entity described in para-
       graph (3) is deemed to be in compliance with this sec-
       tion if the summary of benefits and coverage described
@@ -1105,8 +1055,6 @@ the standards developed under this section.
       issuer shall provide notice of such modification to en-
 
 
-      HR 3590 EAS/PP
-                             28
       rollees not later than 60 days prior to the date on
       which such modification will become effective.
       ‘‘(e) REEMPTION  .—The standards developed under
@@ -1133,8 +1081,6 @@ fense for purposes of this subsection.
       premium, deductible, co-insurance, co-payment, out-
       of-pocket limit, preferred provider, non-preferred pro-
 
-      HR 3590 EAS/PP
-                             29
       vider, out-of-network co-payments, UCR (usual, cus-
       tomary and reasonable) fees, excluded services, griev-
       ance and appeals, and such other terms as the Sec-
@@ -1161,8 +1107,6 @@ bility (including continued eligibility) of any full-time em-
 ployee under the terms of the plan that are based on the
 total hourly or annual salary of the employee or otherwise
 
-      HR 3590 EAS/PP
-                             30
 establish eligibility rules that have the effect of discrimi-
 nating in favor of higher wage employees.
       ‘‘(b) IMITATION .—Subsection (a) shall not be con-
@@ -1189,8 +1133,6 @@ tion.
           porting, effective case management, care coordi-
           nation, chronic disease management, and medi-
 
-      HR 3590 EAS/PP
-                             31
           cation and care compliance initiatives, including
           through the use of the medical homes model as
           defined for purposes of section 3602 of the Pa-
@@ -1217,8 +1159,6 @@ tion.
           ally submit to the Secretary, and to enrollees
           under the plan or coverage, a report on whether
 
-      HR 3590 EAS/PP
-                            32
           the benefits under the plan or coverage satisfy
           the elements described in subparagraphs (A)
           through (D) of paragraph (1).
@@ -1245,8 +1185,6 @@ tion.
 purposes of subsection (a)(1)(D), wellness and health pro-
 motion activities may include personalized wellness and
 
-      HR 3590 EAS/PP
-                              33
 prevention services, which are coordinated, maintained or
 delivered by a health care provider, a wellness and preven-
 tion plan manager, or a health, wellness or prevention serv-
@@ -1273,8 +1211,6 @@ after the date on which regulations are promulgated under
 subsection (c), the Government Accountability Office shall
 review such regulations and conduct a study and submit
 
-      HR 3590 EAS/PP
-                           34
 to the Committee on Health, Education, Labor, and Pen-
 sions of the Senate and the Committee on Energy and Com-
 merce of the House of Representatives a report regarding
@@ -1301,8 +1237,6 @@ ment of Health and Human Services.
  FOR THEIR PREMIUM  P AYMENTS.—
 
 
-      HR 3590 EAS/PP
-                             35
           ‘‘(1) REQUIREMENT TO PROVIDE VALUE FOR
       PREMIUM PAYMENTS   .—A health insurance issuer of-
       fering group or individual health insurance coverage
@@ -1329,8 +1263,6 @@ ment of Health and Human Services.
       graph (1), a State shall seek to ensure adequate par-
       ticipation by health insurance issuers, competition in
 
-      HR 3590 EAS/PP
-                             36
       the health insurance market in the State, and value
       for consumers so that premiums are used for clinical
       services and quality improvements.
@@ -1357,8 +1289,6 @@ issuer shall, at a minimum—
           ‘‘(1) have in effect an internal claims appeal
       process;
 
-      HR 3590 EAS/PP
-                             37
           ‘‘(2) provide notice to enrollees, in a culturally
       and linguistically appropriate manner, of available
       internal and external appeals processes, and the
@@ -1385,8 +1315,6 @@ end the following:
 to States to enable such States (or the Exchanges operating
 
 
-      HR 3590 EAS/PP
-                             38
 in such States) to establish, expand, or provide support
 for—
           ‘‘(1) offices of health insurance consumer assist-
@@ -1413,8 +1341,6 @@ assistance or health insurance ombudsman shall—
       peal or grievance process of the group health plan or
 
 
-      HR 3590 EAS/PP
-                             39
       health insurance issuer involved and providing infor-
       mation about the external appeal process;
           ‘‘(2) collect, track, and quantify problems and
@@ -1441,8 +1367,6 @@ enforcement activities of such agencies.
       ‘‘(e)UNDING  .—
 
 
-      HR 3590 EAS/PP
-                            40
           ‘‘(1)NITIAL FUNDING .—There is hereby appro-
      priated to the Secretary, out of any funds in the
      Treasury not otherwise appropriated, $30,000,000 for
@@ -1469,8 +1393,6 @@ is further amended by adding at the end the following:
      creases in premiums for health insurance coverage.
 
 
-      HR 3590 EAS/PP
-                            41
           ‘‘(2) JUSTIFICATION  AND   DISCLOSURE  .—The
      process established under paragraph (1) shall require
      health insurance issuers to submit to the Secretary
@@ -1497,8 +1419,6 @@ is further amended by adding at the end the following:
           on a pattern or practice of excessive or unjusti-
           fied premium increases.
 
-      HR 3590 EAS/PP
-                            42
           ‘‘(2) MONITORING BY SECRETARY OF PREMIUM
      INCREASES .—
               ‘‘(A) IN GENERAL  .—Beginning with plan
@@ -1525,8 +1445,6 @@ is further amended by adding at the end the following:
      States in carrying out subsection (a), including—
 
 
-      HR 3590 EAS/PP
-                             43
                ‘‘(A) in reviewing and, if appropriate under
           State law, approving premium increases for
           health insurance coverage; and
@@ -1553,8 +1471,6 @@ is further amended by adding at the end the following:
           any grant to a State under this subsection.
           Under such formula—
 
-      HR 3590 EAS/PP
-                             44
                    ‘‘(i) the Secretary shall consider the
                number of plans of health insurance cov-
                erage offered in each State and the popu-
@@ -1581,8 +1497,6 @@ ment of this Act.
 
 
 
-      HR 3590 EAS/PP
-                           45
    Subtitle B—Immediate Actions to
     Preserve and Expand Coverage
  SEC. 1101. IMMEDIATE ACCESS TO INSURANCE FOR UNIN-
@@ -1609,8 +1523,6 @@ gram is established and ending on January 1, 2014.
           tablish and administer a qualified high risk pool
           for eligible individuals.
 
-      HR 3590 EAS/PP
-                            46
           (3) MAINTENANCE OF EFFORT  .—To be eligible to
      enter into a contract with the Secretary under this
      subsection, a State shall agree not to reduce the an-
@@ -1637,8 +1549,6 @@ gram is established and ending on January 1, 2014.
                    (ii) that has an out of pocket limit not
               greater than the applicable amount de-
 
-      HR 3590 EAS/PP
-                             47
                scribed in section 223(c)(2) of the Internal
                Revenue Code of 1986 for the year involved,
                except that the Secretary may modify such
@@ -1665,8 +1575,6 @@ deemed to be an eligible individual for purposes of this sec-
 tion if such individual—
 
 
-      HR 3590 EAS/PP
-                            48
           (1) is a citizen or national of the United States
      or is lawfully present in the United States (as deter-
      mined in accordance with section 1411);
@@ -1693,8 +1601,6 @@ tion if such individual—
      incurred by the program for an individual who, based
      on criteria established by the Secretary, the Secretary
 
-      HR 3590 EAS/PP
-                             49
       finds was encouraged by the issuer to disenroll from
       health benefits coverage prior to enrolling in coverage
       through the program. The criteria shall include at
@@ -1721,8 +1627,6 @@ tion if such individual—
                     the issuer; or
 
 
-      HR 3590 EAS/PP
-                             50
                         (II) the prior coverage is a policy
                    for which duration of coverage form
                    issue or health status are factors that
@@ -1749,8 +1653,6 @@ tion if such individual—
       uals enrolled in the high risk pool. Such funds shall
       be available without fiscal year limitation.
 
-      HR 3590 EAS/PP
-                             51
           (2) INSUFFICIENT FUNDS  .—If the Secretary esti-
       mates for any fiscal year that the aggregate amounts
       available for the payment of the expenses of the high
@@ -1777,8 +1679,6 @@ tion if such individual—
       thority to stop taking applications for participation
 
 
-      HR 3590 EAS/PP
-                             52
       in the program under this section to comply with the
       funding limitation provided for in paragraph (1).
           (5) R ELATION TO STATE LAWS   .—The standards
@@ -1805,8 +1705,6 @@ tion if such individual—
           scription drug, and such other benefits as shall
           be determined by the Secretary, whether self-
 
-      HR 3590 EAS/PP
-                             53
           funded, or delivered through the purchase of in-
           surance or otherwise.
                (B) E MPLOYMENT  -BASED PLAN  .—The term
@@ -1833,8 +1731,6 @@ tion if such individual—
           older but are not eligible for coverage under title
           XVIII of the Social Security Act, and who are
 
-      HR 3590 EAS/PP
-                            54
           not active employees of an employer maintain-
           ing, or currently contributing to, the employ-
           ment-based plan or of any employer that has
@@ -1861,8 +1757,6 @@ tion if such individual—
           cost of medical claims involved; and
               (C) is certified by the Secretary.
 
-      HR 3590 EAS/PP
-                            55
      (c) PAYMENTS .—
           (1) SUBMISSION OF CLAIMS .—
                (A) N GENERAL  .—A participating employ-
@@ -1889,8 +1783,6 @@ tion if such individual—
           the early retiree or the retiree’s spouse, surviving
           spouse, or dependent in the form of deductibles,
 
-      HR 3590 EAS/PP
-                             56
           co-payments, or co-insurance shall be included in
           the amounts paid by the participating employ-
           ment-based plan.
@@ -1917,8 +1809,6 @@ tion if such individual—
       an entity described in subsection (a)(2)(B)(i) or to re-
       duce premium contributions, co-payments,
 
-      HR 3590 EAS/PP
-                             57
       deductibles, co-insurance, or other out-of-pocket costs
       for plan participants. Such payments shall not be
       used as general revenues for an entity described in
@@ -1945,8 +1835,6 @@ are in compliance with the requirements of this section.
       (e) UNDING .—There is appropriated to the Secretary,
 out of any moneys in the Treasury not otherwise appro-
 
-      HR 3590 EAS/PP
-                           58
 priated, $5,000,000,000 to carry out the program under this
 section. Such funds shall be available without fiscal year
 limitation.
@@ -1973,8 +1861,6 @@ based on the availability of funding under subsection (e).
           health insurance issuers, other than coverage that
 
 
-      HR 3590 EAS/PP
-                            59
           provides reimbursement only for the treatment or
           mitigation of—
                    (i) a single disease or condition; or
@@ -2001,8 +1887,6 @@ based on the availability of funding under subsection (e).
      mation on the percentage of total premium revenue
      expended on nonclinical costs (as reported under sec-
 
-      HR 3590 EAS/PP
-                           60
      tion 2718(a) of the Public Health Service Act), eligi-
      bility, availability, premium rates, and cost sharing
      with respect to such coverage options and be con-
@@ -2029,8 +1913,6 @@ ed—
      (b) OPERATING  R ULES FOR  H EALTH  INFORMATION
  TRANSACTIONS .—
 
-      HR 3590 EAS/PP
-                             61
           (1) D EFINITION OF OPERATING RULES   .—Section
       1171 of the Social Security Act (42 U.S.C. 1320d) is
       amended by adding at the end the following:
@@ -2057,8 +1939,6 @@ ed—
                ual’s eligibility and financial responsibility
 
 
-      HR 3590 EAS/PP
-                             62
                for specific services prior to or at the point
                of care;
                    ‘‘(ii) be comprehensive, requiring mini-
@@ -2085,8 +1965,6 @@ ed—
           electronic forms) and data entry required by pa-
           tients and providers.’’; and
 
-      HR 3590 EAS/PP
-                            63
                (C) by adding at the end the following new
           subsections:
      ‘‘(g) PERATING  R ULES.—
@@ -2113,8 +1991,6 @@ ed—
           by or participation from health plans, health
           care providers, vendors, relevant Federal agen-
 
-      HR 3590 EAS/PP
-                             64
           cies, and other standard development organiza-
           tions.
                ‘‘(C) The entity has a public set of guiding
@@ -2141,8 +2017,6 @@ ed—
           stakeholders and are consistent with and do not
           conflict with other existing standards;
 
-      HR 3590 EAS/PP
-                            65
                ‘‘(D) evaluate whether such operating rules
           are consistent with electronic standards adopted
           for health information technology; and
@@ -2169,8 +2043,6 @@ ed—
                2011, in a manner ensuring that such oper-
                ating rules are effective not later than Jan-
 
-      HR 3590 EAS/PP
-                             66
                uary 1, 2013, and may allow for the use of
                a machine readable identification card.
                     ‘‘(ii) LECTRONIC FUNDS TRANSFERS
@@ -2197,8 +2069,6 @@ ed—
                health plan premium payments, and refer-
                ral certification and authorization trans-
 
-      HR 3590 EAS/PP
-                             67
                actions shall be adopted not later than July
                1, 2014, in a manner ensuring that such
                operating rules are effective not later than
@@ -2225,8 +2095,6 @@ ed—
           any applicable standards (as described under
           paragraph (7) of section 1171) and associated
 
-      HR 3590 EAS/PP
-                             68
           operating rules (as described under paragraph
           (9) of such section) for electronic funds transfers,
           eligibility for a health plan, health claim status,
@@ -2253,8 +2121,6 @@ ed—
           transactions as is required to certify compliance
 
 
-      HR 3590 EAS/PP
-                            69
           with the transactions specified in subparagraph
           (A).
           ‘‘(2) D OCUMENTATION    OF   COMPLIANCE   .—A
@@ -2281,8 +2147,6 @@ ed—
      shall comply with any applicable certification and
      compliance requirements (and provide the Secretary
 
-      HR 3590 EAS/PP
-                            70
      with adequate documentation of such compliance)
      under this subsection.
           ‘‘(4) ERTIFICATION BY OUTSIDE ENTITY    .—The
@@ -2309,8 +2173,6 @@ ed—
                subsection; or
 
 
-      HR 3590 EAS/PP
-                            71
                    ‘‘(ii) establishes a standard (as de-
               scribed under subsection (a)(1)(B)) or asso-
               ciated operating rules (as described under
@@ -2337,8 +2199,6 @@ ed—
           Secretary, acting through the review committee,
           shall conduct hearings to evaluate and review the
 
-      HR 3590 EAS/PP
-                            72
           adopted standards and operating rules estab-
           lished under this section.
                ‘‘(B) REPORT .—Not later than July 1,
@@ -2365,8 +2225,6 @@ ed—
                comments on any interim final rule pub-
 
 
-      HR 3590 EAS/PP
-                             73
                lished under this paragraph for 60 days
                after the date of such publication.
                    ‘‘(ii) EFFECTIVE DATE  .—The effective
@@ -2393,8 +2251,6 @@ ed—
           nation, as appropriate, with the standards that
           support the certified electronic health record tech-
 
-      HR 3590 EAS/PP
-                             74
           nology approved by the Office of the National
           Coordinator for Health Information Technology.
           ‘‘(5) OPERATING RULES FOR OTHER STANDARDS
@@ -2421,8 +2277,6 @@ ed—
                (i)(5)) for any other financial and adminis-
                trative transactions.
 
-      HR 3590 EAS/PP
-                             75
                ‘‘(B) FEE AMOUNT   .—Subject to subpara-
           graphs (C), (D), and (E), the Secretary shall as-
           sess a penalty fee against a health plan in the
@@ -2449,8 +2303,6 @@ ed—
           care expenditures, as determined by the Sec-
           retary.
 
-      HR 3590 EAS/PP
-                             76
                ‘‘(E) PENALTY LIMIT  .—A penalty fee as-
           sessed against a health plan under this sub-
           section shall not exceed, on an annual basis—
@@ -2477,8 +2329,6 @@ ed—
           ‘‘(3) PENALTY FEE REPORT     .—Not later than
       May 1, 2014, and annually thereafter, the Secretary
 
-      HR 3590 EAS/PP
-                             77
       shall provide the Secretary of the Treasury with a re-
       port identifying those health plans that have been as-
       sessed a penalty fee under this subsection.
@@ -2505,8 +2355,6 @@ ed—
           annually thereafter.
 
 
-      HR 3590 EAS/PP
-                            78
               ‘‘(D) UNPAID PENALTY FEES  .—Any amount
           of a penalty fee assessed against a health plan
           under this subsection for which payment has not
@@ -2533,8 +2381,6 @@ ed—
      unique health plan identifier (as described in section
      1173(b) of the Social Security Act (42 U.S.C. 1320d–
 
-      HR 3590 EAS/PP
-                             79
       2(b))) based on the input of the National Committee
       on Vital and Health Statistics. The Secretary may do
       so on an interim final basis and such rule shall be
@@ -2561,8 +2407,6 @@ ed—
       January 1, 2014, in a manner ensuring that such
       standard is effective not later than January 1, 2016.
 
-      HR 3590 EAS/PP
-                           80
      (d) E XPANSION OF  E LECTRONIC  TRANSACTIONS IN
  MEDICARE .—Section 1862(a) of the Social Security Act (42
 U.S.C. 1395y(a)) is amended—
@@ -2589,8 +2433,6 @@ of this Act.
 (42 U.S.C. 300gg et seq.), as amended by section 1001, is
 further amended—
 
-      HR 3590 EAS/PP
-                            81
           (1) by striking the heading for subpart 1 and in-
      serting the following:
              ‘‘Subpart I—General Reform’’;
@@ -2617,8 +2459,6 @@ exclusion with respect to such plan or coverage.’’; and
                place that such appears and inserting
 
 
-      HR 3590 EAS/PP
-                            82
               ‘‘health insurance issuer offering group or
               individual health insurance coverage’’; and
                    (II) in paragraph (2)(A)—
@@ -2645,8 +2485,6 @@ exclusion with respect to such plan or coverage.’’; and
           ‘‘(1)N GENERAL  .—With respect to the premium
      rate charged by a health insurance issuer for health
 
-      HR 3590 EAS/PP
-                             83
       insurance coverage offered in the individual or small
       group market—
                ‘‘(A) such rate shall vary with respect to the
@@ -2673,8 +2511,6 @@ exclusion with respect to such plan or coverage.’’; and
           retary shall review the rating areas established
           by each State under subparagraph (A) to ensure
 
-      HR 3590 EAS/PP
-                             84
           the adequacy of such areas for purposes of car-
           rying out the requirements of this title. If the
           Secretary determines a State’s rating areas are
@@ -2701,8 +2537,6 @@ exclusion with respect to such plan or coverage.’’; and
       change (as provided for under section 1312(f)(2)(B) of
       the Patient Protection and Affordable Care Act), the
 
-      HR 3590 EAS/PP
-                            85
      provisions of this subsection shall apply to all cov-
      erage offered in such market in the State.
  ‘‘SEC. 2702. GUARANTEED AVAILABILITY OF COVERAGE.
@@ -2729,8 +2563,6 @@ in the State that applies for such coverage.
 
 
 
-      HR 3590 EAS/PP
-                             86
  ‘‘SEC. 2703. GUARANTEED RENEWABILITY OF COVERAGE.
       ‘‘(a)NIG ENERAL .—Except as provided in this section,
 if a health insurance issuer offers health insurance coverage
@@ -2757,8 +2589,6 @@ vidual or a dependent of the individual:
           ‘‘(7) Evidence of insurability (including condi-
       tions arising out of acts of domestic violence).
           ‘‘(8) Disability.
-      HR 3590 EAS/PP
-                           87
           ‘‘(9) Any other health status-related factor deter-
      mined appropriate by the Secretary.
      ‘‘(j) ROGRAMS OF  H EALTH  PROMOTION OR  D ISEASE
@@ -2785,8 +2615,6 @@ vidual or a dependent of the individual:
           TUS FACTOR .—If any of the conditions for ob-
           taining a premium discount or rebate or other
 
-      HR 3590 EAS/PP
-                             88
           reward for participation in a wellness program
           is based on an individual satisfying a standard
           that is related to a health status factor, such
@@ -2813,8 +2641,6 @@ vidual or a dependent of the individual:
           base any part of the reward on outcomes.
 
 
-      HR 3590 EAS/PP
-                             89
                ‘‘(C) A program that encourages preventive
           care related to a health condition through the
           waiver of the copayment or deductible require-
@@ -2841,8 +2667,6 @@ vidual or a dependent of the individual:
           grams with respect to the plan that requires sat-
           isfaction of a standard related to a health status
 
-      HR 3590 EAS/PP
-                             90
           factor, shall not exceed 30 percent of the cost of
           employee-only coverage under the plan. If, in ad-
           dition to employees or individuals, any class of
@@ -2869,8 +2693,6 @@ vidual or a dependent of the individual:
           of the cost of coverage if the Secretaries deter-
           mine that such an increase is appropriate.
 
-      HR 3590 EAS/PP
-                             91
                ‘‘(B) The wellness program shall be reason-
           ably designed to promote health or prevent dis-
           ease. A program complies with the preceding sen-
@@ -2897,8 +2719,6 @@ vidual or a dependent of the individual:
                     applicable standard) for obtaining the
                     reward for any individual for whom,
 
-      HR 3590 EAS/PP
-                             92
                     for that period, it is unreasonably dif-
                     ficult due to a medical condition to
                     satisfy the otherwise applicable stand-
@@ -2925,8 +2745,6 @@ vidual or a dependent of the individual:
           waiver of the otherwise applicable standard) re-
           quired under subparagraph (D). If plan mate-
 
-      HR 3590 EAS/PP
-                            93
           rials disclose that such a program is available,
           without describing its terms, the disclosure under
           this subparagraph shall not be required.
@@ -2953,8 +2771,6 @@ carried out for as long as such regulations remain in effect.
      paragraph (1) is effective, such Secretaries may, be-
 
 
-      HR 3590 EAS/PP
-                            94
      ginning on July 1, 2017 expand such demonstration
      project to include additional participating States.
           ‘‘(3) EQUIREMENTS  .—
@@ -2981,8 +2797,6 @@ carried out for as long as such regulations remain in effect.
                plicable copayments or deductibles for ad-
                herence to, or participation in, a reasonably
 
-      HR 3590 EAS/PP
-                             95
                designed program of health promotion and
                disease prevention;
                     ‘‘(ii) shall ensure that requirements of
@@ -3009,8 +2823,6 @@ carried out for as long as such regulations remain in effect.
                discounts or other rewards provided under
                the project reflect the expected level of par-
 
-      HR 3590 EAS/PP
-                             96
                ticipation in the wellness program involved
                and the anticipated effect the program will
                have on utilization or medical claim costs.
@@ -3037,8 +2849,6 @@ carried out for as long as such regulations remain in effect.
           ‘‘(2) DATA COLLECTION  .—In preparing the re-
       port described in paragraph (1), the Secretaries shall
 
-      HR 3590 EAS/PP
-                              97
       gather relevant information from employers who pro-
       vide employees with access to wellness programs, in-
       cluding State and Federal agencies.
@@ -3065,8 +2875,6 @@ ance measures.
 the Patient Protection and Affordable Care Act (relating
 to non-discrimination) shall apply with respect to a group
 
-      HR 3590 EAS/PP
-                           98
 health plan or health insurance issuer offering group or in-
 dividual health insurance coverage.
  ‘‘SEC. 2707. COMPREHENSIVE HEALTH INSURANCE COV-
@@ -3094,8 +2902,6 @@ have not attained the age of 21.
 a plan described in section 1302(d)(2)(B)(ii)(I).
 
 
-      HR 3590 EAS/PP
-                           99
  ‘‘SEC. 2708. PROHIBITION ON EXCESSIVE WAITING PERIODS.
      ‘‘A group health plan and a health insurance issuer
 offering group or individual health insurance coverage shall
@@ -3122,8 +2928,6 @@ not apply any waiting period (as defined in section
      (b) ALLOWANCE FOR  FAMILY M EMBERS T O JOINC UR-
  RENT COVERAGE .—With respect to a group health plan or
 health insurance coverage in which an individual was en-
-      HR 3590 EAS/PP
-                           100
 rolled on the date of enactment of this Act and which is
 renewed after such date, family members of such individual
 shall be permitted to enroll in such plan or coverage if such
@@ -3150,8 +2954,6 @@ agreement relating to the coverage which amends the cov-
 erage solely to conform to any requirement added by this
 
 
-      HR 3590 EAS/PP
-                             101
 subtitle or subtitle A (or amendments) shall not be treated
 as a termination of such collective bargaining agreement.
       (e) D EFINITION .—In this title, the term ‘‘grand-
@@ -3178,8 +2980,6 @@ after January 1, 2014.
 
 
 
-      HR 3590 EAS/PP
-                           102
     Subtitle D—Available Coverage
         Choices for All Americans
  PART I—ESTABLISHMENT OF QUALIFIED HEALTH
@@ -3206,8 +3006,6 @@ after January 1, 2014.
               fied health plan in the silver level and at
 
 
-      HR 3590 EAS/PP
-                           103
               least one plan in the gold level in each such
               Exchange;
                    (iii) agrees to charge the same pre-
@@ -3234,8 +3032,6 @@ title:
           means health insurance coverage and a group
           health plan.
 
-      HR 3590 EAS/PP
-                           104
               (B) E XCEPTION FOR SELF  INSURED PLANS
           AND MEWAS  .—Except to the extent specifically
           provided by this title, the term ‘‘health plan’’
@@ -3262,8 +3058,6 @@ means, with respect to any health plan, coverage that—
      cordance with subsection (c); and
 
 
-      HR 3590 EAS/PP
-                           105
           (3) subject to subsection (e), provides either the
      bronze, silver, gold, or platinum level of coverage de-
      scribed in subsection (d).
@@ -3290,8 +3084,6 @@ means, with respect to any health plan, coverage that—
           vision care.
           (2) LIMITATION.—
 
-      HR 3590 EAS/PP
-                            106
                (A) IN GENERAL  .—The Secretary shall en-
           sure that the scope of the essential health benefits
           under paragraph (1) is equal to the scope of ben-
@@ -3318,8 +3110,6 @@ means, with respect to any health plan, coverage that—
       for public comment.
 
 
-      HR 3590 EAS/PP
-                            107
           (4) R  EQUIRED    ELEMENTS    FOR   CONSIDER  -
       ATION.—In defining the essential health benefits
       under paragraph (1), the Secretary shall—
@@ -3346,8 +3136,6 @@ means, with respect to any health plan, coverage that—
                (E) provide that a qualified health plan
           shall not be treated as providing coverage for the
 
-      HR 3590 EAS/PP
-                            108
           essential health benefits described in paragraph
           (1) unless the plan provides that—
                     (i) coverage for emergency department
@@ -3374,8 +3162,6 @@ means, with respect to any health plan, coverage that—
           change, another health plan offered through such
           Exchange shall not fail to be treated as a quali-
 
-      HR 3590 EAS/PP
-                            109
           fied health plan solely because the plan does not
           offer coverage of benefits offered through the
           stand-alone plan that are otherwise required
@@ -3402,8 +3188,6 @@ means, with respect to any health plan, coverage that—
                tations described in paragraph (2); and
 
 
-      HR 3590 EAS/PP
-                           110
               (H) periodically update the essential health
           benefits under paragraph (1) to address any
           gaps in access to coverage or changes in the evi-
@@ -3430,8 +3214,6 @@ means, with respect to any health plan, coverage that—
                    (i) in the case of self-only coverage, be
               equal to the dollar amount under subpara-
 
-      HR 3590 EAS/PP
-                            111
                graph (A) for self-only coverage for plan
                years beginning in 2014, increased by an
                amount equal to the product of that amount
@@ -3458,8 +3240,6 @@ means, with respect to any health plan, coverage that—
           pant under a flexible spending arrangement de-
           scribed in section 106(c)(2) of the Internal Rev-
 
-      HR 3590 EAS/PP
-                            112
           enue Code of 1986 (determined without regard to
           any salary reduction arrangement).
                (B) INDEXING OF LIMITS   .—In the case of
@@ -3486,8 +3266,6 @@ means, with respect to any health plan, coverage that—
           any health plan, including a plan in the bronze
           level.
 
-      HR 3590 EAS/PP
-                            113
                (D) COORDINATION WITH PREVENTIVE LIM     -
           ITS.—Nothing in this paragraph shall be con-
           strued to allow a plan to have a deductible under
@@ -3514,8 +3292,6 @@ means, with respect to any health plan, coverage that—
       year is the percentage (if any) by which the average
       per capita premium for health insurance coverage in
 
-      HR 3590 EAS/PP
-                            114
       the United States for the preceding calendar year (as
       estimated by the Secretary no later than October 1 of
       such preceding calendar year) exceeds such average
@@ -3542,8 +3318,6 @@ means, with respect to any health plan, coverage that—
                (D) PLATINUM LEVEL  .—A plan in the plat-
           inum level shall provide a level of coverage that
 
-      HR 3590 EAS/PP
-                            115
           is designed to provide benefits that are actuari-
           ally equivalent to 90 percent of the full actuarial
           value of the benefits provided under the plan.
@@ -3570,8 +3344,6 @@ means, with respect to any health plan, coverage that—
           that are provided by such plan or coverage, the
 
 
-      HR 3590 EAS/PP
-                            116
           rules contained in the regulations under this
           paragraph shall apply.
           (3) ALLOWABLE VARIANCE   .—The Secretary shall
@@ -3598,8 +3370,6 @@ means, with respect to any health plan, coverage that—
                under subsection (b), except that the plan
                provides no benefits for any plan year until
 
-      HR 3590 EAS/PP
-                            117
                the individual has incurred cost-sharing ex-
                penses in an amount equal to the annual
                limitation in effect under subsection (c)(1)
@@ -3626,8 +3396,6 @@ means, with respect to any health plan, coverage that—
       health insurance issuer offers a health plan described
 
 
-      HR 3590 EAS/PP
-                           118
      in this subsection, the issuer may only offer the plan
      in the individual market.
      (f) CHILD-ONLY PLANS .—If a qualified health plan is
@@ -3654,8 +3422,6 @@ plan shall be treated as a qualified health plan.
               tial health benefits for any plan year; and
 
 
-      HR 3590 EAS/PP
-                            119
                    (ii) the issuer of a qualified health
                plan shall determine whether or not the
                plan provides coverage of services described
@@ -3682,8 +3448,6 @@ plan shall be treated as a qualified health plan.
                year involved.
 
 
-      HR 3590 EAS/PP
-                            120
                (C) PROHIBITION ON FEDERAL FUNDS FOR
           ABORTION SERVICES IN COMMUNITY HEALTH IN     -
           SURANCE OPTION  .—
@@ -3710,8 +3474,6 @@ plan shall be treated as a qualified health plan.
                    this title, takes all necessary steps to
                    assure that the United States does not
 
-      HR 3590 EAS/PP
-                            121
                     bear the insurance risk for a commu-
                     nity health insurance option’s coverage
                     of services described in subparagraph
@@ -3738,8 +3500,6 @@ plan shall be treated as a qualified health plan.
                Services described in subparagraph (B)(ii)
                shall be covered to the same extent as such
 
-      HR 3590 EAS/PP
-                            122
                services are covered under title XIX of the
                Social Security Act.
                (D) A SSURED   AVAILABILITY  OF   VARIED
@@ -3766,8 +3526,6 @@ plan shall be treated as a qualified health plan.
                    covering more than 1 insurance mar-
                    ket, the Secretary shall meet the re-
 
-      HR 3590 EAS/PP
-                            123
                    quirements of clause (i) separately
                    with respect to each such market.
           (2) P ROHIBITION ON THE USE OF FEDERAL
@@ -3794,8 +3552,6 @@ plan shall be treated as a qualified health plan.
           issuer of the plan shall, out of amounts not de-
           scribed in subparagraph (A), segregate an
 
-      HR 3590 EAS/PP
-                            124
           amount equal to the actuarial amounts deter-
           mined under subparagraph (C) for all enrollees
           from the amounts described in subparagraph
@@ -3822,8 +3578,6 @@ plan shall be treated as a qualified health plan.
                    tire population covered; and
 
 
-      HR 3590 EAS/PP
-                           125
                        (III) may not estimate such a cost
                   at less than $1 per enrollee, per month.
           (3) PROVIDER CONSCIENCE PROTECTIONS   .—No
@@ -3850,8 +3604,6 @@ plan shall be treated as a qualified health plan.
                   (i) conscience protection;
 
 
-      HR 3590 EAS/PP
-                           126
                   (ii) willingness or refusal to provide
               abortion; and
                   (iii) discrimination on the basis of the
@@ -3878,8 +3630,6 @@ title:
      maintained by an employer.
 
 
-      HR 3590 EAS/PP
-                            127
           (2) INDIVIDUAL MARKET  .—The term ‘‘individual
       market’’ means the market for health insurance cov-
       erage offered to individuals other than in connection
@@ -3906,8 +3656,6 @@ title:
       plan with respect to a calendar year and a plan year,
       an employer who employed an average of at least 1
 
-      HR 3590 EAS/PP
-                            128
      but not more than 100 employees on business days
      during the preceding calendar year and who employs
      at least 1 employee on the first day of the plan year.
@@ -3934,8 +3682,6 @@ title:
           ploy on business days in the current calendar
           year.
 
-      HR 3590 EAS/PP
-                            129
                (C) PREDECESSORS  .—Any reference in this
           subsection to an employer shall include a ref-
           erence to any predecessor of such employer.
@@ -3962,8 +3708,6 @@ of the 50 States and the District of Columbia.
 
 
 
-      HR 3590 EAS/PP
-                          130
  PART II—CONSUMER CHOICES AND INSURANCE
      COMPETITION THROUGH HEALTH BENEFIT
      EXCHANGES
@@ -3990,8 +3734,6 @@ of the 50 States and the District of Columbia.
      subsection (b).
          (4) RENEWABILITY OF GRANT .—
 
-     HR 3590 EAS/PP
-                           131
               (A) I N  GENERAL .—Subject to subsection
           (d)(4), the Secretary may renew a grant award-
           ed under paragraph (1) if the State recipient of
@@ -4018,8 +3760,6 @@ of the 50 States and the District of Columbia.
      Benefit Exchange (referred to in this title as an ‘‘Ex-
      change’’) for the State that—
 
-      HR 3590 EAS/PP
-                           132
               (A) facilitates the purchase of qualified
           health plans;
               (B) provides for the establishment of a
@@ -4046,8 +3786,6 @@ of the 50 States and the District of Columbia.
      imum—
 
 
-      HR 3590 EAS/PP
-                            133
                (A) meet marketing requirements, and not
           employ marketing practices or benefit designs
           that have the effect of discouraging the enroll-
@@ -4074,8 +3812,6 @@ of the 50 States and the District of Columbia.
           vide coverage for any specific medical procedure;
 
 
-      HR 3590 EAS/PP
-                            134
                (D)(i) be accredited with respect to local
           performance on clinical quality measures such as
           the Healthcare Effectiveness Data and Informa-
@@ -4102,8 +3838,6 @@ of the 50 States and the District of Columbia.
           enrolling in qualified health plans offered
           through such Exchange, and that takes into ac-
 
-      HR 3590 EAS/PP
-                            135
           count criteria that the National Association of
           Insurance Commissioners develops and submits
           to the Secretary;
@@ -4130,8 +3864,6 @@ of the 50 States and the District of Columbia.
       graph (4).
 
 
-      HR 3590 EAS/PP
-                            136
           (4) ENROLLEE SATISFACTION SYSTEM    .—The Sec-
       retary shall develop an enrollee satisfaction survey
       system that would evaluate the level of enrollee satis-
@@ -4158,8 +3890,6 @@ of the 50 States and the District of Columbia.
           Exchange or eligible for a premium tax credit or
           cost-sharing reduction, and to present standard-
 
-      HR 3590 EAS/PP
-                            137
           ized information (including quality ratings) re-
           garding qualified health plans offered through an
           Exchange to assist consumers in making easy
@@ -4186,8 +3916,6 @@ of the 50 States and the District of Columbia.
 
 
 
-      HR 3590 EAS/PP
-                            138
                (D) special monthly enrollment periods for
           Indians (as defined in section 4 of the Indian
           Health Care Improvement Act).
@@ -4214,8 +3942,6 @@ of the 50 States and the District of Columbia.
                with a qualified health plan) if the plan
 
 
-      HR 3590 EAS/PP
-                           139
               provides pediatric dental benefits meeting
               the requirements of section 1302(b)(1)(J)).
           (3) RULES RELATING TO ADDITIONAL REQUIRED
@@ -4242,8 +3968,6 @@ of the 50 States and the District of Columbia.
               reduction under section 1402 to defray the
               cost to the individual of any additional ben-
 
-      HR 3590 EAS/PP
-                            140
                efits described in clause (i) which are not el-
                igible for such credit or reduction under sec-
                tion 36B(b)(3)(D) of such Code and section
@@ -4270,8 +3994,6 @@ of the 50 States and the District of Columbia.
           senting health benefits plan options in the Ex-
           change, including the use of the uniform outline
 
-      HR 3590 EAS/PP
-                            141
           of coverage established under section 2715 of the
           Public Health Service Act;
                (F) in accordance with section 1413, inform
@@ -4298,8 +4020,6 @@ of the 50 States and the District of Columbia.
           quirement or from the penalty imposed by such
           section because—
 
-      HR 3590 EAS/PP
-                            142
                    (i) there is no affordable qualified
                health plan available through the Exchange,
                or the individual’s employer, covering the
@@ -4326,8 +4046,6 @@ of the 50 States and the District of Columbia.
                    minimum essential coverage but it was
                    determined under section 36B(c)(2)(C)
 
-      HR 3590 EAS/PP
-                            143
                    of such Code to either be unaffordable
                    to the employee or not provide the re-
                    quired minimum actuarial value; and
@@ -4354,8 +4072,6 @@ of the 50 States and the District of Columbia.
           change to charge assessments or user fees to par-
 
 
-      HR 3590 EAS/PP
-                            144
           ticipating health insurance issuers, or to other-
           wise generate funding, to support its operations.
                (B) P  ROHIBITING   WASTEFUL    USE   OF
@@ -4382,8 +4098,6 @@ of the 50 States and the District of Columbia.
           (7) PUBLICATION OF COSTS  .—An Exchange shall
       publish the average costs of licensing, regulatory fees,
 
-      HR 3590 EAS/PP
-                            145
       and any other payments required by the Exchange,
       and the administrative costs of such Exchange, on an
       Internet website to educate consumers on such costs.
@@ -4410,8 +4124,6 @@ of the 50 States and the District of Columbia.
                deaths in circumstances the Exchange deter-
                mines are inappropriate or too costly.
 
-      HR 3590 EAS/PP
-                            146
           (2) PREMIUM CONSIDERATIONS    .—The Exchange
      shall require health plans seeking certification as
      qualified health plans to submit a justification for
@@ -4438,8 +4150,6 @@ of the 50 States and the District of Columbia.
                (B) the Secretary approves such regional or
           interstate Exchange.
 
-      HR 3590 EAS/PP
-                            147
           (2) SUBSIDIARY EXCHANGES   .—A State may es-
       tablish one or more subsidiary Exchanges if—
                (A) each such Exchange serves a geographi-
@@ -4466,8 +4176,6 @@ of the 50 States and the District of Columbia.
                         (III) that is not a health insur-
                    ance issuer or that is treated under
 
-      HR 3590 EAS/PP
-                           148
                    subsection (a) or (b) of section 52 of
                    the Internal Revenue Code of 1986 as
                    a member of the same controlled group
@@ -4494,8 +4202,6 @@ of the 50 States and the District of Columbia.
           vent hospital readmissions through a comprehen-
           sive program for hospital discharge that includes
 
-      HR 3590 EAS/PP
-                            149
           patient-centered education and counseling, com-
           prehensive discharge planning, and post dis-
           charge reinforcement by an appropriate health
@@ -4522,8 +4228,6 @@ of the 50 States and the District of Columbia.
      January 1, 2015, a qualified health plan may con-
      tract with—
 
-      HR 3590 EAS/PP
-                            150
                (A) a hospital with greater than 50 beds
           only if such hospital—
                    (i) utilizes a patient safety evaluation
@@ -4550,8 +4254,6 @@ of the 50 States and the District of Columbia.
           (1) IN GENERAL .—An Exchange shall establish a
       program under which it awards grants to entities de-
 
-      HR 3590 EAS/PP
-                            151
       scribed in paragraph (2) to carry out the duties de-
       scribed in paragraph (3).
           (2) ELIGIBILITY.—
@@ -4578,8 +4280,6 @@ of the 50 States and the District of Columbia.
                    (ii) meet the standards described in
                paragraph (4); and
 
-      HR 3590 EAS/PP
-                            152
                    (iii) provide information consistent
                with the standards developed under para-
                graph (5).
@@ -4606,8 +4306,6 @@ of the 50 States and the District of Columbia.
           a determination under such plan or coverage;
           and
 
-      HR 3590 EAS/PP
-                            153
                (E) provide information in a manner that
           is culturally and linguistically appropriate to
           the needs of the population being served by the
@@ -4634,8 +4332,6 @@ of the 50 States and the District of Columbia.
      mation made available by navigators is fair, accu-
      rate, and impartial.
 
-      HR 3590 EAS/PP
-                           154
           (6) FUNDING .—Grants under this subsection
      shall be made from the operational funds of the Ex-
      change and not Federal funds received by the State to
@@ -4662,8 +4358,6 @@ promulgated by the Secretary under this subtitle.
           through an Exchange.
 
 
-      HR 3590 EAS/PP
-                           155
               (B) E MPLOYEE MAY CHOOSE PLANS WITHIN
           A LEVEL .—Each employee of a qualified em-
           ployer that elects a level of coverage under sub-
@@ -4690,8 +4384,6 @@ fied health plan.
           (3) M ERGER OF MARKETS   .—A State may re-
      quire the individual and small group insurance mar-
 
-      HR 3590 EAS/PP
-                           156
      kets within a State to be merged if the State deter-
      mines appropriate.
           (4) STATE LAW .—A State law requiring grand-
@@ -4718,8 +4410,6 @@ fied health plan.
               (A) C HOICE TO ENROLL OR NOT TO EN      -
           ROLL.—Nothing in this title shall be construed to
 
-      HR 3590 EAS/PP
-                            157
           restrict the choice of a qualified individual to en-
           roll or not to enroll in a qualified health plan
           or to participate in an Exchange.
@@ -4746,8 +4436,6 @@ fied health plan.
                ice as a Member of Congress or congres-
                sional staff shall be health plans that are—
 
-      HR 3590 EAS/PP
-                            158
                         (I) created under this Act (or an
                    amendment made by this Act); or
                         (II) offered through an Exchange
@@ -4774,8 +4462,6 @@ fied health plan.
      minimum essential coverage (as defined in section
      5000A(f) of the Internal Revenue Code of 1986 with-
 
-      HR 3590 EAS/PP
-                           159
      out regard to paragraph (1)(C) or (D) thereof) or
      such coverage becomes affordable (within the meaning
      of section 36B(c)(2)(C) of such Code).
@@ -4802,8 +4488,6 @@ plans offered through an exchange.
               health plan in the individual market offered
               through the Exchange; and
 
-      HR 3590 EAS/PP
-                            160
                    (ii) resides in the State that established
                the Exchange (except with respect to terri-
                torial agreements under section 1312(f)).
@@ -4830,8 +4514,6 @@ plans offered through an exchange.
                through an Exchange.
 
 
-      HR 3590 EAS/PP
-                           161
                    (ii) LARGE EMPLOYERS ELIGIBLE   .—If
               a State under clause (i) allows issuers to
               offer qualified health plans in the large
@@ -4858,8 +4540,6 @@ plans offered through an exchange.
      penditures and shall annually submit to the Secretary
      a report concerning such accountings.
 
-      HR 3590 EAS/PP
-                            162
           (2) INVESTIGATIONS .—The Secretary, in coordi-
       nation with the Inspector General of the Department
       of Health and Human Services, may investigate the
@@ -4886,8 +4566,6 @@ plans offered through an exchange.
       the Secretary shall provide for the efficient and non-
 
 
-      HR 3590 EAS/PP
-                            163
      discriminatory administration of Exchange activities
      and implement any measure or procedure that—
                (A) the Secretary determines is appropriate
@@ -4914,8 +4592,6 @@ plans offered through an exchange.
           Claims Act on any person found liable under
           such Act as described in subparagraph (A) shall
 
-      HR 3590 EAS/PP
-                            164
           be increased by not less than 3 times and not
           more than 6 times the amount of damages which
           the Government sustains because of the act of
@@ -4942,8 +4618,6 @@ Such study shall review—
       and
 
 
-      HR 3590 EAS/PP
-                           165
           (4) how many physicians, by area and specialty,
      are not taking or accepting new patients enrolled in
      Federal Government health care programs, and the
@@ -4970,8 +4644,6 @@ Such study shall review—
           retary determines appropriate.
 
 
-      HR 3590 EAS/PP
-                           166
      The preceding sentence shall not apply to standards
      for requirements under subtitles A and C (and the
      amendments made by such subtitles) for which the
@@ -4998,8 +4670,6 @@ not later than January 1, 2014, adopt and have in effect—
  MENT R EQUIREMENTS  .—
           (1) N GENERAL .—If—
 
-      HR 3590 EAS/PP
-                            167
                (A) a State is not an electing State under
           subsection (b); or
                (B) the Secretary determines, on or before
@@ -5026,8 +4696,6 @@ not later than January 1, 2014, adopt and have in effect—
       any limitation on the application of those provisions
       to group health plans).
 
-      HR 3590 EAS/PP
-                          168
      (d) NO  INTERFERENCE   W ITH STATE  R EGULATORY
  AUTHORITY .—Nothing in this title shall be construed to
 preempt any State law that does not prevent the applica-
@@ -5054,8 +4722,6 @@ tion of the provisions of this title.
 
 
 
-      HR 3590 EAS/PP
-                           169
  SEC. 1322. FEDERAL PROGRAM TO ASSIST ESTABLISHMENT
              AND OPERATION OF NONPROFIT, MEMBER-
              RUN HEALTH INSURANCE ISSUERS.
@@ -5082,8 +4748,6 @@ tion of the provisions of this title.
           son in meeting any solvency requirements of
           States in which the person seeks to be licensed to
           issue qualified health plans.
-      HR 3590 EAS/PP
-                            170
           (2) REQUIREMENTS FOR AWARDING LOANS AND
      GRANTS  .—
                (A) IN GENERAL .—In awarding loans and
@@ -5110,8 +4774,6 @@ tion of the provisions of this title.
           be a qualified nonprofit health insurance issuer
           within a State, the Secretary may use amounts
 
-      HR 3590 EAS/PP
-                            171
           appropriated under this section for the awarding
           of grants to encourage the establishment of a
           qualified nonprofit health insurance issuer with-
@@ -5138,8 +4800,6 @@ tion of the provisions of this title.
                made available by any loan or grant under
                this section may be used—
 
-      HR 3590 EAS/PP
-                            172
                         (I) for carrying on propaganda,
                     or otherwise attempting, to influence
                     legislation; or
@@ -5166,8 +4826,6 @@ tion of the provisions of this title.
                     loans or grants were outstanding.
 
 
-      HR 3590 EAS/PP
-                           173
               The Secretary shall notify the Secretary of
               the Treasury of any determination under
               this section of a failure that results in the
@@ -5194,8 +4852,6 @@ tion of the provisions of this title.
               ment and interference.
 
 
-      HR 3590 EAS/PP
-                           174
                    (ii) O RIGINAL  APPOINTMENTS  .—The
               original appointment of board members
               under subparagraph (A)(ii) shall be made
@@ -5222,8 +4878,6 @@ tion of the provisions of this title.
           14 of such Act shall not apply.
 
 
-      HR 3590 EAS/PP
-                           175
               (F) T  ERMINATION .—The advisory board
           shall terminate on the earlier of the date that it
           completes its duties under this section or Decem-
@@ -5250,8 +4904,6 @@ tion of the provisions of this title.
           issuer on July 16, 2009; or
 
 
-      HR 3590 EAS/PP
-                            176
                (B) the organization is sponsored by a State
           or local government, any political subdivision
           thereof, or any instrumentality of such govern-
@@ -5278,8 +4930,6 @@ tion of the provisions of this title.
       grams intended to improve the quality of health care
       delivered to its members.
 
-      HR 3590 EAS/PP
-                           177
           (5) C  OMPLIANCE   WITH   STATE   INSURANCE
      LAWS .—An organization shall not be treated as a
      qualified nonprofit health insurance issuer unless the
@@ -5306,8 +4956,6 @@ tion of the provisions of this title.
      surance issuers participating in the CO–OP program
      under this section may establish a private purchasing
 
-      HR 3590 EAS/PP
-                           178
      council to enter into collective purchasing arrange-
      ments for items and services that increase adminis-
      trative and other cost efficiencies, including claims
@@ -5334,8 +4982,6 @@ tion of the provisions of this title.
           12(a)). Such term also includes section 5 of the
           Federal Trade Commission Act (15 U.S.C. 45) to
 
-      HR 3590 EAS/PP
-                            179
           the extent that such section 5 applies to unfair
           methods of competition.
       (e) LIMITATION ON   PARTICIPATION .—No representa-
@@ -5362,8 +5008,6 @@ cil established under subsection (d).
       fits through qualified nonprofit health insurance
       issuers.
 
-      HR 3590 EAS/PP
-                           180
      (g) APPROPRIATIONS .—There are hereby appropriated,
 out of any funds in the Treasury not otherwise appro-
 priated, $6,000,000,000 to carry out this section.
@@ -5390,8 +5034,6 @@ priated, $6,000,000,000 to carry out this section.
               to the Secretary, in such manner as the Sec-
               retary may by regulations prescribe, that it
 
-      HR 3590 EAS/PP
-                           181
               is applying for recognition of its status
               under this paragraph,
                    ‘‘(ii) except as provided in section
@@ -5418,8 +5060,6 @@ priated, $6,000,000,000 to carry out this section.
 501(c)(29) shall include on the return required under sub-
 section (a) the following information:
 
-      HR 3590 EAS/PP
-                           182
           ‘‘(1) The amount of the reserves required by each
      State in which the organization is licensed to issue
      qualified health plans.
@@ -5446,8 +5086,6 @@ section (a) the following information:
      conducted under paragraph (1), including any rec-
      ommendations for administrative or legislative
 
-      HR 3590 EAS/PP
-                           183
      changes the Comptroller General determines necessary
      or appropriate to increase competition in the health
      insurance market.
@@ -5474,8 +5112,6 @@ section (a) the following information:
           through the Exchange.
 
 
-      HR 3590 EAS/PP
-                           184
      (b) ESTABLISHMENT OF   COMMUNITY   HEALTH  INSUR -
  ANCE O PTION.—
           (1) ESTABLISHMENT .—The Secretary shall estab-
@@ -5502,8 +5138,6 @@ section (a) the following information:
           to beneficiaries;
 
 
-      HR 3590 EAS/PP
-                            185
                (F) offers a sufficient choice of providers;
           and
                (G) complies with State laws (if any), ex-
@@ -5530,8 +5164,6 @@ section (a) the following information:
                Revenue Code of 1986 in the same manner
 
 
-      HR 3590 EAS/PP
-                            186
                as an individual who is enrolled in a quali-
                fied health plan.
                    (ii) NO ADDITIONAL FEDERAL COST   .—
@@ -5558,8 +5190,6 @@ section (a) the following information:
           shall prohibit any type of medical provider from
           accepting an out-of-pocket payment from an in-
 
-      HR 3590 EAS/PP
-                           187
           dividual enrolled in a community health insur-
           ance option for a service otherwise not included
           as an essential health benefit.
@@ -5586,8 +5216,6 @@ section (a) the following information:
 
 
 
-      HR 3590 EAS/PP
-                            188
                (C) COLLECTION OF DATA   .—The Secretary
           shall collect data as necessary to set premium
           rates under subparagraph (A).
@@ -5614,8 +5242,6 @@ section (a) the following information:
           Council established or designated under sub-
           section (d) may develop or encourage the use of
 
-      HR 3590 EAS/PP
-                           189
           innovative payment policies that promote qual-
           ity, efficiency and savings to consumers.
           (7) SOLVENCY AND CONSUMER PROTECTION    .—
@@ -5642,8 +5268,6 @@ section (a) the following information:
           surance Commissioners (in this paragraph re-
           ferred to as the ‘‘NAIC’’), may promulgate regu-
 
-      HR 3590 EAS/PP
-                           190
           lations to establish additional requirements for a
           community health insurance option.
               (B) A PPLICABILITY.—Any requirement pro-
@@ -5670,8 +5294,6 @@ section (a) the following information:
           and Human Services as necessary to—
 
 
-      HR 3590 EAS/PP
-                           191
                    (i) pay the start-up costs associated
               with the initial operations of a community
               health insurance option; and
@@ -5698,8 +5320,6 @@ section (a) the following information:
           payment is made. The Secretary may require the
           payment of interest with respect to such repay-
 
-      HR 3590 EAS/PP
-                            192
           ments at rates that do not exceed the market in-
           terest rate (as determined by the Secretary).
                (B) S ANCTIONS IN CASE OF FOR     PROFIT
@@ -5726,8 +5346,6 @@ section (a) the following information:
      lowing:
 
 
-      HR 3590 EAS/PP
-                           193
               (A) policies and procedures to integrate
           quality improvement and cost containment
           mechanisms into the health care delivery system;
@@ -5754,8 +5372,6 @@ section (a) the following information:
           qualified entities for the purpose of performing
           administrative functions (including functions de-
 
-      HR 3590 EAS/PP
-                            194
           scribed in subsection (a)(4) of section 1874A of
           the Social Security Act) with respect to a com-
           munity health insurance option in the same
@@ -5782,8 +5398,6 @@ section (a) the following information:
           the Secretary has entered into a contract under
 
 
-      HR 3590 EAS/PP
-                            195
           this paragraph shall be referred to as a ‘‘con-
           tracting administrator’’.
           (2) Q UALIFIED ENTITY  .—To be qualified to be
@@ -5810,8 +5424,6 @@ section (a) the following information:
       account number is not used, and shall also include
       procedures for the use of technology (including front-
 
-      HR 3590 EAS/PP
-                            196
       end, prepayment intelligent data-matching technology
       similar to that used by hedge funds, investment funds,
       and banks) to provide real-time data analysis of
@@ -5838,8 +5450,6 @@ section (a) the following information:
       tion.
 
 
-      HR 3590 EAS/PP
-                            197
           (6) R EVOCATION .—A contract awarded under
       this subsection shall be revoked by the Secretary, upon
       the recommendation of the Inspector General, only
@@ -5866,8 +5476,6 @@ section (a) the following information:
           ministrator, in the determination of the Sec-
           retary, meets performance requirements estab-
 
-      HR 3590 EAS/PP
-                           198
           lished by the Secretary, in at least the following
           areas:
                    (i) Maintaining low premium costs
@@ -5894,8 +5502,6 @@ section (a) the following information:
      (f) REPORT BY  HHS   AND  INSOLVENCY  W ARNINGS.—
 
 
-      HR 3590 EAS/PP
-                            199
           (1) IN GENERAL  .—On an annual basis, the Sec-
       retary shall conduct a study on the solvency of a com-
       munity health insurance option and submit to Con-
@@ -5922,8 +5528,6 @@ section (a) the following information:
           the Medicare Prescription Drug, Improvement,
 
 
-      HR 3590 EAS/PP
-                            200
           and Modernization Act of 2003 that shall be used
           for a medicare funding warning.
       (g) MARKETING   PARITY .—In a facility controlled by
@@ -5950,8 +5554,6 @@ wide qualified health plan under section 1333(b), is not sub-
 ject to such law.
 
 
-      HR 3590 EAS/PP
-                           201
      (b) LAWS  DESCRIBED .—The Federal and State laws
 described in this subsection are those Federal and State
 laws relating to—
@@ -5978,8 +5580,6 @@ laws relating to—
      a basic health program meeting the requirements of
      this section under which a State may enter into con-
 
-      HR 3590 EAS/PP
-                            202
       tracts to offer 1 or more standard health plans pro-
       viding at least the essential health benefits described
       in section 1302(b) to eligible individuals in lieu of of-
@@ -6006,8 +5606,6 @@ laws relating to—
                applicable second lowest cost silver plan (as
                defined in section 36B(b)(3)(B) of the Inter-
 
-      HR 3590 EAS/PP
-                            203
                nal Revenue Code of 1986) offered to the in-
                dividual through an Exchange; and
                     (ii) that the cost-sharing an eligible in-
@@ -6034,8 +5632,6 @@ laws relating to—
       mined after reduction for any premium tax credits
 
 
-      HR 3590 EAS/PP
-                           204
      and cost-sharing reductions allowable with respect to
      either plan.
      (b) S TANDARD  H EALTH  P LAN.—In this section, the
@@ -6062,8 +5658,6 @@ that the State contracts with under this section—
           of a standard health plan for the inclusion of in-
           novative features in the plan, including—
 
-      HR 3590 EAS/PP
-                            205
                    (i) care coordination and care manage-
                ment for enrollees, especially for those with
                chronic health conditions;
@@ -6090,8 +5684,6 @@ that the State contracts with under this section—
           feasible in the local health care market.
 
 
-      HR 3590 EAS/PP
-                            206
                (D) P  ERFORMANCE     MEASURES  .—Estab-
           lishing specific performance measures and stand-
           ards for issuers of standard health plans that
@@ -6118,8 +5710,6 @@ that the State contracts with under this section—
      gram under this section with the State medicaid pro-
      gram under title XIX of the Social Security Act, the
 
-      HR 3590 EAS/PP
-                           207
      State child health plan under title XXI of such Act,
      and other State-administered health programs to
      maximize the efficiency of such programs and to im-
@@ -6146,8 +5736,6 @@ that the State contracts with under this section—
           (3) AMOUNT OF PAYMENT  .—
               (A) SECRETARIAL DETERMINATION   .—
 
-      HR 3590 EAS/PP
-                            208
                     (i) N GENERAL   .—The amount deter-
                mined under this paragraph for any fiscal
                year is the amount the Secretary determines
@@ -6174,8 +5762,6 @@ that the State contracts with under this section—
                family coverage, geographic differences in
                average spending for health care across rat-
 
-      HR 3590 EAS/PP
-                            209
                ing areas, the health status of the enrollee
                for purposes of determining risk adjustment
                payments and reinsurance payments that
@@ -6202,8 +5788,6 @@ that the State contracts with under this section—
                Such certifications shall be based on suffi-
                cient data from the State and from com-
 
-      HR 3590 EAS/PP
-                            210
                parable States about their experience with
                programs created by this Act.
                (B) CORRECTIONS  .—The Secretary shall ad-
@@ -6230,8 +5814,6 @@ that the State contracts with under this section—
                (C) who is not eligible for minimum essen-
           tial coverage (as defined in section 5000A(f) of
 
-      HR 3590 EAS/PP
-                            211
           the Internal Revenue Code of 1986) or is eligible
           for an employer-sponsored plan that is not af-
           fordable coverage (as determined under section
@@ -6258,8 +5840,6 @@ ensuring that the State program meets—
           (3) the quality and performance standards under
       this section.
 
-      HR 3590 EAS/PP
-                           212
      (g) STANDARD   H EALTH  PLAN  OFFERORS  .—A State
 may provide that persons eligible to offer standard health
 plans under a basic health program established under this
@@ -6286,8 +5866,6 @@ such section.
                    (i) a comprehensive description of the
               State legislation and program to implement
 
-      HR 3590 EAS/PP
-                            213
                a plan meeting the requirements for a waiv-
                er under this section; and
                    (ii) a 10-year budget plan for such
@@ -6314,8 +5892,6 @@ such section.
       for which they would otherwise be eligible, the Sec-
       retary shall provide for an alternative means by
 
-      HR 3590 EAS/PP
-                            214
       which the aggregate amount of such credits or reduc-
       tions that would have been paid on behalf of partici-
       pants in the Exchanges established under this title
@@ -6342,8 +5918,6 @@ such section.
                hearings, sufficient to ensure a meaningful
                level of public input;
 
-      HR 3590 EAS/PP
-                            215
                     (ii) a process for the submission of an
                application that ensures the disclosure of—
                         (I) the provisions of law that the
@@ -6370,8 +5944,6 @@ such section.
                the waiver.
 
 
-      HR 3590 EAS/PP
-                           216
               (C) R EPORT .—The Secretary shall annually
           report to Congress concerning actions taken by
           the Secretary with respect to applications for
@@ -6398,8 +5970,6 @@ such section.
      (b) GRANTING OF  WAIVERS .—
 
 
-      HR 3590 EAS/PP
-                            217
           (1) IN GENERAL  .—The Secretary may grant a
       request for a waiver under subsection (a)(1) only if
       the Secretary determines that the State plan—
@@ -6426,8 +5996,6 @@ such section.
           actions under a waiver under this section, in-
 
 
-      HR 3590 EAS/PP
-                           218
           cluding the implementation of the State plan
           under subsection (a)(1)(B).
               (B) T ERMINATION OF OPT OUT   .—A State
@@ -6454,8 +6022,6 @@ such section.
           State involved of such determination and the
           terms and effectiveness of such waiver.
 
-      HR 3590 EAS/PP
-                           219
               (B) D ENIAL OF WAIVER .—If the Secretary
           determines a waiver should not be granted under
           subsection (a)(1), the Secretary shall notify the
@@ -6482,8 +6048,6 @@ to the request.
      agreement under which—
 
 
-      HR 3590 EAS/PP
-                            220
                (A) 1 or more qualified health plans could
           be offered in the individual markets in all such
           States but, except as provided in subparagraph
@@ -6510,8 +6074,6 @@ to the request.
                that the policy may not be subject to all the
 
 
-      HR 3590 EAS/PP
-                            221
                laws and regulations of the State in which
                the purchaser resides.
           (2) STATE AUTHORITY   .—A State may not enter
@@ -6538,8 +6100,6 @@ to the request.
           and
 
 
-      HR 3590 EAS/PP
-                           222
               (E) will not weaken enforcement of laws
           and regulations described in paragraph (1)(B)(i)
           in any State that is included in such compact.
@@ -6566,8 +6126,6 @@ to the request.
           health plan.
 
 
-      HR 3590 EAS/PP
-                            223
           (2) S TATE OPT -OUT .—A State may, by specific
       reference in a law enacted after the date of enactment
       of this title, provide that this subsection shall not
@@ -6594,8 +6152,6 @@ to the request.
           cluding the requirement to offer the silver and
 
 
-      HR 3590 EAS/PP
-                            224
           gold levels of the plan in each Exchange in the
           State for the market in which the plan is offered;
                (D) the issuer determines the premiums for
@@ -6622,8 +6178,6 @@ to the request.
           tailed statement of the benefits offered and the
 
 
-      HR 3590 EAS/PP
-                            225
           benefit differences in that State, in accordance
           with rules promulgated by the Secretary.
           (4) F ORM REVIEW FOR NATIONWIDE PLANS       .—
@@ -6650,8 +6204,6 @@ to the request.
       this subsection, a State law mandating benefit cov-
       erage by a health plan is a law that mandates health
 
-      HR 3590 EAS/PP
-                           226
      insurance coverage or the offer of health insurance
      coverage for specific health services or specific dis-
      eases. A law that mandates health insurance coverage
@@ -6678,8 +6230,6 @@ January 1, 2014—
           (1) IN GENERAL  .—In establishing the Federal
      standards under section 1321(a), the Secretary, in
 
-      HR 3590 EAS/PP
-                            227
       consultation with the National Association of Insur-
       ance Commissioners (the ‘‘NAIC’’), shall include pro-
       visions that enable States to establish and maintain
@@ -6706,8 +6256,6 @@ January 1, 2014—
           be identified as high risk individuals for pur-
           poses of the reinsurance program established
 
-      HR 3590 EAS/PP
-                            228
           under this section. Such method shall provide for
           identification of individuals as high-risk indi-
           viduals on the basis of—
@@ -6734,8 +6282,6 @@ January 1, 2014—
                subparagraph (A); or
 
 
-      HR 3590 EAS/PP
-                            229
                    (ii) to use any other comparable meth-
                od for determining payment amounts that
                is recommended by the American Academy
@@ -6762,8 +6308,6 @@ January 1, 2014—
                (B) SPECIFIC REQUIREMENTS  .—The method
           under this paragraph shall be designed so that—
 
-      HR 3590 EAS/PP
-                            230
                     (i) the contribution amount for each
                issuer proportionally reflects each issuer’s
                fully insured commercial book of business
@@ -6790,8 +6334,6 @@ January 1, 2014—
                proportionate share of an additional
                $2,000,000,000 for 2014, an additional
 
-      HR 3590 EAS/PP
-                           231
               $2,000,000,000 for 2015, and an additional
               $1,000,000,000 for 2016.
           Nothing in this subparagraph shall be construed
@@ -6818,8 +6360,6 @@ January 1, 2014—
      (c) A PPLICABLE  R EINSURANCE   ENTITY .—For pur-
 poses of this section—
 
-      HR 3590 EAS/PP
-                            232
           (1) IN GENERAL  .—The term ‘‘applicable reinsur-
       ance entity’’ means a not-for-profit organization—
                (A) the purpose of which is to help stabilize
@@ -6846,8 +6386,6 @@ poses of this section—
       nal Revenue Code of 1986. The preceding sentence
       shall not apply to the tax imposed by section 511
 
-      HR 3590 EAS/PP
-                          233
      such Code (relating to tax on unrelated business tax-
      able income of an exempt organization).
      (d) COORDINATION W ITH STATE H IGH-RISKP OOLS.—
@@ -6874,8 +6412,6 @@ part D of title XVIII of the Social Security Act.
      (a) that if—
 
 
-      HR 3590 EAS/PP
-                            234
                (A) a participating plan’s allowable costs
           for any plan year are more than 103 percent but
           not more than 108 percent of the target amount,
@@ -6902,8 +6438,6 @@ part D of title XVIII of the Social Security Act.
           for any plan year are less than 92 percent of the
           target amount, the plan shall pay to the Sec-
 
-      HR 3590 EAS/PP
-                           235
           retary an amount equal to the sum of 2.5 per-
           cent of the target amount plus 80 percent of the
           excess of 92 percent of the target amount over the
@@ -6930,8 +6464,6 @@ part D of title XVIII of the Social Security Act.
           (1) LOW ACTUARIAL RISK PLANS .—Using the cri-
      teria and methods developed under subsection (b),
 
-      HR 3590 EAS/PP
-                            236
       each State shall assess a charge on health plans and
       health insurance issuers (with respect to health insur-
       ance coverage) described in subsection (c) if the actu-
@@ -6958,8 +6490,6 @@ sultation with States, shall establish criteria and methods
 to be used in carrying out the risk adjustment activities
 under this section. The Secretary may utilize criteria and
 
-      HR 3590 EAS/PP
-                           237
 methods similar to the criteria and methods utilized under
 part C or D of title XVIII of the Social Security Act. Such
 criteria and methods shall be included in the standards and
@@ -6986,8 +6516,6 @@ tion 36A the following new section:
 
 
 
-      HR 3590 EAS/PP
-                           238
  ‘‘SEC. 36B. REFUNDABLE CREDIT FOR COVERAGE UNDER A
              QUALIFIED HEALTH PLAN.
      ‘‘(a) N GENERAL  .—In the case of an applicable tax-
@@ -7014,8 +6542,6 @@ purposes of this section—
           dependent (as defined in section 152) of the tax-
           payer and which were enrolled in through an
           Exchange established by the State under 1311 of
-      HR 3590 EAS/PP
-                            239
           the Patient Protection and Affordable Care Act,
           or
                ‘‘(B) the excess (if any) of—
@@ -7042,8 +6568,6 @@ purposes of this section—
                    come for the taxable year in excess of
 
 
-      HR 3590 EAS/PP
-                            240
                     100 percent of the poverty line for a
                     family of the size involved, bears to
                          ‘‘(II) an amount equal to 200 per-
@@ -7070,8 +6594,6 @@ purposes of this section—
                ‘‘(B) A PPLICABLE SECOND LOWEST COST
           SILVER PLAN  .—The applicable second lowest cost
 
-      HR 3590 EAS/PP
-                            241
           silver plan with respect to any applicable tax-
           payer is the second lowest cost silver plan of the
           individual market in the rating area in which
@@ -7098,8 +6620,6 @@ purposes of this section—
                         ‘‘(II) family coverage in the case
                     of any other applicable taxpayer.
 
-      HR 3590 EAS/PP
-                            242
           If a taxpayer files a joint return and no credit
           is allowed under this section with respect to 1 of
           the spouses by reason of subsection (e), the tax-
@@ -7126,8 +6646,6 @@ purposes of this section—
           justed monthly premium shall be determined
 
 
-      HR 3590 EAS/PP
-                            243
           without regard to any premium discount or re-
           bate under such project.
                ‘‘(D) ADDITIONAL BENEFITS  .—If—
@@ -7154,8 +6672,6 @@ purposes of this section—
           and a plan described in section
           1311(d)(2)(B)(ii)(I) of the Patient Protection
 
-      HR 3590 EAS/PP
-                           244
           and Affordable Care Act for any plan year, the
           portion of the premium for the plan described in
           such section that (under regulations prescribed
@@ -7182,8 +6698,6 @@ purposes of this section—
               which is not greater than 100 percent of an
 
 
-      HR 3590 EAS/PP
-                            245
                amount equal to the poverty line for a fam-
                ily of the size involved, and
                     ‘‘(ii) the taxpayer is an alien lawfully
@@ -7210,8 +6724,6 @@ purposes of this section—
           other taxpayer for a taxable year beginning in
 
 
-      HR 3590 EAS/PP
-                            246
           the calendar year in which such individual’s
           taxable year begins.
           ‘‘(2) COVERAGE MONTH   .—For purposes of this
@@ -7238,8 +6750,6 @@ purposes of this section—
                    ‘‘(i) N GENERAL .—The term ‘coverage
                month’ shall not include any month with
 
-      HR 3590 EAS/PP
-                            247
                respect to an individual if for such month
                the individual is eligible for minimum es-
                sential coverage other than eligibility for
@@ -7266,8 +6776,6 @@ purposes of this section—
                    tion 5000A(e)(1)(B)) with respect to
 
 
-      HR 3590 EAS/PP
-                            248
                     the plan exceeds 9.8 percent of the ap-
                     plicable taxpayer’s household income.
                This clause shall also apply to an indi-
@@ -7294,8 +6802,6 @@ purposes of this section—
                     ‘‘(iv)NDEXING  .—In the case of plan
                years beginning in any calendar year after
 
-      HR 3590 EAS/PP
-                           249
               2014, the Secretary shall adjust the 9.8 per-
               cent under clause (i)(II) in the same man-
               ner as the percentages are adjusted under
@@ -7322,8 +6828,6 @@ For purposes of this section—
      taxable year.
           ‘‘(2) OUSEHOLD INCOME  .—
 
-      HR 3590 EAS/PP
-                            250
                ‘‘(A) H OUSEHOLD     INCOME .—The term
           ‘household income’ means, with respect to any
           taxpayer, an amount equal to the sum of—
@@ -7350,8 +6854,6 @@ For purposes of this section—
                sections 911, 931, and 933.
           ‘‘(3) OVERTY LINE .—
 
-      HR 3590 EAS/PP
-                           251
               ‘‘(A) N GENERAL  .—The term ‘poverty line’
           has the meaning given that term in section
           2110(c)(5) of the Social Security Act (42 U.S.C.
@@ -7378,8 +6880,6 @@ For purposes of this section—
           is attributable to such individuals, and
 
 
-      HR 3590 EAS/PP
-                            252
                ‘‘(B) for purposes of applying this section,
           the determination as to what percentage a tax-
           payer’s household income bears to the poverty
@@ -7406,8 +6906,6 @@ For purposes of this section—
 
 
 
-      HR 3590 EAS/PP
-                            253
                    ‘‘(ii) A comparable method reaching
                the same result as the method under clause
                (i).
@@ -7434,8 +6932,6 @@ For purposes of this section—
       lowed under this section for any taxable year shall be
       reduced (but not below zero) by the amount of any
 
-      HR 3590 EAS/PP
-                            254
       advance payment of such credit under section 1412 of
       the Patient Protection and Affordable Care Act.
           ‘‘(2) XCESS ADVANCE PAYMENTS    .—
@@ -7462,8 +6958,6 @@ For purposes of this section—
                    ‘‘(ii) NDEXING OF AMOUNT    .—In the
                case of any calendar year beginning after
 
-      HR 3590 EAS/PP
-                            255
                2014, each of the dollar amounts under
                clause (i) shall be increased by an amount
                equal to—
@@ -7490,8 +6984,6 @@ for—
           ‘‘(2) the application of subsection (f) where the
       filing status of the taxpayer for a taxable year is dif-
 
-      HR 3590 EAS/PP
-                           256
      ferent from such status used for determining the ad-
      vance payment of the credit.’’.
      (b) DISALLOWANCE OF  D EDUCTION .—Section 280C of
@@ -7518,8 +7010,6 @@ section 36B(a) with respect to such premiums.’’.
               employers under section 45R of such Code
 
 
-      HR 3590 EAS/PP
-                            257
                on maintaining and expanding the health
                insurance coverage of individuals;
                    (ii) the availability of affordable health
@@ -7546,8 +7036,6 @@ section 36B(a) with respect to such premiums.’’.
           under such subparagraph.
 
 
-      HR 3590 EAS/PP
-                           258
           (2) APPROPRIATE COMMITTEES OF CONGRESS    .—
      In this subsection, the term ‘‘appropriate committees
      of Congress’’ means the Committee on Ways and
@@ -7574,8 +7062,6 @@ section shall apply to taxable years ending after December
 enrolled in a qualified health plan—
           (1) the Secretary shall notify the issuer of the
      plan of such eligibility; and
-      HR 3590 EAS/PP
-                            259
           (2) the issuer shall reduce the cost-sharing under
       the plan at the level and in the manner specified in
       subsection (c).
@@ -7602,8 +7088,6 @@ to 100 percent for purposes of applying this section.
                income is more than 100 percent but not
                more than 200 percent of the poverty line
 
-      HR 3590 EAS/PP
-                            260
                for a family of the size involved, by two-
                thirds;
                    (ii) an eligible insured whose household
@@ -7630,8 +7114,6 @@ to 100 percent for purposes of applying this section.
                    eligible insured described in paragraph
                    (2)(B); and
 
-      HR 3590 EAS/PP
-                            261
                         (III) 70 percent in the case of an
                     eligible insured described in clause (ii)
                     or (iii) of subparagraph (A).
@@ -7658,8 +7140,6 @@ to 100 percent for purposes of applying this section.
           not more than 200 percent of the poverty line for
           a family of the size involved, increase the plan’s
 
-      HR 3590 EAS/PP
-                            262
           share of the total allowed costs of benefits pro-
           vided under the plan to 80 percent of such costs.
           (3) M ETHODS FOR REDUCING COST   -SHARING .—
@@ -7686,8 +7166,6 @@ to 100 percent for purposes of applying this section.
       cost-sharing under this section shall not apply to such
       additional benefits.
 
-      HR 3590 EAS/PP
-                           263
           (5) S PECIAL  RULE  FOR   PEDIATRIC  DENTAL
      PLANS .—If an individual enrolls in both a qualified
      health plan and a plan described in section
@@ -7714,8 +7192,6 @@ to 100 percent for purposes of applying this section.
           any cost-sharing under the plan.
 
 
-      HR 3590 EAS/PP
-                           264
           (2) ITEMS OR SERVICES FURNISHED THROUGH
      INDIAN HEALTH PROVIDERS   .—If an Indian (as so de-
      fined) enrolled in a qualified health plan is furnished
@@ -7742,8 +7218,6 @@ to 100 percent for purposes of applying this section.
 
 
 
-      HR 3590 EAS/PP
-                            265
                (A) no cost-sharing reduction under this
           section shall apply with respect to the indi-
           vidual; and
@@ -7770,8 +7244,6 @@ to 100 percent for purposes of applying this section.
                         which is the poverty line for the
 
 
-      HR 3590 EAS/PP
-                            266
                         taxpayer’s family size determined
                         without regard to subclause (I).
                    (ii) A comparable method reaching the
@@ -7798,8 +7270,6 @@ tion:
           (1) IN GENERAL .—Any term used in this section
       which is also used in section 36B of the Internal Rev-
 
-      HR 3590 EAS/PP
-                           267
      enue Code of 1986 shall have the meaning given such
      term by such section.
           (2) LIMITATIONS ON REDUCTION  .—No cost-shar-
@@ -7826,8 +7296,6 @@ section for determining—
           (1) whether an individual who is to be covered
      in the individual market by a qualified health plan
 
-      HR 3590 EAS/PP
-                            268
       offered through an Exchange, or who is claiming a
       premium tax credit or reduced cost-sharing, meets the
       requirements of sections 1312(f)(3), 1402(e), and
@@ -7854,8 +7322,6 @@ section for determining—
       dividual responsibility requirement or the penalty
       imposed by such section.
 
-      HR 3590 EAS/PP
-                           269
      (b) NFORMATION   REQUIRED  TO B E PROVIDED BY A P-
  PLICANTS.—
           (1) N GENERAL  .—An applicant for enrollment
@@ -7882,8 +7348,6 @@ section for determining—
           tion status as the Secretary, after consultation
 
 
-      HR 3590 EAS/PP
-                            270
           with the Secretary of Homeland Security, deter-
           mines appropriate.
           (3) ELIGIBILITY AND AMOUNT OF TAX CREDIT OR
@@ -7910,8 +7374,6 @@ section for determining—
       a premium tax credit under section 36B of such Code
       or cost-sharing reduction under section 1402 is being
 
-      HR 3590 EAS/PP
-                            271
       established on the basis that the enrollee’s (or related
       individual’s) employer is not treated under section
       36B(c)(2)(C) of such Code as providing minimum es-
@@ -7938,8 +7400,6 @@ section for determining—
       lowed, the enrollee shall notify the Exchange of such
       change or additional employment and provide the in-
 
-      HR 3590 EAS/PP
-                           272
      formation described in this paragraph with respect to
      the new employer.
           (5) EXEMPTIONS FROM INDIVIDUAL RESPONSI     -
@@ -7966,8 +7426,6 @@ section for determining—
      RETARY .—An Exchange shall submit the information
      provided by an applicant under subsection (b) to the
 
-      HR 3590 EAS/PP
-                           273
      Secretary for verification in accordance with the re-
      quirements of this subsection and subsection (d).
           (2) CITIZENSHIP OR IMMIGRATION STATUS  .—
@@ -7994,8 +7452,6 @@ section for determining—
                    vidual is a citizen but with respect to
                    whom the Commissioner of Social Se-
 
-      HR 3590 EAS/PP
-                            274
                     curity has notified the Secretary under
                     subsection (e)(3) that the attestation is
                     inconsistent with information in the
@@ -8022,8 +7478,6 @@ section for determining—
                     citizen.
 
 
-      HR 3590 EAS/PP
-                            275
           (3) E LIGIBILITY FOR TAX CREDIT AND COST      -
       SHARING REDUCTION   .—The Secretary shall submit
       the information described in subsection (b)(3)(A) pro-
@@ -8050,8 +7504,6 @@ section for determining—
                Homeland Security, or the Commissioner of
 
 
-      HR 3590 EAS/PP
-                            276
                Social Security through such other method
                as is approved by the Secretary.
                (B) F  LEXIBILITY .—The Secretary may
@@ -8078,8 +7530,6 @@ information in such manner as the Secretary determines
 appropriate, including delegating responsibility for
 verification to the Exchange.
 
-      HR 3590 EAS/PP
-                           277
      (e) ACTIONS RELATING TO  VERIFICATION .—
           (1) N GENERAL  .—Each person to whom the Sec-
      retary provided information under subsection (c)
@@ -8106,8 +7556,6 @@ verification to the Exchange.
               section 1412(c) of the amount of any ad-
               vance payment to be made.
 
-      HR 3590 EAS/PP
-                            278
                (B) E XEMPTION FROM INDIVIDUAL RESPON    -
           SIBILITY.—If information provided by an appli-
           cant under subsection (b)(5) is verified under
@@ -8134,8 +7582,6 @@ verification to the Exchange.
           persons under subsection (c) or is not verified
           under subsection (d), the Secretary shall notify
 
-      HR 3590 EAS/PP
-                            279
           the Exchange and the Exchange shall take the
           following actions:
                    (i) R EASONABLE   EFFORT  .—The Ex-
@@ -8162,8 +7608,6 @@ verification to the Exchange.
                    the date on which the notice required
 
 
-      HR 3590 EAS/PP
-                            280
                     under subclause (I) is sent to the ap-
                     plicant.
                The Secretary may extend the 90-day pe-
@@ -8190,8 +7634,6 @@ verification to the Exchange.
                the basis of the records maintained by per-
                sons under subsection (c).
 
-      HR 3590 EAS/PP
-                            281
                    (iii) E MPLOYER   AFFORDABILITY  .—If
                the Secretary notifies an Exchange that an
                enrollee is eligible for a premium tax credit
@@ -8218,8 +7660,6 @@ verification to the Exchange.
                (C) A  PPEALS  PROCESS  .—The Exchange
           shall also notify each person receiving notice
 
-      HR 3590 EAS/PP
-                           282
           under this paragraph of the appeals processes es-
           tablished under subsection (f).
      (f) APPEALS AND R EDETERMINATIONS  .—
@@ -8246,8 +7686,6 @@ verification to the Exchange.
           provide that coverage but it is not affordable cov-
 
 
-      HR 3590 EAS/PP
-                            283
           erage with respect to an employee. Such process
           shall provide an employer the opportunity to—
                    (i) present information to the Ex-
@@ -8274,8 +7712,6 @@ verification to the Exchange.
                    (i) the employer may be notified as to
                the name of an employee and whether or
 
-      HR 3590 EAS/PP
-                            284
                not the employee’s income is above or below
                the threshold by which the affordability of
                an employer’s health insurance coverage is
@@ -8302,8 +7738,6 @@ verification to the Exchange.
                (A) use the information only for the pur-
           poses of, and to the extent necessary in, ensuring
 
-      HR 3590 EAS/PP
-                            285
           the efficient operation of the Exchange, including
           verifying the eligibility of an individual to enroll
           through an Exchange or to claim a premium tax
@@ -8330,8 +7764,6 @@ verification to the Exchange.
                ‘‘negligence’’ and ‘‘disregard’’ shall have the
 
 
-      HR 3590 EAS/PP
-                            286
                same meanings as when used in section
                6662 of the Internal Revenue Code of 1986.
                    (ii) REASONABLE CAUSE EXCEPTION   .—
@@ -8358,8 +7790,6 @@ verification to the Exchange.
           property of a person by reason of any failure to
           pay the penalty imposed by this subsection; or
 
-      HR 3590 EAS/PP
-                           287
               (B) levy on any such property with respect
           to such failure.
      (i) STUDY OF   ADMINISTRATION OF   E MPLOYER   RE -
@@ -8386,8 +7816,6 @@ verification to the Exchange.
      graph (1), including any recommendations for legisla-
      tive changes, to the Committees on Finance and
 
-      HR 3590 EAS/PP
-                           288
      Health, Education, Labor and Pensions of the Senate
      and the Committees of Education and Labor and
      Ways and Means of the House of Representatives.
@@ -8414,8 +7842,6 @@ under which—
           employee of the employer were determined to be
           eligible for the premium tax credit under section
 
-      HR 3590 EAS/PP
-                           289
           36B of the Internal Revenue Code of 1986 and
           the cost-sharing reductions under section 1402
           because—
@@ -8442,8 +7868,6 @@ under which—
           enrollment period as may be specified by the
           Secretary); and
 
-      HR 3590 EAS/PP
-                            290
                (B) on the basis of the individual’s house-
           hold income for the most recent taxable year for
           which the Secretary, after consultation with the
@@ -8470,8 +7894,6 @@ under which—
           in cases where the taxpayer was not required to
 
 
-      HR 3590 EAS/PP
-                           291
           file a return of tax imposed by this chapter for
           the second preceding taxable year.
      (c) PAYMENT OF  P REMIUM  TAX C REDITS AND  COST-
@@ -8498,8 +7920,6 @@ under which—
                    (ii) notify the Exchange and the Sec-
               retary of such reduction;
 
-      HR 3590 EAS/PP
-                           292
                    (iii) include with each billing state-
               ment the amount by which the premium for
               the plan has been reduced by reason of the
@@ -8526,8 +7946,6 @@ amendments made by this subtitle allows Federal payments,
 credits, or cost-sharing reductions for individuals who are
 not lawfully present in the United States.
 
-      HR 3590 EAS/PP
-                           293
      (e) STATE  FLEXIBILITY.—Nothing in this subtitle or
 the amendments made by this subtitle shall be construed
 to prohibit a State from making payments to or on behalf
@@ -8554,8 +7972,6 @@ under such plan or program.
      (b) R EQUIREMENTS   RELATING TO   FORMS AND   N O-
  TICE.—
 
-      HR 3590 EAS/PP
-                            294
           (1) REQUIREMENTS RELATING TO FORMS    .—
                (A) IN GENERAL  .—The Secretary shall de-
           velop and provide to each State a single, stream-
@@ -8582,8 +7998,6 @@ under such plan or program.
           mulgated by the Secretary under this section.
 
 
-      HR 3590 EAS/PP
-                           295
               (C) SUPPLEMENTAL ELIGIBILITY FORMS   .—
           The Secretary may allow a State to use a sup-
           plemental or alternative form in the case of indi-
@@ -8610,8 +8024,6 @@ under such plan or program.
      contained in the application forms described in sub-
      section (b)) that allows a determination of eligibility
 
-      HR 3590 EAS/PP
-                            296
       for all such programs based on a single application.
       Such interface shall be compatible with the method es-
       tablished for data verification under section
@@ -8638,8 +8050,6 @@ under such plan or program.
                    bility; and
 
 
-      HR 3590 EAS/PP
-                            297
                (C) consistent with standards promulgated
           by the Secretary, including the privacy and data
           security safeguards described in section 1942 of
@@ -8666,8 +8076,6 @@ under such plan or program.
           pected gains in accuracy, efficiency, and pro-
           gram participation.
 
-      HR 3590 EAS/PP
-                           298
           (4) S ECRETARIAL STANDARDS   .—The Secretary
      shall, after consultation with persons in possession of
      the data to be matched and representatives of applica-
@@ -8694,8 +8102,6 @@ under such plan or program.
           plies with the Secretary’s requirements ensuring
 
 
-      HR 3590 EAS/PP
-                          299
          reduced administrative costs, eligibility errors,
          and disruptions in coverage; or
               (B) change any requirement under title XIX
@@ -8722,8 +8128,6 @@ subsidy program’’ means—
  AND SOCIAL SECURITY N UMBERS .—
 
 
-      HR 3590 EAS/PP
-                           300
           (1) T AXPAYER   RETURN   INFORMATION  .—Sub-
      section (l) of section 6103 of the Internal Revenue
      Code of 1986 is amended by adding at the end the fol-
@@ -8750,8 +8154,6 @@ subsidy program’’ means—
           ited to—
 
 
-      HR 3590 EAS/PP
-                            301
                    ‘‘(i) taxpayer identity information
                with respect to such taxpayer,
                    ‘‘(ii) the filing status of such taxpayer,
@@ -8778,8 +8180,6 @@ subsidy program’’ means—
           STATE AGENCIES  .—The Secretary of Health and
           Human Services may disclose to an Exchange
 
-      HR 3590 EAS/PP
-                            302
           established under the Patient Protection and Af-
           fordable Care Act or its contractors, or to a State
           agency administering a State program described
@@ -8806,8 +8206,6 @@ subsidy program’’ means—
       205(c)(2)(C) of the Social Security Act is amended by
       adding at the end the following new clause:
 
-      HR 3590 EAS/PP
-                           303
                    ‘‘(x) The Secretary of Health and
               Human Services, and the Exchanges estab-
               lished under section 1311 of the Patient
@@ -8834,8 +8232,6 @@ Code is amended—
      in the matter after subparagraph (F).
 
 
-      HR 3590 EAS/PP
-                           304
      (d) U NAUTHORIZED   D ISCLOSURE OR   NSPECTION .—
 Paragraph (2) of section 7213(a) of such Code is amended
 by striking ‘‘or (20)’’ and inserting ‘‘(20), or (21)’’.
@@ -8862,8 +8258,6 @@ part with Federal funds—
 
 
 
-      HR 3590 EAS/PP
-                           305
       PART II—SMALL BUSINESS TAX CREDIT
  SEC. 1421. CREDIT FOR EMPLOYEE HEALTH INSURANCE EX-
              PENSES OF SMALL BUSINESSES.
@@ -8890,8 +8284,6 @@ small employer) of the lesser of—
      fied health plans offered by the employer to its em-
      ployees through an Exchange, or
 
-      HR 3590 EAS/PP
-                          306
          ‘‘(2) the aggregate amount of nonelective con-
      tributions which the employer would have made dur-
      ing the taxable year under the arrangement if each
@@ -8918,8 +8310,6 @@ the sum of the following amounts:
      ‘‘(d) LIGIBLE S MALL E MPLOYER .—For purposes of
 this section—
 
-      HR 3590 EAS/PP
-                            307
           ‘‘(1) N GENERAL .—The term ‘eligible small em-
      ployer’ means, with respect to any taxable year, an
      employer—
@@ -8946,8 +8336,6 @@ this section—
                ‘‘(B) XCESS HOURS NOT COUNTED    .—If an
           employee works in excess of 2,080 hours of serv-
 
-      HR 3590 EAS/PP
-                            308
           ice during any taxable year, such excess shall not
           be taken into account under subparagraph (A).
                ‘‘(C) HOURS OF SERVICE  .—The Secretary,
@@ -8974,8 +8362,6 @@ this section—
                ‘‘(B) DOLLAR AMOUNT   .—For purposes of
           paragraph (1)(B)—
 
-      HR 3590 EAS/PP
-                            309
                     ‘‘(i) 20112012, AND 2013.—The dollar
                amount in effect under this paragraph for
                taxable years beginning in 2011, 2012, or
@@ -9002,8 +8388,6 @@ this section—
                ‘‘(A) N GENERAL  .—The number of hours of
           service worked by, and wages paid to, a seasonal
 
-      HR 3590 EAS/PP
-                           310
           worker of an employer shall not be taken into ac-
           count in determining the full-time equivalent
           employees and average annual wages of the em-
@@ -9030,8 +8414,6 @@ of this section—
               in section 416(i)(1)(B)(i)) of an eligible
               small business, or
 
-      HR 3590 EAS/PP
-                            311
                    ‘‘(iv) any individual who bears any of
                the relationships described in subpara-
                graphs (A) through (G) of section 152(d)(2)
@@ -9058,8 +8440,6 @@ of this section—
           ‘‘(5) GGREGATION AND OTHER RULES MADE AP      -
       PLICABLE .—
 
-      HR 3590 EAS/PP
-                           312
               ‘‘(A) AGGREGATION RULES  .—All employers
           treated as a single employer under subsection
           (b), (c), (m), or (o) of section 414 shall be treated
@@ -9086,8 +8466,6 @@ of this section—
      in section 501(c) which is exempt from taxation
      under section 501(a).
 
-      HR 3590 EAS/PP
-                            313
           ‘‘(3) AYROLL TAXES  .—For purposes of this sub-
      section—
                ‘‘(A)N GENERAL  .—The term ‘payroll taxes’
@@ -9114,8 +8492,6 @@ of the credit under subsection (a):
      able year is in a credit period and for purposes of ap-
      plying this section to taxable years beginning after
 
-      HR 3590 EAS/PP
-                            314
      2013, no credit period shall be treated as beginning
      with a taxable year beginning before 2014.
           ‘‘(2) AMOUNT OF CREDIT   .—The amount of the
@@ -9142,8 +8518,6 @@ of the credit under subsection (a):
      rangement shall not fail to meet the requirements of
 
 
-      HR 3590 EAS/PP
-                           315
      subsection (d)(4) solely because it provides for the of-
      fering of insurance outside of an Exchange.
      ‘‘(h)NSURANCE  D EFINITIONS.—Any term used in this
@@ -9170,8 +8544,6 @@ plus’’, and by inserting after paragraph (35) the following:
  IMUM  TAX.—Section 38(c)(4)(B) of the Internal Revenue
 Code of 1986 (defining specified credits) is amended by re-
 
-      HR 3590 EAS/PP
-                          316
 designating clauses (vi), (vii), and (viii) as clauses (vii),
 (viii), and (ix), respectively, and by inserting after clause
 (v) the following new clause:
@@ -9198,8 +8570,6 @@ to the premiums.’’.
      ‘‘and’’ at the end of paragraph (12), by striking the
      period at the end of paragraph (13) and inserting ‘‘,
 
-      HR 3590 EAS/PP
-                           317
      and’’, and by adding at the end the following new
      paragraph:
           ‘‘(14) the small employer health insurance credit
@@ -9226,8 +8596,6 @@ the end the following:
      (a) FINDINGS.—Congress makes the following findings:
           (1) N GENERAL  .—The individual responsibility
      requirement provided for in this section (in this sub-
-      HR 3590 EAS/PP
-                            318
       section referred to as the ‘‘requirement’’) is commer-
       cial and economic in nature, and substantially affects
       interstate commerce, as a result of the effects described
@@ -9254,8 +8622,6 @@ the end the following:
           sold in interstate commerce and claims pay-
           ments flow through interstate commerce.
 
-      HR 3590 EAS/PP
-                            319
                (C) The requirement, together with the other
           provisions of this Act, will add millions of new
           consumers to the health insurance market, in-
@@ -9282,8 +8648,6 @@ the end the following:
           Security Act of 1974 (29 U.S.C. 1001 et seq.),
           the Public Health Service Act (42 U.S.C. 201 et
 
-      HR 3590 EAS/PP
-                            320
           seq.), and this Act, the Federal Government has
           a significant role in regulating health insurance
           which is in interstate commerce.
@@ -9310,8 +8674,6 @@ the end the following:
           the size of purchasing pools, which will increase
           economies of scale, the requirement, together with
 
-      HR 3590 EAS/PP
-                          321
          the other provisions of this Act, will significantly
          reduce administrative costs and lower health in-
          surance premiums. The requirement is essential
@@ -9338,8 +8700,6 @@ any dependent of the individual who is an applicable indi-
 vidual, is covered under minimum essential coverage for
 such month.
 
-      HR 3590 EAS/PP
-                           322
      ‘‘(b) HARED  R ESPONSIBILITY PAYMENT .—
           ‘‘(1) N GENERAL .—If an applicable individual
      fails to meet the requirement of subsection (a) for 1
@@ -9366,8 +8726,6 @@ such month.
           for such penalty.
      ‘‘(c) MOUNT OF  PENALTY .—
 
-      HR 3590 EAS/PP
-                            323
           ‘‘(1) IN   GENERAL .—The penalty determined
       under this subsection for any month with respect to
       any individual is an amount equal to  112 of the ap-
@@ -9394,8 +8752,6 @@ such month.
           spect to such individual for the month shall be
 
 
-      HR 3590 EAS/PP
-                            324
           equal to one-half of the applicable dollar amount
           for the calendar year in which the month occurs.
                ‘‘(D) NDEXING OF AMOUNT   .—In the case of
@@ -9422,8 +8778,6 @@ such month.
                ‘‘(B) H  OUSEHOLD    INCOME  .—The term
           ‘household income’ means, with respect to any
 
-      HR 3590 EAS/PP
-                            325
           taxpayer for any taxable year, an amount equal
           to the sum of—
                    ‘‘(i) the modified gross income of the
@@ -9450,8 +8804,6 @@ such month.
                ‘‘(D) OVERTY LINE  .—
 
 
-      HR 3590 EAS/PP
-                            326
                     ‘‘(i)N GENERAL  .—The term ‘poverty
                line’ has the meaning given that term in
                section 2110(c)(5) of the Social Security Act
@@ -9478,8 +8830,6 @@ section—
           member of a recognized religious sect or division
           thereof described in section 1402(g)(1) and an
 
-      HR 3590 EAS/PP
-                            327
           adherent of established tenets or teachings of such
           sect or division as described in such section.
                ‘‘(B) HEALTH CARE SHARING MINISTRY   .—
@@ -9506,8 +8856,6 @@ section—
                         ‘‘(IV) which (or a predecessor of
                    which) has been in existence at all
 
-      HR 3590 EAS/PP
-                            328
                    times since December 31, 1999, and
                    medical expenses of its members have
                    been shared continuously and without
@@ -9534,8 +8882,6 @@ under subsection (a) with respect to—
           ‘‘(1) NDIVIDUALS WHO CANNOT AFFORD COV        -
       ERAGE .—
 
-      HR 3590 EAS/PP
-                            329
                ‘‘(A) N GENERAL   .—Any applicable indi-
           vidual for any month if the applicable individ-
           ual’s required contribution (determined on an
@@ -9562,8 +8908,6 @@ under subsection (a) with respect to—
                for self-only coverage, or
 
 
-      HR 3590 EAS/PP
-                            330
                     ‘‘(ii) in the case of an individual eligi-
                ble only to purchase minimum essential
                coverage described in subsection (f)(1)(C),
@@ -9590,8 +8934,6 @@ under subsection (a) with respect to—
                ‘‘(D) NDEXING  .—In the case of plan years
           beginning in any calendar year after 2014, sub-
 
-      HR 3590 EAS/PP
-                            331
           paragraph (A) shall be applied by substituting
           for ‘8 percent’ the percentage the Secretary of
           Health and Human Services determines reflects
@@ -9618,8 +8960,6 @@ under subsection (a) with respect to—
           imum essential coverage for a continuous period
           of less than 3 months.
 
-      HR 3590 EAS/PP
-                            332
                ‘‘(B) SPECIAL RULES .—For purposes of ap-
           plying this paragraph—
                     ‘‘(i) the length of a continuous period
@@ -9646,8 +8986,6 @@ under subsection (a) with respect to—
       Health and Human Services under section
       1311(d)(4)(H) to have suffered a hardship with re-
 
-      HR 3590 EAS/PP
-                            333
      spect to the capability to obtain coverage under a
      qualified health plan.
      ‘‘(f) MINIMUM  ESSENTIAL  COVERAGE  .—For purposes
@@ -9674,8 +9012,6 @@ of this section—
 
 
 
-      HR 3590 EAS/PP
-                           334
               ‘‘(C) PLANS IN THE INDIVIDUAL MARKET  .—
           Coverage under a health plan offered in the indi-
           vidual market within a State.
@@ -9702,8 +9038,6 @@ of this section—
           ‘‘(3) XCEPTED BENEFITS NOT TREATED AS MIN    -
      IMUM ESSENTIAL COVERAGE    .—The term ‘minimum
 
-      HR 3590 EAS/PP
-                            335
       essential coverage’ shall not include health insurance
       coverage which consists of coverage of excepted bene-
       fits—
@@ -9730,8 +9064,6 @@ of this section—
       used in this section which is also used in title I of
 
 
-      HR 3590 EAS/PP
-                            336
      the Patient Protection and Affordable Care Act shall
      have the same meaning as when used in such title.
      ‘‘(g) DMINISTRATION AND   PROCEDURE  .—
@@ -9758,8 +9090,6 @@ of this section—
                    ‘‘(ii) levy on any such property with
                respect to such failure.’’.
 
-      HR 3590 EAS/PP
-                           337
      (c) CLERICAL A MENDMENT  .—The table of chapters for
 
 subtitle D of the Internal Revenue Code of 1986 is amended
@@ -9789,8 +9119,6 @@ make a return described in subsection (b).
 
               ‘‘(A) is in such form as the Secretary may
           prescribe, and
-      HR 3590 EAS/PP
-                            338
                ‘‘(B) contains—
                    ‘‘(i) the name, address and TIN of the
                primary insured and the name and TIN of
@@ -9817,8 +9145,6 @@ make a return described in subsection (b).
                    under section 36B with respect to such
                    coverage, and
 
-      HR 3590 EAS/PP
-                           339
                   ‘‘(iv) such other information as the
               Secretary may require.
           ‘‘(2)NFORMATION RELATING TO EMPLOYER   PRO -
@@ -9845,8 +9171,6 @@ make a return described in subsection (b).
           ‘‘(1) N GENERAL .—Every person required to
      make a return under subsection (a) shall furnish to
 
-      HR 3590 EAS/PP
-                           340
      each individual whose name is required to be set forth
      in such return a written statement showing—
               ‘‘(A) the name and address of the person re-
@@ -9873,8 +9197,6 @@ the meaning given such term by section 5000A(f).’’.
      (b) ASSESSABLE PENALTIES .—
 
 
-      HR 3590 EAS/PP
-                            341
           (1) Subparagraph (B) of section 6724(d)(1) of
       the Internal Revenue Code of 1986 (relating to defini-
       tions) is amended by striking ‘‘or’’ at the end of
@@ -9901,8 +9223,6 @@ ices, shall send a notification to each individual who files
 an individual income tax return and who is not enrolled
 in minimum essential coverage (as defined in section 5000A
 
-      HR 3590 EAS/PP
-                            342
 of the Internal Revenue Code of 1986). Such notification
 shall contain information on the services available through
 the Exchange operating in the State in which such indi-
@@ -9930,8 +9250,6 @@ matically enroll new full-time employees in one of the plans
 offered (subject to any waiting period authorized by law)
 and to continue the enrollment of current employees in a
 health benefits plan offered through the employer. Any auto-
-      HR 3590 EAS/PP
-                            343
 matic enrollment program shall include adequate notice
 and the opportunity for an employee to opt out of any cov-
 erage the individual or employee were automatically en-
@@ -9958,8 +9276,6 @@ March 1, 2013), written notice—
       provided by such Exchange, and the manner in which
 
 
-      HR 3590 EAS/PP
-                            344
      the employee may contact the Exchange to request as-
      sistance;
           ‘‘(2) if the employer plan’s share of the total al-
@@ -9986,8 +9302,6 @@ Code of 1986 is amended by adding at the end the following:
 
 
 
-      HR 3590 EAS/PP
-                          345
  ‘‘SEC. 4980H. SHARED RESPONSIBILITY FOR EMPLOYERS
             REGARDING HEALTH COVERAGE.
      ‘‘(a) ARGE  E MPLOYERS  NOT  OFFERING  H EALTH
@@ -10014,8 +9328,6 @@ ployer as full-time employees during such month.
          ‘‘(1)N GENERAL .—In the case of any applicable
      large employer which requires an extended waiting
      period to enroll in any minimum essential coverage
-     HR 3590 EAS/PP
-                          346
      under an employer-sponsored plan (as defined in sec-
      tion 5000A(f)(2)), there is hereby imposed on the em-
      ployer an assessable payment, in the amount specified
@@ -10042,8 +9354,6 @@ ployer as full-time employees during such month.
          its full-time employees (and their dependents) the
          opportunity to enroll in minimum essential cov-
 
-     HR 3590 EAS/PP
-                            347
           erage under an eligible employer-sponsored plan
           (as defined in section 5000A(f)(2)) for any
           month, and
@@ -10070,8 +9380,6 @@ ployer as full-time employees during such month.
      ‘‘(d) DEFINITIONS AND   SPECIAL  R ULES.—For pur-
 poses of this section—
 
-      HR 3590 EAS/PP
-                            348
           ‘‘(1) APPLICABLE PAYMENT AMOUNT     .—The term
       ‘applicable payment amount’ means, with respect to
                     1
@@ -10099,8 +9407,6 @@ poses of this section—
                worker who performs labor or services on a
                seasonal basis as defined by the Secretary of
 
-      HR 3590 EAS/PP
-                            349
                Labor, including workers covered by section
                500.20(s)(1) of title 29, Code of Federal
                Regulations and retail workers employed ex-
@@ -10127,8 +9433,6 @@ poses of this section—
                in this subsection to an employer shall in-
 
 
-      HR 3590 EAS/PP
-                            350
                clude a reference to any predecessor of such
                employer.
           ‘‘(3) APPLICABLE PREMIUM TAX CREDIT AND
@@ -10155,8 +9459,6 @@ poses of this section—
           are not compensated on an hourly basis.
           ‘‘(5) NFLATION ADJUSTMENT  .—
 
-      HR 3590 EAS/PP
-                            351
                ‘‘(A) N GENERAL .—In the case of any cal-
           endar year after 2014, each of the dollar
           amounts in subsection (b)(2) and (d)(1) shall be
@@ -10183,8 +9485,6 @@ poses of this section—
      vided by this section shall be paid upon notice and
      demand by the Secretary, and shall be assessed and
 
-      HR 3590 EAS/PP
-                           352
      collected in the same manner as an assessable penalty
      under subchapter B of chapter 68.
           ‘‘(2) IME FOR PAYMENT   .—The Secretary may
@@ -10211,8 +9511,6 @@ the following new item:
      conduct a study to determine whether employees’
      wages are reduced by reason of the application of the
      assessable payments under section 4980H of the Inter-
-      HR 3590 EAS/PP
-                           353
      nal Revenue Code of 1986 (as added by the amend-
      ments made by this section). The Secretary shall
      make such determination on the basis of the National
@@ -10239,8 +9537,6 @@ respect to its full-time employees during a calendar year
 shall, at such time as the Secretary may prescribe, make
 a return described in subsection (b).
 
-      HR 3590 EAS/PP
-                            354
      ‘‘(b) ORM AND  M ANNER OF  RETURN  .—A return is de-
 scribed in this subsection if such return—
           ‘‘(1) is in such form as the Secretary may pre-
@@ -10267,8 +9563,6 @@ scribed in this subsection if such return—
 
 
 
-      HR 3590 EAS/PP
-                          355
                   ‘‘(iii) the monthly premium for the
               lowest cost option in each of the enrollment
               categories under the plan, and
@@ -10295,8 +9589,6 @@ scribed in this subsection if such return—
          quired to make such return and the phone num-
 
 
-      HR 3590 EAS/PP
-                          356
          ber of the information contact for such person,
          and
               ‘‘(B) the information required to be shown
@@ -10323,8 +9615,6 @@ that—
      ‘‘(e) COVERAGE    PROVIDED   BY   GOVERNMENTAL
  UNITS.—In the case of any applicable large employer which
 
-      HR 3590 EAS/PP
-                            357
 is a governmental unit or any agency or instrumentality
 thereof, the person appropriately designated for purposes of
 this section shall make the returns and statements required
@@ -10351,8 +9641,6 @@ term used in this section which is also used in section
       and by inserting after subparagraph (GG) the fol-
       lowing new subparagraph:
 
-      HR 3590 EAS/PP
-                           358
               ‘‘(HH) section 6056(c) (relating to state-
           ments relating to large employers required to re-
           port on health insurance coverage).’’.
@@ -10379,8 +9667,6 @@ the end the following new paragraph:
           through an Exchange established under section
           1311 of such Act.
 
-      HR 3590 EAS/PP
-                           359
               ‘‘(B) EXCEPTION FOR EXCHANGE   -ELIGIBLE
           EMPLOYERS .—Subparagraph (A) shall not apply
           with respect to any employee if such employee’s
@@ -10407,8 +9693,6 @@ ber 31, 2013.
      Unless specifically provided for otherwise, the defini-
 tions contained in section 2791 of the Public Health Service
 
-      HR 3590 EAS/PP
-                             360
 Act (42 U.S.C. 300gg–91) shall apply with respect to this
 title.
  SEC. 1552. TRANSPARENCY IN GOVERNMENT.
@@ -10435,8 +9719,6 @@ suicide, euthanasia, or mercy killing.
 entity’’ includes an individual physician or other health
 care professional, a hospital, a provider-sponsored organi-
 
-      HR 3590 EAS/PP
-                            361
 zation, a health maintenance organization, a health insur-
 ance plan, or any other kind of health care facility, organi-
 zation, or plan.
@@ -10463,8 +9745,6 @@ this section.
 Secretary of Health and Human Services shall not promul-
 gate any regulation that—
 
-      HR 3590 EAS/PP
-                            362
           (1) creates any unreasonable barriers to the abil-
       ity of individuals to obtain appropriate medical care;
           (2) impedes timely access to health care services;
@@ -10491,8 +9771,6 @@ health insurance program expanded by this Act (or any
 such amendments), and there shall be no penalty or fine
 
 
-      HR 3590 EAS/PP
-                            363
 imposed upon any such issuer for choosing not to partici-
 pate in such programs.
  SEC. 1556. EQUITY FOR CERTAIN ELIGIBLE SURVIVORS.
@@ -10519,8 +9797,6 @@ title IX of the Education Amendments of 1972 (20 U.S.C.
 U.S.C. 6101 et seq.), or section 504 of the Rehabilitation
 Act of 1973 (29 U.S.C. 794), be excluded from participation
 
-      HR 3590 EAS/PP
-                             364
 in, be denied the benefits of, or be subjected to discrimina-
 tion under, any health program or activity, any part of
 which is receiving Federal financial assistance, including
@@ -10547,8 +9823,6 @@ crimination on any basis described in subsection (a).
 regulations to implement this section.
 
 
-      HR 3590 EAS/PP
-                             365
  SEC. 1558. PROTECTIONS FOR EMPLOYEES.
       The Fair Labor Standards Act of 1938 is amended by
 inserting after section 18B (as added by section 1512) the
@@ -10575,8 +9849,6 @@ vidual acting at the request of the employee) has—
       or participate, in such a proceeding; or
            ‘‘(5) objected to, or refused to participate in, any
       activity, policy, practice, or assigned task that the
-      HR 3590 EAS/PP
-                            366
       employee (or other such person) reasonably believed to
       be in violation of any provision of this title (or
       amendment), or any order, rule, regulation, standard,
@@ -10603,8 +9875,6 @@ respect to the administration and implementation of this
 title as it relates to such Department.
 
 
-      HR 3590 EAS/PP
-                          367
  SEC. 1560. RULES OF CONSTRUCTION.
      (a) NO E FFECT ON  ANTITRUST  LAWS .—Nothing in
 this title (or an amendment made by this title) shall be
@@ -10631,8 +9901,6 @@ cation Act of 1965) from offering a student health insurance
 plan, to the extent that such requirement is otherwise per-
 mitted under applicable Federal, State or local law.
 
-      HR 3590 EAS/PP
-                           368
      (d) NO EFFECT ON  EXISTING REQUIREMENTS  .—Noth-
 ing in this title (or an amendment made by this title, unless
 specified by direct statutory reference) shall be construed
@@ -10659,8 +9927,6 @@ grams identified in section 1413.
      enrollment in such programs through methods deter-
      mined appropriate by the Secretary, which shall in-
 
-      HR 3590 EAS/PP
-                            369
       clude providing individuals and third parties author-
       ized by such individuals and their designees notifica-
       tion of eligibility and verification of eligibility re-
@@ -10687,8 +9953,6 @@ scribed in subsection (a) shall allow for the following:
           ‘‘(5) Ability to expand the enrollment system to
       integrate new programs, rules, and functionalities, to
 
-      HR 3590 EAS/PP
-                           370
      operate at increased volume, and to apply stream-
      lined verification and eligibility processes to other
      Federal and State programs, as appropriate.
@@ -10715,8 +9979,6 @@ the HIT Standards Committee, the Secretary—
      existing, technology systems to implement the HIT en-
      rollment standards and protocols developed under
 
-      HR 3590 EAS/PP
-                            371
       subsection (a) (referred to in this subsection as ‘ap-
       propriate HIT technology’).
           ‘‘(2) ELIGIBLE ENTITIES  .—To be eligible for a
@@ -10743,8 +10005,6 @@ the HIT Standards Committee, the Secretary—
                and
 
 
-      HR 3590 EAS/PP
-                            372
                    ‘‘(iii) such other information as the
                Secretary may require.
           ‘‘(3) HARING .—
@@ -10771,8 +10031,6 @@ nated by section 1001(4), is amended—
           through 3’’ and inserting ‘‘1 and 2’’; and
                (B) in paragraph (2)—
 
-      HR 3590 EAS/PP
-                            373
                     (i) in subparagraph (A), by striking
                ‘‘subparagraph (D)’’ and inserting ‘‘sub-
                paragraph (D) or (E)’’;
@@ -10799,8 +10057,6 @@ nated by section 1001(4), is amended—
                not apply to any group’’ and inserting ‘‘1
 
 
-      HR 3590 EAS/PP
-                           374
               and 2 shall not apply to any individual
               coverage or any group’’; and
                    (ii) in subparagraph (C), by inserting
@@ -10827,8 +10083,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
 300gg et seq.) is amended—
 
 
-      HR 3590 EAS/PP
-                            375
           (1) in section 2704 (42 U.S.C. 300gg), as so re-
       designated by section 1201(2)—
                (A) in subsection (c)—
@@ -10855,8 +10109,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
       of part A (relating to other requirements);
 
 
-      HR 3590 EAS/PP
-                            376
           (3) in section 2725 (42 U.S.C. 300gg–4), as so
       redesignated by section 1001(2)—
                (A) in subsection (a), by striking ‘‘health
@@ -10883,8 +10135,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
 
 
 
-      HR 3590 EAS/PP
-                            377
                     (ii) in paragraph (3), by striking
                ‘‘issuer’’ and inserting ‘‘health insurance
                issuer’’; and
@@ -10911,8 +10161,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
                     (i) in paragraph (1), by striking ‘‘(and
                group health insurance coverage offered in
 
-      HR 3590 EAS/PP
-                            378
                connection with a group health plan)’’ and
                inserting ‘‘and a health insurance issuer of-
                fering group or individual health insurance
@@ -10939,8 +10187,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
                     (i) in paragraph (1), by striking ‘‘or a
                health insurance issuer that provides health
 
-      HR 3590 EAS/PP
-                            379
                insurance coverage in connection with a
                group health plan’’ and inserting ‘‘or a
                health insurance issuer that offers group or
@@ -10967,8 +10213,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
           (7) by striking the heading for subpart 3;
 
 
-      HR 3590 EAS/PP
-                            380
           (8) in section 2731 (42 U.S.C. 300gg–11), as so
       redesignated by section 1001(3)—
                (A) by striking the section heading and all
@@ -10995,8 +10239,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
                         lated factor relating to such’’ and
                         inserting ‘‘and individuals with-
 
-      HR 3590 EAS/PP
-                            381
                          out regard to the claims experi-
                          ence of those individuals, employ-
                          ers and their employees (and their
@@ -11023,8 +10265,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
                (D) by striking subsection (e);
                (E) by striking subsection (f); and
 
-      HR 3590 EAS/PP
-                            382
                (F) by transferring such section (as amend-
           ed by this paragraph) to appear at the end of
           section 2702 (as added by section 1001(4));
@@ -11051,8 +10291,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
       plan, the plan sponsor has failed to comply with a
       material plan provision relating to employer con-
 
-      HR 3590 EAS/PP
-                            383
       tribution or group participation rules, pursuant to
       applicable State law.’’;
                (C) in subsection (c)—
@@ -11079,8 +10317,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
                     (ii) in paragraph (2)(A)—
 
 
-      HR 3590 EAS/PP
-                            384
                         (I) in the matter preceding clause
                     (i), by striking ‘‘small group market or
                     the large group market, or both mar-
@@ -11107,8 +10343,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
                (B) in subsection (b)—
                     (i) in paragraph (1)—
 
-      HR 3590 EAS/PP
-                            385
                         (I) in the matter preceding sub-
                     paragraph (A), by striking ‘‘small em-
                     ployer’’ and inserting ‘‘employer, or
@@ -11135,8 +10369,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
                (C) by redesignating such section (as
           amended by this paragraph) as section 2709 and
 
-      HR 3590 EAS/PP
-                            386
           transferring such section to appear after section
           2708 (as added by section 1001(5));
           (11) by redesignating subpart 4 as subpart 2;
@@ -11163,8 +10395,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
 
 
 
-      HR 3590 EAS/PP
-                            387
                (B) in subsection (b)(1)(B), by inserting
           ‘‘individual health insurance coverage or’’ after
           ‘‘respect to’’; and
@@ -11191,8 +10421,6 @@ Title XXVII of the Public Health Service Act (42 U.S.C.
       viding health insurance coverage in the individual
 
 
-      HR 3590 EAS/PP
-                            388
       market in a State, the provisions of such part A shall
       apply.’’; and
           (16) in section 2791(e) (42 U.S.C. 300gg–
@@ -11219,8 +10447,6 @@ shall be construed to—
       made by this subtitle.
 
 
-      HR 3590 EAS/PP
-                           389
      (e) TECHNICAL  AMENDMENT TO THE    E MPLOYEE  R E-
  TIREMENT  INCOME  SECURITY A CT OF 1974.—Subpart B of
 part 7 of subtitle A of title I of the Employee Retirement
@@ -11247,8 +10473,6 @@ provisions of sections 2716 and 2718 of title XXVII of the
 Public Health Service Act (as amended by the Patient Pro-
 tection and Affordable Care Act) shall not apply with re-
 
-      HR 3590 EAS/PP
-                           390
 spect to self-insured group health plans, and the provisions
 of this part shall continue to apply to such plans as if such
 sections of the Public Health Service Act (as so amended)
@@ -11275,8 +10499,6 @@ section (b)—
      part A shall apply.
 
 
-      HR 3590 EAS/PP
-                            391
       ‘‘(b) XCEPTION .—Notwithstanding subsection (a), the
 provisions of sections 2716 and 2718 of title XXVII of the
 Public Health Service Act (as amended by the Patient Pro-
@@ -11303,8 +10525,6 @@ ings:
       Community Living Assistance Services and Supports
 
 
-      HR 3590 EAS/PP
-                         392
      (CLASS) program are necessary to ensure the long-
      term solvency of that program.
      (b) ENSE OF THE SENATE.—It is the sense of the Sen-
@@ -11331,8 +10551,6 @@ ate that—
          (VI);
 
 
-     HR 3590 EAS/PP
-                            393
                (B) by adding ‘‘or’’ at the end of subclause
           (VII); and
                (C) by inserting after subclause (VII) the
@@ -11359,8 +10577,6 @@ ate that—
 vidual described in subclause (VIII) of subsection
 (a)(10)(A)(i) shall consist of benchmark coverage described
 
-      HR 3590 EAS/PP
-                             394
 in section 1937(b)(1) or benchmark equivalent coverage de-
 scribed in section 1937(b)(2). Such medical assistance shall
 be provided subject to the requirements of section 1937,
@@ -11387,8 +10603,6 @@ section.’’.
       clause (VIII) of subsection (a)(10)(A)(i) other than
       medical assistance provided through benchmark cov-
 
-      HR 3590 EAS/PP
-                          395
      erage described in section 1937(b)(1) or benchmark
      equivalent coverage described in section 1937(b)(2).’’.
          (3) FEDERAL FUNDING FOR COST OF COVERING
@@ -11415,8 +10629,6 @@ section.’’.
          be equal to 100 percent.
               ‘‘(B) 201AND 2018.—
 
-      HR 3590 EAS/PP
-                              396
                      ‘‘(i) N GENERAL   .—During the period
                 that begins on January 1, 2017, and ends
                 on December 31, 2018, notwithstanding sub-
@@ -11446,8 +10658,6 @@ section.’’.
              2017 30.3 34.3
              2018 31.3 33.3
 
-      HR 3590 EAS/PP
-                            397
                         ‘‘(II) E XPANSION    STATE   DE -
                     FINED.—For purposes of the table in
                     subclause (I), a State is an expansion
@@ -11474,8 +10684,6 @@ section.’’.
           ginning January 1, 2019, notwithstanding sub-
           section (b) but subject to subparagraph (D), the
 
-      HR 3590 EAS/PP
-                            398
           Federal medical assistance percentage deter-
           mined for a State that is one of the 50 States or
           the District of Columbia for each fiscal year
@@ -11502,8 +10710,6 @@ section.’’.
           paragraph (A), (B), or (C) of section 1937(b)(1)
           or benchmark equivalent coverage described in
 
-      HR 3590 EAS/PP
-                            399
           section 1937(b)(2) that has an aggregate actu-
           arial value that is at least actuarially equivalent
           to benchmark coverage described in subpara-
@@ -11530,8 +10736,6 @@ section.’’.
           paragraph (1) the following:
 
 
-      HR 3590 EAS/PP
-                               400
        ‘‘(2) Beginning with the first day of any fiscal year
 quarter that begins on or after January 1, 2011, and before
 January 1, 2014, a State may elect through a State plan
@@ -11558,8 +10762,6 @@ ceding sentence, the term ‘parent’ includes an individual
 treated as a caretaker relative for purposes of carrying out
 section 1931.’’.
 
-       HR 3590 EAS/PP
-                            401
                (B) P  RESUMPTIVE   ELIGIBILITY .—Section
           1920 of the Social Security Act (42 U.S.C.
           1396r–1) is amended by adding at the end the
@@ -11586,8 +10788,6 @@ the Secretary shall establish.’’.
 
 
 
-      HR 3590 EAS/PP
-                            402
                (B) Section 1902(l)(2)(C) of such Act (42
           U.S.C. 1396a(l)(2)(C)) is amended by striking
           ‘‘100’’ and inserting ‘‘133’’.
@@ -11614,8 +10814,6 @@ the Secretary shall establish.’’.
 
 
 
-      HR 3590 EAS/PP
-                           403
      (b) M  AINTENANCE  OF   M EDICAID  INCOME   E LIGI-
  BILITY.—Section 1902 of the Social Security Act (42 U.S.C.
 1396a) is amended—
@@ -11642,8 +10840,6 @@ the Secretary shall establish.’’.
      tablished by the State under section 1311 of the Pa-
      tient Protection and Affordable Care Act is fully oper-
 
-      HR 3590 EAS/PP
-                            404
       ational, as a condition for receiving any Federal pay-
       ments under section 1903(a) for calendar quarters oc-
       curring during such period, a State shall not have in
@@ -11670,8 +10866,6 @@ the Secretary shall establish.’’.
       2013, the requirement under paragraph (1) shall not
       apply to a State with respect to nonpregnant, non-
 
-      HR 3590 EAS/PP
-                            405
       disabled adults who are eligible for medical assistance
       under the State plan or under a waiver of the plan
       at the option of the State and whose income exceeds
@@ -11698,8 +10892,6 @@ the Secretary shall establish.’’.
           under a waiver of the plan on the date of enact-
           ment of the Patient Protection and Affordable
 
-      HR 3590 EAS/PP
-                            406
           Care Act for purposes of determining compliance
           with the requirements of paragraph (1), (2), or
           (3).
@@ -11726,8 +10918,6 @@ the Secretary shall establish.’’.
           1902(a)(10)(A)(i), shall not be considered to have
           in effect eligibility standards, methodologies, or
 
-      HR 3590 EAS/PP
-                          407
          procedures that are more restrictive than the
          standards, methodologies, or procedures in effect
          under the State plan or under a waiver of the
@@ -11754,8 +10944,6 @@ the Secretary shall establish.’’.
                   ‘‘(iv) Coverage of prescription drugs.
                   ‘‘(v) Mental health services.’’; and
 
-      HR 3590 EAS/PP
-                            408
                (C) in subparagraph (C)—
                    (i) by striking clauses (i) and (ii); and
                    (ii) by redesignating clauses (iii) and
@@ -11782,8 +10970,6 @@ the Secretary shall establish.’’.
           efits comply with the requirements of section
           2705(a) of the Public Health Service Act in the
 
-      HR 3590 EAS/PP
-                           409
           same manner as such requirements apply to a
           group health plan.
               ‘‘(B) DEEMED COMPLIANCE  .—Coverage pro-
@@ -11810,8 +10996,6 @@ the Secretary shall establish.’’.
      and annually thereafter, the State shall submit a re-
      port to the Secretary that contains—
 
-      HR 3590 EAS/PP
-                            410
                ‘‘(A) the total number of enrolled and newly
           enrolled individuals in the State plan or under
           a waiver of the plan for the fiscal year ending
@@ -11838,8 +11022,6 @@ the Secretary shall establish.’’.
       the appropriate committees of Congress on the total
       enrollment and new enrollment in Medicaid for the
 
-      HR 3590 EAS/PP
-                           411
      fiscal year ending on September 30 of the preceding
      calendar year on a national and State-by-State basis,
      and shall include in each such report such rec-
@@ -11866,8 +11048,6 @@ the Secretary shall establish.’’.
                   clause, and whose income (as deter-
                   mined under subsection (e)(14)) exceeds
 
-      HR 3590 EAS/PP
-                              412
                      133 percent of the poverty line (as de-
                      fined in section 2110(c)(5)) applicable
                      to a family of the size involved but
@@ -11894,8 +11074,6 @@ vidual may not be enrolled under the State plan unless the
 individual’s child is enrolled under the State plan or under
 a waiver of the plan or is enrolled in other health insurance
 
-      HR 3590 EAS/PP
-                            413
 coverage. For purposes of the preceding sentence, the term
 ‘parent’ includes an individual treated as a caretaker rel-
 ative for purposes of carrying out section 1931.’’.
@@ -11922,8 +11100,6 @@ ative for purposes of carrying out section 1931.’’.
           ‘‘clause (i)(VIII)’’.
 
 
-      HR 3590 EAS/PP
-                           414
  SEC. 2002. INCOME ELIGIBILITY FOR NONELDERLY DETER-
              MINED USING MODIFIED GROSS INCOME.
      (a) IN GENERAL .—Section 1902(e) of the Social Secu-
@@ -11950,8 +11126,6 @@ end the following:
           plan using modified gross income and household
           income that are not less than the effective income
           eligibility levels that applied under the State
-      HR 3590 EAS/PP
-                            415
           plan or waiver on the date of enactment of the
           Patient Protection and Affordable Care Act. For
           purposes of complying with the maintenance of
@@ -11978,8 +11152,6 @@ end the following:
           under the plan or waiver for which a determina-
           tion of income is required.
 
-      HR 3590 EAS/PP
-                            416
                ‘‘(C) NO ASSETS TEST  .—A State shall not
           apply any assets or resources test for purposes of
           determining eligibility for medical assistance
@@ -12006,8 +11178,6 @@ end the following:
                     or State aid or assistance, individuals
                     who are eligible on the basis of receiv-
 
-      HR 3590 EAS/PP
-                            417
                     ing (or being treated as if receiving)
                     supplemental security income benefits
                     under title XVI, and individuals who
@@ -12034,8 +11204,6 @@ end the following:
                          ‘‘(V) Individuals described in any
                     clause of subsection (a)(10)(E).
 
-      HR 3590 EAS/PP
-                            418
                    ‘‘(ii) EXPRESS  LANE   AGENCY  FIND  -
                INGS.—In the case of a State that elects the
                Express Lane option under paragraph (13),
@@ -12062,8 +11230,6 @@ end the following:
                any institution equivalent to that of nurs-
                ing facility services, home or community-
 
-      HR 3590 EAS/PP
-                            419
                based services furnished under a waiver or
                State plan amendment under section 1915
                or a waiver under section 1115, and serv-
@@ -12090,8 +11256,6 @@ end the following:
           retary for the Secretary’s approval the income
           eligibility thresholds proposed to be established
 
-      HR 3590 EAS/PP
-                            420
           using modified gross income and household in-
           come, the methodologies and procedures to be
           used to determine income eligibility using modi-
@@ -12118,8 +11282,6 @@ end the following:
           ance.
 
 
-      HR 3590 EAS/PP
-                            421
                ‘‘(F) LIMITATION   ON  SECRETARIAL   AU  -
           THORITY .—The Secretary shall not waive com-
           pliance with the requirements of this paragraph
@@ -12146,8 +11308,6 @@ end the following:
           the State plan or under any waiver of such plan
           and for any other purpose applicable under the
 
-      HR 3590 EAS/PP
-                           422
           plan or waiver for which a determination of in-
           come is required shall not be construed as affect-
           ing or limiting the application of—
@@ -12174,8 +11334,6 @@ U.S.C. 1396e–1) is amended—
           (1) in subsection (a)—
 
 
-      HR 3590 EAS/PP
-                            423
                (A) by striking ‘‘may elect to’’ and insert-
           ing ‘‘shall’’;
                (B) by striking ‘‘under age 19’’; and
@@ -12202,8 +11360,6 @@ U.S.C. 1396e–1) is amended—
           (4) in subsection (e), by striking ‘‘under age 19’’
       each place it appears.
 
-      HR 3590 EAS/PP
-                            424
      (b) CONFORMING   A MENDMENT  .—The heading for sec-
 tion 1906A of such Act (42 U.S.C. 1396e–1) is amended
  by striking OPTION FOR CHILDREN  ’’.
@@ -12230,8 +11386,6 @@ tion 2001(a)(1), is amended—
                    age;’’.
 
 
-      HR 3590 EAS/PP
-                           425
      (b) O PTION  T O  PROVIDE   PRESUMPTIVE    ELIGI-
  BILITY.—Section 1920(e) of such Act (42 U.S.C. 1396r–
 1(e)), as added by section 2001(a)(4)(B) and amended by
@@ -12258,8 +11412,6 @@ amended—
      inserting ‘‘paragraphs (3) and (5)’’;
 
 
-      HR 3590 EAS/PP
-                           426
           (2) in paragraph (4), by striking ‘‘and (3)’’ and
      inserting ‘‘(3), and (4)’’; and
           (3) by adding at the end the following para-
@@ -12286,8 +11438,6 @@ U.S.C. 1308(g)(4)) is amended—
           2014, payments made to Puerto Rico, the Virgin
           Islands, Guam, the Northern Mariana Islands,
 
-      HR 3590 EAS/PP
-                            427
           or American Samoa with respect to amounts ex-
           pended for medical assistance for newly eligible
           (as defined in section 1905(y)(2)) nonpregnant
@@ -12314,8 +11464,6 @@ U.S.C. 1308(g)(4)) is amended—
 
 
 
-      HR 3590 EAS/PP
-                            428
  SEC. 2006. SPECIAL ADJUSTMENT TO FMAP DETERMINA-
               TION FOR CERTAIN STATES RECOVERING
               FROM A MAJOR DISASTER.
@@ -12342,8 +11490,6 @@ State shall be equal to the following:
       section and subsection (y), is less than the Federal
       medical assistance percentage determined for the
       State for the preceding fiscal year after the applica-
-      HR 3590 EAS/PP
-                             429
       tion of only subsection (a) of section 5001 of Public
       Law 111–5 (if applicable to the preceding fiscal year)
       and without regard to this subsection, subsection (y),
@@ -12370,8 +11516,6 @@ T. Stafford Disaster Relief and Emergency Assistance Act
 and determined as a result of such disaster that every coun-
 ty or parish in the State warrant individual and public
 
-      HR 3590 EAS/PP
-                            430
 assistance or public assistance from the Federal Govern-
 ment under such Act and for which—
           ‘‘(A) in the case of the first fiscal year (or part
@@ -12398,8 +11542,6 @@ ment under such Act and for which—
       ‘‘(3) The Federal medical assistance percentage deter-
 mined for a disaster-recovery FMAP adjustment State
 
-      HR 3590 EAS/PP
-                            431
 under paragraph (1) shall apply for purposes of this title
 (other than with respect to disproportionate share hospital
 payments described in section 1923 and payments under
@@ -12426,8 +11568,6 @@ amended—
 
 
 
-      HR 3590 EAS/PP
-                           432
  Subtitle B—Enhanced Support for
      the Children’s Health Insurance
      Program
@@ -12454,8 +11594,6 @@ first sentence of section 1905(b).’’.
           ‘‘(3) ONTINUATION OF ELIGIBILITY STANDARDS
      FOR CHILDREN UNTIL OCTOBER 1  ,2019.—
 
-      HR 3590 EAS/PP
-                            433
                ‘‘(A) N GENERAL  .—During the period that
           begins on the date of enactment of the Patient
           Protection and Affordable Care Act and ends on
@@ -12482,8 +11620,6 @@ first sentence of section 1905(b).’’.
                Act; or
 
 
-      HR 3590 EAS/PP
-                            434
                    ‘‘(ii) imposing a limitation described
                in section 2112(b)(7) for a fiscal year in
                order to limit expenditures under the State
@@ -12510,8 +11646,6 @@ first sentence of section 1905(b).’’.
      ‘‘, except as required under section 1902(e)(14)’’.
 
 
-      HR 3590 EAS/PP
-                          435
      (c) NO ENROLLMENT   BONUS  PAYMENTS FOR   CHIL-
  DREN  ENROLLED   AFTER  FISCAL  YEAR  2013.—Section
 2105(a)(3)(F)(iii) of the Social Security Act (42 U.S.C.
@@ -12538,8 +11672,6 @@ dren enrolled on or after October 1, 2013’’ before the period.
              er for which a determination of income is
              required, including with respect to the im-
 
-     HR 3590 EAS/PP
-                           436
               position of premiums and cost-sharing, con-
               sistent with section 1902(e)(14).’’.
           (2) C   ONFORMING      AMENDMENT  .—Section
@@ -12566,8 +11698,6 @@ amended by adding at the end the following:
 State shall treat any child who is determined to be ineligible
 for medical assistance under the State Medicaid plan or
 
-      HR 3590 EAS/PP
-                             437
 under a waiver of the plan as a result of the elimination
 of the application of an income disregard based on expense
 or type of income, as required under section 1902(e)(14)
@@ -12594,8 +11724,6 @@ referred to as ‘‘CHIPRA’’):
       PANSION PROGRAMS   .—For purposes of recalculating
       the fiscal year 2010 allotment, in the case of one of
 
-      HR 3590 EAS/PP
-                            438
       the 50 States or the District of Columbia that has an
       approved State plan amendment effective January 1,
       2006, to provide child health assistance through the
@@ -12622,8 +11750,6 @@ referred to as ‘‘CHIPRA’’):
       clause (IV).
 
 
-      HR 3590 EAS/PP
-                            439
           (5) Section 2105(c)(9)(B) of the Social Security
      Act (42 U.S.C. 1397e(c)(9)(B)), as added by section
      211(c)(1) of CHIPRA, is amended by striking ‘‘sec-
@@ -12650,8 +11776,6 @@ referred to as ‘‘CHIPRA’’):
           to be added by such section to section 1903(a)(3)
 
 
-      HR 3590 EAS/PP
-                          440
          of the Social Security Act as a new subpara-
          graph (H).
      (b) ARRA.—Effective as if included in the enactment
@@ -12678,8 +11802,6 @@ State shall ensure that the requirements of subsection (b)
 is met.
 
 
-      HR 3590 EAS/PP
-                           441
      ‘‘(b) NROLLMENT   S IMPLIFICATION AND  COORDINA -
  TION W ITH STATE  HEALTH  INSURANCE  E XCHANGES AND
  CHIP.—
@@ -12706,8 +11828,6 @@ is met.
               ‘‘(C) ensuring that individuals who apply
           for but are determined to be ineligible for med-
 
-      HR 3590 EAS/PP
-                            442
           ical assistance under the State plan or a waiver
           or ineligible for child health assistance under the
           State child health plan under title XXI, are
@@ -12734,8 +11854,6 @@ is met.
           for administering the State child health plan
           under title XXI (in this section referred to as the
 
-      HR 3590 EAS/PP
-                            443
           ‘State CHIP agency’) and an Exchange estab-
           lished by the State under section 1311 of the Pa-
           tient Protection and Affordable Care Act utilize
@@ -12762,8 +11880,6 @@ is met.
           and provided in accordance with the require-
           ments of section 1902(a)(43); and
 
-      HR 3590 EAS/PP
-                            444
                ‘‘(F) conducting outreach to and enrolling
           vulnerable and underserved populations eligible
           for medical assistance under this title XIX or for
@@ -12790,8 +11906,6 @@ is met.
       tions and requirements as the Secretary of the Treas-
       ury may prescribe to reduce administrative costs and
 
-      HR 3590 EAS/PP
-                            445
      the likelihood of eligibility errors and disruptions in
      coverage.
           ‘‘(3) TREAMLINED ENROLLMENT SYSTEM      .—The
@@ -12818,8 +11932,6 @@ is met.
      premiums, and cost-sharing applicable to the indi-
      vidual under the State plan or waiver with the bene-
 
-      HR 3590 EAS/PP
-                            446
      fits, premiums, and cost-sharing available to the indi-
      vidual under a qualified health plan offered through
      such an Exchange, including, in the case of a child,
@@ -12846,8 +11958,6 @@ Security Act (42 U.S.C. 1396a(a)(47)) is amended—
      vide’’ and inserting ‘‘provide—
                ‘‘(A) at the option of the State,’’;
 
-      HR 3590 EAS/PP
-                            447
           (2) by inserting ‘‘and’’ after the semicolon; and
           (3) by adding at the end the following:
                ‘‘(B) that any hospital that is a partici-
@@ -12874,8 +11984,6 @@ is amended—
       following: ‘‘, or for medical assistance provided to an
       individual during a presumptive eligibility period re-
 
-      HR 3590 EAS/PP
-                           448
      sulting from a determination of presumptive eligi-
      bility made by a hospital that elects under section
      1902(a)(47)(B) to be a qualified entity for such pur-
@@ -12902,8 +12010,6 @@ Act (42 U.S.C. 1396d), is amended—
      (as defined in subsection (l)(3)(B)) and that are oth-
      erwise included in the plan; and’’; and
 
-      HR 3590 EAS/PP
-                             449
            (2) in subsection (l), by adding at the end the
       following new paragraph:
       ‘‘(3)(A) The term ‘freestanding birth center services’
@@ -12930,8 +12036,6 @@ in subparagraph (B)), such as nurse midwives and other
 providers of services such as birth attendants recognized
 under State law, as determined appropriate by the Sec-
 
-      HR 3590 EAS/PP
-                            450
 retary. For purposes of the preceding sentence, the term
 ‘birth attendant’ means an individual who is recognized or
 registered by the State involved to provide health care at
@@ -12958,8 +12062,6 @@ clause (i) by striking ‘‘and (21)’’ and inserting ‘‘, (21), and
       QUIRED .—In the case of a State plan for medical as-
       sistance under title XIX of the Social Security Act
 
-      HR 3590 EAS/PP
-                            451
       which the Secretary of Health and Human Services
       determines requires State legislation (other than legis-
       lation appropriating funds) in order for the plan to
@@ -12986,8 +12088,6 @@ curity Act (42 U.S.C. 1396d(o)(1)) is amended—
       ‘‘(C) A voluntary election to have payment made for
 hospice care for a child (as defined by the State) shall not
 
-      HR 3590 EAS/PP
-                           452
 constitute a waiver of any rights of the child to be provided
 with, or to have payment made under this title for, services
 that are related to the treatment of the child’s condition
@@ -13014,8 +12114,6 @@ minal illness has been made’’ after ‘‘hospice care’’.
           subclause:
 
 
-      HR 3590 EAS/PP
-                            453
                         ‘‘(XXI) who are described in sub-
                     section (ii) (relating to individuals
                     who meet certain income standards);’’.
@@ -13042,8 +12140,6 @@ dividuals—
       pursuant to a waiver granted under section 1115.
 
 
-      HR 3590 EAS/PP
-                            454
           ‘‘(3) At the option of a State, for purposes of
      subsection (a)(17)(B), in determining eligibility for
      services under this subsection, the State may consider
@@ -13070,8 +12166,6 @@ dividuals—
           ceding paragraph (1)—
 
 
-      HR 3590 EAS/PP
-                            455
                     (i) in clause (xiv), by striking ‘‘or’’ at
                the end;
                     (ii) in clause (xv), by adding ‘‘or’’ at
@@ -13098,8 +12192,6 @@ assistance available to an individual described in section
 eligibility standard) during a presumptive eligibility pe-
 riod. In the case of an individual described in section
 1902(ii), such medical assistance shall be limited to family
-      HR 3590 EAS/PP
-                            456
 planning services and supplies described in 1905(a)(4)(C)
 and, at the State’s option, medical diagnosis and treatment
 services that are provided in conjunction with a family
@@ -13126,8 +12218,6 @@ planning service in a family planning setting.
                tion referred to in subparagraph (A), such
                last day.
 
-      HR 3590 EAS/PP
-                            457
           ‘‘(2) UALIFIED ENTITY  .—
                ‘‘(A) IN  GENERAL .—Subject to subpara-
           graph (B), the term ‘qualified entity’ means any
@@ -13154,8 +12244,6 @@ planning service in a family planning setting.
           ‘‘(2) NOTIFICATION REQUIREMENTS    .—A quali-
       fied entity that determines under subsection (b)(1)(A)
 
-      HR 3590 EAS/PP
-                            458
       that an individual described in subsection (a) is pre-
       sumptively eligible for medical assistance under a
       State plan shall—
@@ -13182,8 +12270,6 @@ of law, medical assistance that—
                ‘‘(A) during a presumptive eligibility pe-
           riod; and
 
-      HR 3590 EAS/PP
-                            459
                ‘‘(B) by a entity that is eligible for pay-
           ments under the State plan; and
           ‘‘(2) is included in the care and services covered
@@ -13210,8 +12296,6 @@ for purposes of clause (4) of the first sentence of section
           section 2202(b), is amended by inserting ‘‘or for
           medical assistance provided to an individual de-
 
-      HR 3590 EAS/PP
-                           460
           scribed in subsection (a) of section 1920C during
           a presumptive eligibility period under such sec-
           tion,’’ after ‘‘1920B during a presumptive eligi-
@@ -13238,8 +12322,6 @@ such date.
 
 
 
-      HR 3590 EAS/PP
-                          461
  SEC. 2304. CLARIFICATION OF DEFINITION OF MEDICAL AS-
             SISTANCE.
      Section 1905(a) of the Social Security Act (42 U.S.C.
@@ -13266,8 +12348,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
      applicable for an individual who has been determined
      to require an institutional level of care to be eligible
      for nursing facility services under the State plan and
-     HR 3590 EAS/PP
-                            462
       with respect to whom there has been a determination
       that, but for the provision of such services, the indi-
       viduals would require the level of care provided in a
@@ -13294,8 +12374,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
                     ‘‘(ii) in a home or community setting,
                which does not include a nursing facility,
 
-      HR 3590 EAS/PP
-                            463
                institution for mental diseases, or an inter-
                mediate care facility for the mentally re-
                tarded;
@@ -13322,8 +12400,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
           plishing activities of daily living, instrumental
           activities of daily living, and health related
 
-      HR 3590 EAS/PP
-                            464
           tasks, the home and community-based attendant
           services and supports made available include—
                     ‘‘(i) the acquisition, maintenance, and
@@ -13350,8 +12426,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
                the Rehabilitation Act of 1973;
 
 
-      HR 3590 EAS/PP
-                            465
                     ‘‘(iii) assistive technology devices and
                assistive technology services other than those
                under (1)(B)(ii);
@@ -13378,8 +12452,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
                to the extent that expenditures would other-
                wise be made for the human assistance.
 
-      HR 3590 EAS/PP
-                            466
           ‘‘(2) NCREASED FEDERAL FINANCIAL PARTICIPA    -
       TION.—For purposes of payments to a State under
       section 1903(a)(1), with respect to amounts expended
@@ -13406,8 +12478,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
           community-based attendant services and sup-
           ports to individuals on a statewide basis, in a
 
-      HR 3590 EAS/PP
-                            467
           manner that provides such services and supports
           in the most integrated setting appropriate to the
           individual’s needs, and without regard to the in-
@@ -13434,8 +12504,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
                sideration procedures of an individual plan,
 
 
-      HR 3590 EAS/PP
-                            468
                and other factors as determined by the Sec-
                retary;
                     ‘‘(ii) incorporates feedback from con-
@@ -13462,8 +12530,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
           providing Federal oversight, and conducting an
           evaluation under paragraph (5)(A), including
 
-      HR 3590 EAS/PP
-                            469
           data regarding how the State provides home and
           community-based attendant services and sup-
           ports and other home and community-based serv-
@@ -13490,8 +12556,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
           ance; and
                ‘‘(D) occupational health and safety.
 
-      HR 3590 EAS/PP
-                            470
           ‘‘(5) EVALUATION  , DATA COLLECTION  , AND RE  -
       PORT TO CONGRESS  .—
                ‘‘(A) E VALUATION  .—The Secretary shall
@@ -13518,8 +12582,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
           for which such services and supports are pro-
           vided:
 
-      HR 3590 EAS/PP
-                            471
                    ‘‘(i) The number of individuals who
                are estimated to receive home and commu-
                nity-based attendant services and supports
@@ -13546,8 +12608,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
                to the public a final report on the findings
                of the evaluation under subparagraph (A).
 
-      HR 3590 EAS/PP
-                            472
           ‘‘(6) EFINITIONS .—In this subsection:
                ‘‘(A) ACTIVITIES OF DAILY LIVING   .—The
           term ‘activities of daily living’ includes tasks
@@ -13574,8 +12634,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
                    ‘‘(ii) O THER   MODELS  .—The term
                ‘other models’ means, subject to paragraph
 
-      HR 3590 EAS/PP
-                            473
                (4), methods, other than an agency-provider
                model, for the provision of consumer con-
                trolled services and supports. Such models
@@ -13602,8 +12660,6 @@ themselves, or both’’ before ‘‘(if provided in or after’’.
           and traveling around and participating in the
           community.’’.
 
-      HR 3590 EAS/PP
-                           474
  SEC. 2402. REMOVAL OF BARRIERS TO PROVIDING HOME
              AND COMMUNITY-BASED SERVICES.
      (a) OVERSIGHT AND   ASSESSMENT OF THE    ADMINIS-
@@ -13630,8 +12686,6 @@ tems that are designed to—
      and State-funded programs in order to—
 
 
-      HR 3590 EAS/PP
-                            475
                (A) achieve a more consistent administra-
           tion of policies and procedures across programs
           in relation to the provision of such services; and
@@ -13658,8 +12712,6 @@ by adding at the end the following new paragraphs:
           home and community-based services in accord-
           ance with this subsection to individuals who sat-
 
-      HR 3590 EAS/PP
-                            476
           isfy the needs-based criteria for the receipt of
           such services established under paragraph (1)(A)
           may, in addition to continuing to provide such
@@ -13686,8 +12738,6 @@ by adding at the end the following new paragraphs:
           the needs-based criteria established under para-
           graph (1)(A).
 
-      HR 3590 EAS/PP
-                            477
                ‘‘(C) A UTHORITY   TO  OFFER  DIFFERENT
           TYPE , AMOUNT , DURATION  ,OR SCOPE OF HOME
           AND   COMMUNITY  -BASED   SERVICES .—A State
@@ -13714,8 +12764,6 @@ by adding at the end the following new paragraphs:
                ‘‘(B) 5YEAR TERM  .—
 
 
-      HR 3590 EAS/PP
-                             478
                     ‘‘(i) N GENERAL   .—An election by a
                State under this paragraph shall be for a
                period of 5 years.
@@ -13742,8 +12790,6 @@ by adding at the end the following new paragraphs:
 
 
 
-      HR 3590 EAS/PP
-                         479
                  ‘‘(ii) met the State’s objectives with re-
              spect to quality improvement and bene-
              ficiary outcomes.’’.
@@ -13770,8 +12816,6 @@ by the State as the Secretary may approve’’.
                  and community-based services under
                  needs-based criteria established under
 
-     HR 3590 EAS/PP
-                            480
                    paragraph (1)(A) of section 1915(i), or
                    who are eligible for home and commu-
                    nity-based services under paragraph
@@ -13798,8 +12842,6 @@ by the State as the Secretary may approve’’.
                following new clause:
 
 
-      HR 3590 EAS/PP
-                          481
          ‘‘(xvii) individuals who are eligible for home and
      community-based services under needs-based criteria
      established under paragraph (1)(A) of section 1915(i),
@@ -13826,8 +12868,6 @@ Act (42 U.S.C. 1396n(i)) is amended—
      striking ‘‘to be eligible for such services for a period
      of at least 12 months beginning on the date the indi-
 
-      HR 3590 EAS/PP
-                          482
      vidual first received medical assistance for such serv-
      ices’’ and inserting ‘‘to continue to be eligible for such
      services after the effective date of the modification and
@@ -13854,8 +12894,6 @@ ment of this Act.
          year 2011’’ and inserting ‘‘each of fiscal years
          2011 through 2016’’; and
 
-      HR 3590 EAS/PP
-                           483
               (B) in paragraph (2), by striking ‘‘2011’’
           and inserting ‘‘2016’’.
           (2) E VALUATION .—Paragraphs (2) and (3) of
@@ -13882,8 +12920,6 @@ ment of this Act.
      required under subparagraph (A)(i).’’.
 
 
-      HR 3590 EAS/PP
-                            484
           (2) E FFECTIVE DATE   .—The amendments made
       by this subsection take effect 30 days after the date of
       enactment of this Act.
@@ -13910,8 +12946,6 @@ tion for ‘‘(at the option of the State) is described in section
       Out of any funds in the Treasury not otherwise appro-
 priated, there is appropriated to the Secretary of Health
 
-      HR 3590 EAS/PP
-                            485
 and Human Services, acting through the Assistant Sec-
 retary for Aging, $10,000,000 for each of fiscal years 2010
 through 2014, to carry out subsections (a)(20)(B)(iii) and
@@ -13938,8 +12972,6 @@ ings:
           (3) Despite the Pepper Commission and
       Olmstead decision, the long-term care provided to our
 
-      HR 3590 EAS/PP
-                             486
       Nation’s elderly and disabled has not improved. In
       fact, for many, it has gotten far worse.
            (4) In 2007, 69 percent of Medicaid long-term
@@ -13966,8 +12998,6 @@ ate that—
       in a comprehensive way that guarantees elderly and
       disabled individuals the care they need; and
 
-      HR 3590 EAS/PP
-                         487
          (2) long term services and supports should be
      made available in the community in addition to in
      institutions.
@@ -13994,8 +13024,6 @@ ate that—
 
 
 
-     HR 3590 EAS/PP
-                            488
                         ‘‘(VI) except as provided in clause
                    (iii), after December 31, 2009, 23.1
                    percent.’’; and
@@ -14022,8 +13050,6 @@ ate that—
                         and updated regularly by the Sec-
                         retary.
 
-      HR 3590 EAS/PP
-                            489
                              ‘‘(bb) A drug approved by the
                         Food and Drug Administration
                         exclusively for pediatric indica-
@@ -14050,8 +13076,6 @@ ate that—
                     State under such subparagraph that
                     are attributable (as estimated by the
 
-      HR 3590 EAS/PP
-                            490
                     Secretary based on utilization and
                     other data) to the increase in the min-
                     imum rebate percentage effected by the
@@ -14078,8 +13102,6 @@ ate that—
                for all Medicaid spending under section
                1903(d)(2). Such a disallowance is not sub-
 
-      HR 3590 EAS/PP
-                          491
              ject to a reconsideration under section
              1116(d).’’.
      (b) NCREASE IN R EBATE FOR O THER  DRUGS .—Sec-
@@ -14106,8 +13128,6 @@ tion 1927(c)(3)(B) of such Act (42 U.S.C. 1396r–
          the end and inserting ‘‘; and’’; and
              (C) by adding at the end the following:
 
-     HR 3590 EAS/PP
-                            492
                     ‘‘(xiii) such contract provides that (I)
                covered outpatient drugs dispensed to indi-
                viduals eligible for medical assistance who
@@ -14134,8 +13154,6 @@ tion 1927(c)(3)(B) of such Act (42 U.S.C. 1396r–
                and for which the entity is responsible for
                coverage of such drug under this subsection
 
-      HR 3590 EAS/PP
-                            493
                (other than covered outpatient drugs that
                under subsection (j)(1) of section 1927 are
                not subject to the requirements of that sec-
@@ -14162,8 +13180,6 @@ tion 1927(c)(3)(B) of such Act (42 U.S.C. 1396r–
       the requirements of this section if such drugs are—
 
 
-      HR 3590 EAS/PP
-                          494
               ‘‘(A) dispensed by health maintenance orga-
          nizations, including Medicaid managed care or-
          ganizations that contract under section 1903(m);
@@ -14190,8 +13206,6 @@ tion 1927(c)(3)(B) of such Act (42 U.S.C. 1396r–
               of—
 
 
-      HR 3590 EAS/PP
-                            495
                         ‘‘(I) the average manufacturer
                     price for each dosage form and strength
                     of the new formulation of the single
@@ -14218,8 +13232,6 @@ tion 1927(c)(3)(B) of such Act (42 U.S.C. 1396r–
                out regard to whether the period of market
                exclusivity for the drug under section 527 of
 
-      HR 3590 EAS/PP
-                           496
               such Act has expired or the specific indica-
               tion for use of the drug.’’.
           (2) EFFECTIVE DATE .—The amendment made by
@@ -14246,8 +13258,6 @@ new subparagraph:
               (C) redesignating subsection (d) as sub-
           section (c).
 
-      HR 3590 EAS/PP
-                            497
           (2) E FFECTIVE DATE  .—The amendments made
      by this subsection take effect on January 1, 2010.
  SEC. 2502. ELIMINATION OF EXCLUSION OF COVERAGE OF
@@ -14274,8 +13284,6 @@ rity Act (42 U.S.C. 1397r–8(d)) is amended—
                ‘‘(B) Barbiturates.
                ‘‘(C) Benzodiazepines.’’.
 
-      HR 3590 EAS/PP
-                           498
      (b) EFFECTIVE D ATE.—The amendments made by this
 section shall apply to services furnished on or after January
 1, 2014.
@@ -14302,8 +13310,6 @@ section shall apply to services furnished on or after January
      Such process shall be similar to the smoothing process
 
 
-      HR 3590 EAS/PP
-                            499
       used in determining the average sales price of a drug
       or biological under section 1847A.’’.
           (2) D EFINITION OF AMP .—Section 1927(k)(1) of
@@ -14330,8 +13336,6 @@ section shall apply to services furnished on or after January
                    tail community pharmacies, including
                    (but not limited to) distribution service
 
-      HR 3590 EAS/PP
-                            500
                    fees, inventory management fees, prod-
                    uct stocking allowances, and fees asso-
                    ciated with administrative services
@@ -14358,8 +13362,6 @@ section shall apply to services furnished on or after January
                    other entity that does not conduct busi-
 
 
-      HR 3590 EAS/PP
-                            501
                    ness as a wholesaler or a retail com-
                    munity pharmacy.
                    ‘‘(ii)NCLUSION OF OTHER DISCOUNTS
@@ -14386,8 +13388,6 @@ section shall apply to services furnished on or after January
                and inserting a period; and
                    (iii) by striking clause (iii).
 
-      HR 3590 EAS/PP
-                            502
           (4) D EFINITIONS OF RETAIL COMMUNITY PHAR     -
       MACY; WHOLESALER   .—Section 1927(k) of such Act
       (42 U.S.C. 1396r–8(k)) is amended by adding at the
@@ -14414,8 +13414,6 @@ section shall apply to services furnished on or after January
       (including manufacturer’s and distributor’s ware-
       houses, chain drug warehouses, and wholesale drug
 
-      HR 3590 EAS/PP
-                            503
      warehouses) independent wholesale drug traders, and
      retail community pharmacies that conduct wholesale
      distributions.’’.
@@ -14442,8 +13440,6 @@ section shall apply to services furnished on or after January
      manufacturer prices and the average retail survey
 
 
-      HR 3590 EAS/PP
-                          504
      price determined for each multiple source drug in ac-
      cordance with subsection (f)’’.
      (c) CLARIFICATION OF A PPLICATION OF SURVEY OF
@@ -14470,8 +13466,6 @@ promulgated by such date.
 rity Act (42 U.S.C. 1396r–4(f)) is amended—
 
 
-      HR 3590 EAS/PP
-                            505
           (1) in paragraph (1), by striking ‘‘and (3)’’ and
      inserting ‘‘, (3), and (7)’’;
           (2) in paragraph (3)(A), by striking ‘‘paragraph
@@ -14498,8 +13492,6 @@ rity Act (42 U.S.C. 1396r–4(f)) is amended—
                cable percentage determined for the State
 
 
-      HR 3590 EAS/PP
-                            506
                for the fiscal year under subparagraph
                (B)(i); and
                     ‘‘(ii) in the case of any subsequent fis-
@@ -14526,8 +13518,6 @@ rity Act (42 U.S.C. 1396r–4(f)) is amended—
                     percent.
 
 
-      HR 3590 EAS/PP
-                            507
                     ‘‘(ii) UBSEQUENT FISCAL YEARS IN
                WHICH THE PERCENTAGE OF UNINSURED
                DECREASES  .—In the case of any fiscal year
@@ -14554,8 +13544,6 @@ rity Act (42 U.S.C. 1396r–4(f)) is amended—
                     the fiscal year from the preceding fiscal
                     year and 50 percent.
 
-      HR 3590 EAS/PP
-                            508
                ‘‘(C) FISCAL YEAR DESCRIBED   .—For pur-
           poses of subparagraph (A), the fiscal year de-
           scribed in this subparagraph with respect to a
@@ -14582,8 +13570,6 @@ rity Act (42 U.S.C. 1396r–4(f)) is amended—
           efits coverage under a waiver that is in effect on
           July 2009.
 
-      HR 3590 EAS/PP
-                            509
                ‘‘(E) MINIMUM ALLOTMENT   .—In no event
           shall the DSH allotment determined for a State
           in accordance with this paragraph for fiscal year
@@ -14610,8 +13596,6 @@ section (a) take effect on October 1, 2011.
 
 
 
-      HR 3590 EAS/PP
-                            510
  Subtitle H—Improved Coordination
      for Dual Eligible Beneficiaries
  SEC. 2601. 5-YEAR PERIOD FOR DEMONSTRATION
@@ -14638,8 +13622,6 @@ the purposes of this title, to extend the waiver.
      ‘‘(B) In this paragraph, the term ‘dual eligible indi-
 vidual’ means an individual who is entitled to, or enrolled
 
-      HR 3590 EAS/PP
-                            511
 for, benefits under part A of title XVIII, or enrolled for ben-
 efits under part B of title XVIII, and is eligible for medical
 assistance under the State plan under this title or under
@@ -14666,8 +13648,6 @@ a waiver of such plan.’’.
 
 
 
-      HR 3590 EAS/PP
-                           512
               (B) in subsection (f)(6), by inserting ‘‘(5
           years, in the case of a waiver described in sec-
           tion 1915(h)(2))’’ after ‘‘3 years’’.
@@ -14694,8 +13674,6 @@ nated Health Care Office is to bring together officers and
 employees of the Medicare and Medicaid programs at the
 Centers for Medicare & Medicaid Services in order to—
 
-      HR 3590 EAS/PP
-                            513
           (1) more effectively integrate benefits under the
       Medicare program under title XVIII of the Social Se-
       curity Act and the Medicaid program under title XIX
@@ -14722,8 +13700,6 @@ Health Care Office are as follows:
           (5) Eliminating regulatory conflicts between
       rules under the Medicare and Medicaid programs.
 
-      HR 3590 EAS/PP
-                            514
           (6) Improving care continuity and ensuring safe
       and effective care transitions for dual eligible individ-
       uals.
@@ -14750,8 +13726,6 @@ are as follows:
       nished under the Medicare program.
 
 
-      HR 3590 EAS/PP
-                            515
           (3) Providing support for coordination of con-
       tracting and oversight by States and the Centers for
       Medicare & Medicaid Services with respect to the in-
@@ -14778,8 +13752,6 @@ are as follows:
       (e) EPORT  .—The Secretary shall, as part of the budg-
 et transmitted under section 1105(a) of title 31, United
 
-      HR 3590 EAS/PP
-                         516
 States Code, submit to Congress an annual report con-
 taining recommendations for legislation that would im-
 prove care coordination and benefits for dual eligible indi-
@@ -14806,8 +13778,6 @@ the following new section:
  UNDER M EDICAID.—The Secretary shall identify and pub-
 lish a recommended core set of adult health quality meas-
 
-     HR 3590 EAS/PP
-                            517
 ures for Medicaid eligible adults in the same manner as
 the Secretary identifies and publishes a core set of child
 health quality measures under section 1139A, including
@@ -14834,8 +13804,6 @@ time, that may be applicable to Medicaid eligible adults.
       to encourage States to use such measures to volun-
 
 
-      HR 3590 EAS/PP
-                            518
      tarily report information regarding the quality of
      health care for Medicaid eligible adults.
           ‘‘(4) REPORTS TO CONGRESS    .—Not later than
@@ -14862,8 +13830,6 @@ time, that may be applicable to Medicaid eligible adults.
           tion 1139A(b)(4)(A)
 
 
-      HR 3590 EAS/PP
-                           519
               ‘‘(B) REVISING,STRENGTHENING  , AND IM -
           PROVING INITIAL CORE MEASURES   .—Beginning
           not later than 24 months after the establishment
@@ -14890,8 +13856,6 @@ ices.
               ‘‘(A) State-specific adult health quality
           measures applied by the State under the such
 
-      HR 3590 EAS/PP
-                            520
           plan, including measures described in subsection
           (a)(5); and
                ‘‘(B) State-specific information on the qual-
@@ -14918,8 +13882,6 @@ retary’’) shall identify current State practices that prohibit
 payment for health care-acquired conditions and shall in-
 corporate the practices identified, or elements of such prac-
 
-      HR 3590 EAS/PP
-                             521
 tices, which the Secretary determines appropriate for appli-
 cation to the Medicaid program in regulations. Such regu-
 lations shall be effective as of July 1, 2011, and shall pro-
@@ -14946,8 +13908,6 @@ code specified by the Secretary in such regulations, as ap-
 propriate for the Medicaid program. The Secretary may ex-
 clude certain conditions identified under title XVIII of the
 
-      HR 3590 EAS/PP
-                          522
 Social Security Act for non-payment under title XIX of
 such Act when the Secretary finds the inclusion of such con-
 ditions to be inapplicable to beneficiaries under title XIX.
@@ -14975,8 +13935,6 @@ under subsection (h)(6)) operating with such a provider, or
 a health team (as described under subsection (h)(7)) as the
 
 
-     HR 3590 EAS/PP
-                           523
 individual’s health home for purposes of providing the indi-
 vidual with health home services.
      ‘‘(b) HEALTH  H OME  QUALIFICATION  STANDARDS  .—
@@ -15003,8 +13961,6 @@ be a health home for purposes of this section.
               ‘‘(A) N GENERAL  .—The State shall specify
           in the State plan amendment the methodology
 
-      HR 3590 EAS/PP
-                            524
           the State will use for determining payment for
           the provision of health home services. Such meth-
           odology for determining payment—
@@ -15031,8 +13987,6 @@ be a health home for purposes of this section.
                ‘‘(A) N GENERAL  .—Beginning January 1,
           2011, the Secretary may award planning grants
 
-      HR 3590 EAS/PP
-                            525
           to States for purposes of developing a State plan
           amendment under this section. A planning grant
           awarded to a State under this paragraph shall
@@ -15059,8 +14013,6 @@ Mental Health Services Administration in addressing issues
 regarding the prevention and treatment of mental illness
 
 
-      HR 3590 EAS/PP
-                            526
 and substance abuse among eligible individuals with chron-
 ic conditions.
       ‘‘(f) ONITORING .—A State shall include in the State
@@ -15087,8 +14039,6 @@ vider shall use health information technology in providing
 the State with such information.
       ‘‘(h) EFINITIONS.—In this section:
 
-      HR 3590 EAS/PP
-                            527
           ‘‘(1) ELIGIBLE INDIVIDUAL WITH CHRONIC CON    -
       DITIONS.—
                ‘‘(A) IN  GENERAL  .—Subject to subpara-
@@ -15115,8 +14065,6 @@ the State with such information.
       Secretary and shall include, but is not limited to, the
       following:
 
-      HR 3590 EAS/PP
-                            528
                ‘‘(A) A mental health condition.
                ‘‘(B) Substance use disorder.
                ‘‘(C) Asthma.
@@ -15143,8 +14091,6 @@ the State with such information.
                    ‘‘(ii) care coordination and health pro-
                motion;
 
-      HR 3590 EAS/PP
-                            529
                     ‘‘(iii) comprehensive transitional care,
                including appropriate follow-up, from inpa-
                tient to other settings;
@@ -15171,8 +14117,6 @@ the State with such information.
                ‘‘(B) satisfies the qualification standards es-
           tablished by the Secretary under subsection (b).
 
-      HR 3590 EAS/PP
-                            530
           ‘‘(6) EAM OF HEALTH CARE PROFESSIONALS     .—
      The term ‘team of health care professionals’ means a
      team of health professionals (as described in the State
@@ -15199,8 +14143,6 @@ the State with such information.
           organization to conduct an evaluation and as-
           sessment of the States that have elected the op-
 
-      HR 3590 EAS/PP
-                            531
           tion to provide coordinated care through a health
           home for Medicaid beneficiaries with chronic
           conditions under section 1945 of the Social Secu-
@@ -15227,8 +14169,6 @@ the State with such information.
                uals with chronic conditions;
 
 
-      HR 3590 EAS/PP
-                           532
                    (iv) assessment of program implemen-
               tation;
                    (v) processes and lessons learned (as
@@ -15255,8 +14195,6 @@ the State with such information.
      under title XIX of the Social Security Act to evaluate
 
 
-      HR 3590 EAS/PP
-                            533
       the use of bundled payments for the provision of inte-
       grated care for a Medicaid beneficiary—
                (A) with respect to an episode of care that
@@ -15283,8 +14221,6 @@ be conducted in accordance with the following:
       of Medicaid beneficiaries nationally.
 
 
-      HR 3590 EAS/PP
-                            534
           (2) The demonstration project shall focus on con-
       ditions where there is evidence of an opportunity for
       providers of services and suppliers to improve the
@@ -15311,8 +14247,6 @@ be conducted in accordance with the following:
       States shall ensure that Medicaid beneficiaries are not
       liable for any additional cost sharing than if their
 
-      HR 3590 EAS/PP
-                            535
      care had not been subject to payment under the dem-
      onstration project.
           (5) Hospitals participating in the demonstration
@@ -15339,8 +14273,6 @@ goals of the demonstration, ensure beneficiary access to
 acute and post-acute care, and maintain quality of care.
      (d) EVALUATION AND  R EPORT .—
 
-      HR 3590 EAS/PP
-                            536
           (1) DATA .—Each State selected to participate in
      the demonstration project under this section shall pro-
      vide to the Secretary, in such form and manner as the
@@ -15367,8 +14299,6 @@ structure to a global capitated payment model.
      (b) D  URATION   AND   SCOPE .—The demonstration
 project conducted under this section shall operate during
 
-      HR 3590 EAS/PP
-                           537
 a period of fiscal years 2010 through 2012. The Secretary
 shall select not more than 5 States to participate in the
 demonstration project.
@@ -15395,8 +14325,6 @@ subsection (b).
      (e) REPORT .—Not later than 12 months after the date
 of completion of the demonstration project under this sec-
 
-      HR 3590 EAS/PP
-                           538
 tion, the Secretary shall submit to Congress a report con-
 taining the results of the evaluation and testing conducted
 under subsection (d), together with recommendations for
@@ -15423,8 +14351,6 @@ to carry out this section.
 
 
 
-      HR 3590 EAS/PP
-                            539
           (2) DURATION  .—The demonstration project shall
       begin on January 1, 2012, and shall end on December
       31, 2016.
@@ -15451,8 +14377,6 @@ require.
       Act that must be reached by an accountable care orga-
 
 
-      HR 3590 EAS/PP
-                           540
      nization in order for such organization to receive an
      incentive payment under subsection (d).
           (3) MINIMUM PARTICIPATION PERIOD   .—A pro-
@@ -15479,8 +14403,6 @@ to carry out this section.
  PROJECT .—The Secretary of Health and Human Services
 (in this section referred to as the ‘‘Secretary’’) shall estab-
 
-      HR 3590 EAS/PP
-                             541
 lish a demonstration project under which an eligible State
 (as described in subsection (c)) shall provide payment under
 the State Medicaid plan under title XIX of the Social Secu-
@@ -15507,8 +14429,6 @@ for the stabilization of medical emergency conditions
 through utilization review, authorization, or management
 
 
-      HR 3590 EAS/PP
-                           542
 practices, or the application of medical necessity and ap-
 propriateness criteria applicable to behavioral health.
      (c) ELIGIBLES TATE DEFINED .—
@@ -15535,8 +14455,6 @@ be conducted for a period of 3 consecutive years.
      (e) IMITATIONS ON F EDERAL F UNDING.—
           (1) PPROPRIATION .—
 
-      HR 3590 EAS/PP
-                           543
               (A) IN GENERAL  .—Out of any funds in the
           Treasury not otherwise appropriated, there is
           appropriated to carry out this section,
@@ -15563,8 +14481,6 @@ be conducted for a period of 3 consecutive years.
      of funds, as determined by the Secretary.
 
 
-      HR 3590 EAS/PP
-                            544
           (5) PAYMENTS TO STATES   .—The Secretary shall
      pay to each eligible State, from its allocation under
      paragraph (4), an amount each quarter equal to the
@@ -15591,8 +14507,6 @@ be conducted for a period of 3 consecutive years.
                (C) An assessment of the impact of the dem-
           onstration project on the costs of the full range
 
-      HR 3590 EAS/PP
-                            545
           of mental health services (including inpatient,
           emergency and ambulatory care).
                (D) An analysis of the percentage of con-
@@ -15619,8 +14533,6 @@ be conducted for a period of 3 consecutive years.
      onstration project under this section.
 
 
-      HR 3590 EAS/PP
-                            546
           (2) L IMITED OTHER WAIVER AUTHORITY     .—The
       Secretary may waive other requirements of titles XI
       and XIX of the Social Security Act (including the re-
@@ -15647,8 +14559,6 @@ be conducted for a period of 3 consecutive years.
       assistance’’ has the meaning given that term in sec-
 
 
-      HR 3590 EAS/PP
-                           547
      tion 1905(a) of the Social Security Act (42 U.S.C.
      1396d(a)).
           (5) TABILIZED .—The term ‘‘stabilized’’ means,
@@ -15675,8 +14585,6 @@ Act (42 U.S.C. 1396) is amended—
                   (ii) in subparagraph (A), by striking
               ‘‘children’s’’;
 
-      HR 3590 EAS/PP
-                            548
                     (iii) in subparagraph (B), by inserting
                ‘‘, the Secretary, and States’’ after ‘‘Con-
                gress’’;
@@ -15703,8 +14611,6 @@ Act (42 U.S.C. 1396) is amended—
                          health centers and rural health
                          clinics, managed care entities,
 
-      HR 3590 EAS/PP
-                            549
                          and providers of other covered
                          items and services’’; and
                          (II) in clause (iii), by inserting
@@ -15731,8 +14637,6 @@ Act (42 U.S.C. 1396) is amended—
           tention processes, including a determination of
           the degree to which Federal and State policies
 
-      HR 3590 EAS/PP
-                            550
           encourage the enrollment of individuals who are
           eligible for such programs and screen out indi-
           viduals who are ineligible, while minimizing the
@@ -15759,8 +14663,6 @@ Act (42 U.S.C. 1396) is amended—
           interaction of policies under Medicaid and the
           Medicare program under title XVIII, including
 
-      HR 3590 EAS/PP
-                            551
           with respect to how such interactions affect ac-
           cess to services, payments, and dual eligible indi-
           viduals.’’ and
@@ -15787,8 +14689,6 @@ Act (42 U.S.C. 1396) is amended—
           versely affect, or have the potential to adversely
           affect, access to care by, or the health care status
 
-      HR 3590 EAS/PP
-                            552
           of, Medicaid and CHIP beneficiaries. MACPAC
           shall include in the annual report required
           under paragraph (1)(D) a description of all such
@@ -15815,8 +14715,6 @@ Act (42 U.S.C. 1396) is amended—
                (G) in paragraph (10), as so redesignated,
           by inserting ‘‘, and shall submit with any rec-
 
-      HR 3590 EAS/PP
-                           553
           ommendations, a report on the Federal and
           State-specific budget consequences of the rec-
           ommendations’’ before the period; and
@@ -15843,8 +14741,6 @@ Act (42 U.S.C. 1396) is amended—
           and MedPAC shall have access to deliberations
 
 
-      HR 3590 EAS/PP
-                           554
           and records of the other such entity, respectively,
           upon the request of the other such entity.
           ‘‘(12) ONSULTATION WITH STATES    .—MACPAC
@@ -15871,8 +14767,6 @@ Act (42 U.S.C. 1396) is amended—
               (A) by striking subparagraphs (A) and (B)
           and inserting the following:
 
-      HR 3590 EAS/PP
-                            555
                ‘‘(A) IN  GENERAL  .—The membership of
           MACPAC shall include individuals who have
           had direct experience as enrollees or parents or
@@ -15899,8 +14793,6 @@ Act (42 U.S.C. 1396) is amended—
           representatives of State agencies responsible for
           administering Medicaid, and current or former
 
-      HR 3590 EAS/PP
-                            556
           representatives of State agencies responsible for
           administering CHIP.’’.
           (3) in subsection (d)(2), by inserting ‘‘and
@@ -15927,8 +14819,6 @@ Act (42 U.S.C. 1396) is amended—
                ‘‘(B) T RANSFER    OF   FUNDS .—Notwith-
           standing section 2104(a)(13), from the amounts
 
-      HR 3590 EAS/PP
-                           557
           appropriated in such section for fiscal year
           2010, $2,000,000 is hereby transferred and made
           available in such fiscal year to MACPAC to
@@ -15955,8 +14845,6 @@ is amended—
      Medicaid program under title XIX and the private
      market for health care services with respect to pro-
 
-      HR 3590 EAS/PP
-                            558
      viders for which, on an aggregate national basis, a
      significant portion of revenue or services is associated
      with the Medicaid program. Where appropriate, the
@@ -15983,8 +14871,6 @@ is amended—
      Medicaid policy regarding Medicaid beneficiaries, in-
      cluding Medicaid beneficiaries who are dually eligible
 
-      HR 3590 EAS/PP
-                         559
      for Medicare and Medicaid, shall rest with
      MACPAC.’’.
  Subtitle K—Protections for Amer-
@@ -16012,8 +14898,6 @@ local law to the contrary.
 of the Social Security Act (42 U.S.C. 1396a(e)(13)(F)(ii))
 is amended—
 
-     HR 3590 EAS/PP
-                           560
           (1) in the clause heading, by insertiAND IN-
      DIAN  TRIBES  AND  TRIBAL  ORGANIZATIONS  ’’ after
      ‘AGENCIES ’’; and
@@ -16041,8 +14925,6 @@ or after’’.
 section shall apply to items or services furnished on or after
 January 1, 2010.
 
-      HR 3590 EAS/PP
-                          561
     Subtitle L—Maternal and Child
                Health Services
  SEC. 2951. MATERNAL, INFANT, AND EARLY CHILDHOOD
@@ -16069,8 +14951,6 @@ section:
      allotment for the State under section 502 for fiscal
      year 2011, conduct a statewide needs assessment
 
-      HR 3590 EAS/PP
-                            562
       (which shall be separate from the statewide needs as-
       sessment required under section 505(a)) that identi-
       fies—
@@ -16097,8 +14977,6 @@ section:
                     ‘‘(ii) the gaps in early childhood home
                visitation in the State; and
 
-      HR 3590 EAS/PP
-                            563
                    ‘‘(iii) the extent to which such pro-
                grams or initiatives are meeting the needs
                of eligible families described in subsection
@@ -16125,8 +15003,6 @@ section:
       required under section 205(3) of the Child Abuse Pre-
       vention and Treatment Act.
 
-      HR 3590 EAS/PP
-                           564
           ‘‘(3) UBMISSION TO THE SECRETARY     .—Each
      State shall submit to the Secretary, in such form and
      manner as the Secretary shall require—
@@ -16153,8 +15029,6 @@ section:
      comes, school readiness, and the socioeconomic status
 
 
-      HR 3590 EAS/PP
-                            565
       of such families, and reductions in child abuse, ne-
       glect, and injuries.
           ‘‘(2) AUTHORITY TO USE INITIAL GRANT FUNDS
@@ -16181,8 +15055,6 @@ ducted with a grant made under this section are as follows:
       IN BENCHMARK AREAS   .—
 
 
-      HR 3590 EAS/PP
-                            566
                ‘‘(A) N GENERAL  .—The eligible entity es-
           tablishes, subject to the approval of the Secretary,
           quantifiable, measurable 3- and 5-year bench-
@@ -16209,8 +15081,6 @@ ducted with a grant made under this section are as follows:
                    ‘‘(i) REPORT TO THE SECRETARY     .—
                Not later than 30 days after the end of the
 
-      HR 3590 EAS/PP
-                            567
                3rd year in which the eligible entity con-
                ducts the program, the entity submits to the
                Secretary a report demonstrating improve-
@@ -16237,8 +15107,6 @@ ducted with a grant made under this section are as follows:
                    improvement plan under clause (ii)
                    with technical assistance to develop
 
-      HR 3590 EAS/PP
-                            568
                    and implement the plan. The Secretary
                    may provide the technical assistance
                    directly or through grants, contracts,
@@ -16265,8 +15133,6 @@ ducted with a grant made under this section are as follows:
                under subsection (h)(2)(B).
 
 
-      HR 3590 EAS/PP
-                            569
                ‘‘(C) FINAL REPORT  .—Not later than De-
           cember 31, 2015, the eligible entity shall submit
           a report to the Secretary demonstrating improve-
@@ -16293,8 +15159,6 @@ ducted with a grant made under this section are as follows:
                provements in cognitive, language, social-
 
 
-      HR 3590 EAS/PP
-                            570
                emotional, and physical developmental indi-
                cators.
                     ‘‘(iii) Improvements in parenting
@@ -16321,8 +15185,6 @@ ducted with a grant made under this section are as follows:
                subclause (II) selected by the eligible entity:
 
 
-      HR 3590 EAS/PP
-                            571
                         ‘‘(I) The model conforms to a
                     clear consistent home visitation model
                     that has been in existence for at least
@@ -16349,8 +15211,6 @@ ducted with a grant made under this section are as follows:
                         tion results have been published in
                         a peer-reviewed journal; or
 
-      HR 3590 EAS/PP
-                            572
                              ‘‘(bb) quasi-experimental re-
                         search designs.
                         ‘‘(II) The model conforms to a
@@ -16377,8 +15237,6 @@ ducted with a grant made under this section are as follows:
                shall ensure that the process for establishing
 
 
-      HR 3590 EAS/PP
-                            573
                the criteria is transparent and provides the
                opportunity for public comment.
                ‘‘(B) DDITIONAL REQUIREMENTS    .—
@@ -16405,8 +15263,6 @@ ducted with a grant made under this section are as follows:
                organizational capacity to implement the
                activities involved.
 
-      HR 3590 EAS/PP
-                            574
                     ‘‘(v) The program establishes appro-
                priate linkages and referral networks to
                other community resources and supports for
@@ -16433,8 +15289,6 @@ ducted with a grant made under this section are as follows:
           ment.
 
 
-      HR 3590 EAS/PP
-                            575
                ‘‘(F) Eligible families that have users of to-
           bacco products in the home.
                ‘‘(G) Eligible families that are or have chil-
@@ -16461,8 +15315,6 @@ Secretary may require, that includes the following:
       fied in the statewide needs assessment required under
       subsection (b)(1)(A).
 
-      HR 3590 EAS/PP
-                            576
           ‘‘(3) The service delivery model or models de-
       scribed in subsection (d)(3)(A) that the entity will use
       under the program and the basis for the selection of
@@ -16489,8 +15341,6 @@ Secretary may require, that includes the following:
                ‘‘(A) the participation of each eligible fam-
           ily in the program is voluntary; and
 
-      HR 3590 EAS/PP
-                            577
                ‘‘(B) services are provided to an eligible
           family in accordance with the individual assess-
           ment for that family.
@@ -16517,8 +15367,6 @@ Secretary may require, that includes the following:
           ‘‘(10) Other information as required by the Sec-
       retary.
 
-      HR 3590 EAS/PP
-                           578
      ‘‘(f) MAINTENANCE OF   EFFORT .—Funds provided to
 an eligible entity receiving a grant under this section shall
 supplement, and not supplant, funds from other sources for
@@ -16545,8 +15393,6 @@ early childhood home visitation programs or initiatives.
      evaluation of the statewide needs assessments sub-
      mitted under subsection (b) and the grants made
 
-      HR 3590 EAS/PP
-                            579
       under subsections (c) and (h)(3)(B). The evaluation
       shall include—
                ‘‘(A) an analysis, on a State-by-State basis,
@@ -16573,8 +15419,6 @@ early childhood home visitation programs or initiatives.
                health care system quality, efficiencies, and
                reduce costs.
 
-      HR 3590 EAS/PP
-                            580
           ‘‘(3) REPORT .—Not later than March 31, 2015,
       the Secretary shall submit a report to Congress on the
       results of the evaluation conducted under paragraph
@@ -16601,8 +15445,6 @@ early childhood home visitation programs or initiatives.
           and Evaluation of the Department of Health and
           Human Services, the Centers for Disease Control
 
-      HR 3590 EAS/PP
-                            581
           and Prevention, the National Institute of Child
           Health and Human Development of the National
           Institutes of Health, the Office of Juvenile Jus-
@@ -16629,8 +15471,6 @@ early childhood home visitation programs or initiatives.
                lar to the assessment required for all States
                under subsection (b); and
 
-      HR 3590 EAS/PP
-                            582
                     ‘‘(ii) establish quantifiable, measurable
                3- and 5-year benchmarks consistent with
                subsection (d)(1)(A).
@@ -16657,8 +15497,6 @@ early childhood home visitation programs or initiatives.
                3- and 5-year benchmarks consistent with
                subsection (d)(1)(A).
 
-      HR 3590 EAS/PP
-                            583
           ‘‘(3) ESEARCH AND OTHER EVALUATION ACTIVI     -
       TIES.—
                ‘‘(A) IN  GENERAL .—The Secretary shall
@@ -16685,8 +15523,6 @@ early childhood home visitation programs or initiatives.
           ‘‘(4) EPORT AND RECOMMENDATION     .—Not later
       than December 31, 2015, the Secretary shall submit
 
-      HR 3590 EAS/PP
-                           584
      a report to Congress regarding the programs con-
      ducted with grants under this section. The report re-
      quired under this paragraph shall include—
@@ -16713,8 +15549,6 @@ early childhood home visitation programs or initiatives.
 
 
 
-      HR 3590 EAS/PP
-                            585
                ‘‘(A) Section 504(b)(6) (relating to prohibi-
           tion on payments to excluded individuals and
           entities).
@@ -16741,8 +15575,6 @@ early childhood home visitation programs or initiatives.
                ‘‘(C) $350,000,000 for fiscal year 2012;
                ‘‘(D) $400,000,000 for fiscal year 2013; and
 
-      HR 3590 EAS/PP
-                            586
                ‘‘(E) $400,000,000 for fiscal year 2014.
           ‘‘(2) R ESERVATIONS .—Of the amount appro-
       priated under this subsection for a fiscal year, the
@@ -16769,8 +15601,6 @@ early childhood home visitation programs or initiatives.
                ‘‘(A) N GENERAL  .—The term ‘eligible enti-
           ty’ means a State, an Indian Tribe, Tribal Or-
 
-      HR 3590 EAS/PP
-                            587
           ganization, or Urban Indian Organization,
           Puerto Rico, Guam, the Virgin Islands, the
           Northern Mariana Islands, and American
@@ -16797,8 +15627,6 @@ early childhood home visitation programs or initiatives.
       terms ‘Indian Tribe’ and ‘Tribal Organization’, and
       ‘Urban Indian Organization’ have the meanings
 
-      HR 3590 EAS/PP
-                           588
      given such terms in section 4 of the Indian Health
      Care Improvement Act.’’.
  SEC. 2952. SUPPORT, EDUCATION, AND RESEARCH FOR
@@ -16825,8 +15653,6 @@ early childhood home visitation programs or initiatives.
           and diagnostic techniques.
 
 
-      HR 3590 EAS/PP
-                            589
                (D) Clinical research for the development
           and evaluation of new treatments.
                (E) Information and education programs
@@ -16853,8 +15679,6 @@ early childhood home visitation programs or initiatives.
                    sources.
 
 
-      HR 3590 EAS/PP
-                            590
           (2) SENSE OF CONGRESS REGARDING LONGITU       -
       DINAL STUDY OF RELATIVE MENTAL HEALTH CON         -
       SEQUENCES FOR WOMEN OF RESOLVING A PREG           -
@@ -16881,8 +15705,6 @@ early childhood home visitation programs or initiatives.
           of this Act, and periodically thereafter for the
           duration of the study, such Director may pre-
 
-      HR 3590 EAS/PP
-                           591
           pare and submit to the Congress reports on the
           findings of the study.
      (b) GRANTS  TO P ROVIDE SERVICES TO  INDIVIDUALS
@@ -16909,8 +15731,6 @@ may allow such projects to include the following:
           ‘‘(1) Delivering or enhancing outpatient and
      home-based health and support services, including
 
-      HR 3590 EAS/PP
-                            592
       case management and comprehensive treatment serv-
       ices.
           ‘‘(2) Delivering or enhancing inpatient care
@@ -16937,8 +15757,6 @@ may allow such projects to include the following:
                ditions before new mothers leave the health
                facility; and
 
-      HR 3590 EAS/PP
-                           593
                    ‘‘(ii) ensuring that training programs
               regarding such education are carried out at
               the health facility.
@@ -16965,8 +15783,6 @@ plying with the requirements of this section.
      apply to a grant made under this section.
 
 
-      HR 3590 EAS/PP
-                            594
           ‘‘(2) EXCEPTIONS  .—The following provisions of
       this title shall apply to a grant made under this sec-
       tion to the same extent and in the same manner as
@@ -16993,8 +15809,6 @@ plying with the requirements of this section.
           ‘‘(1) The term ‘eligible entity’—
 
 
-      HR 3590 EAS/PP
-                           595
               ‘‘(A) means a public or nonprofit private
           entity; and
               ‘‘(B) includes a State or local government,
@@ -17021,8 +15835,6 @@ plying with the requirements of this section.
 
 
 
-      HR 3590 EAS/PP
-                            596
                (A) STUDY .—The Secretary shall conduct a
           study on the benefits of screening for postpartum
           conditions.
@@ -17049,8 +15861,6 @@ by adding at the end the following:
                able for allotments to States after the appli-
                cation of subsection (c); and
 
-      HR 3590 EAS/PP
-                            597
                    ‘‘(ii) the State youth population per-
                centage determined under paragraph (2).
                ‘‘(B) INIMUM ALLOTMENT   .—
@@ -17077,8 +15887,6 @@ by adding at the end the following:
                plication shall contain an assurance that
                the State has complied with the require-
 
-      HR 3590 EAS/PP
-                            598
                ments of this section in preparing and sub-
                mitting the application and shall include
                the following as well as such additional in-
@@ -17105,8 +15913,6 @@ by adding at the end the following:
                     populations that are the most high-risk
                     or vulnerable for pregnancies or other-
 
-      HR 3590 EAS/PP
-                            599
                    wise have special circumstances, in-
                    cluding youth in foster care, homeless
                    youth, youth with HIV/AIDS, preg-
@@ -17133,8 +15939,6 @@ by adding at the end the following:
      Subject to paragraph (4)(A), amounts allotted to a
      State pursuant to this subsection for a fiscal year
 
-      HR 3590 EAS/PP
-                            600
       shall remain available for expenditure by the State
       through the end of the second succeeding fiscal year.
           ‘‘(4) UTHORITY TO AWARD GRANTS FROM STATE
@@ -17161,8 +15965,6 @@ by adding at the end the following:
                solicit applications to award 3-year grants
                in each of fiscal years 2012, 2013, and 2014
 
-      HR 3590 EAS/PP
-                            601
                to local organizations and entities to con-
                duct, consistent with subsection (b), pro-
                grams and activities in States that do not
@@ -17189,8 +15991,6 @@ by adding at the end the following:
       organization, or entity for such programs or initia-
       tives for fiscal year 2009.
 
-      HR 3590 EAS/PP
-                           602
           ‘‘(6) DATA  COLLECTION   AND  REPORTING  .—A
      State or local organization or entity receiving funds
      under this section shall cooperate with such require-
@@ -17217,8 +16017,6 @@ by adding at the end the following:
               AIDS, consistent with the requirements of
               subparagraph (B); and
 
-      HR 3590 EAS/PP
-                            603
                     ‘‘(ii) at least 3 of the adulthood prepa-
                ration subjects described in subparagraph
                (C).
@@ -17245,8 +16043,6 @@ by adding at the end the following:
                tion for the prevention of pregnancy among
                youth and sexually transmitted infections.
 
-      HR 3590 EAS/PP
-                            604
                     ‘‘(v) The program provides age-appro-
                priate information and activities.
                     ‘‘(vi) The information and activities
@@ -17273,8 +16069,6 @@ by adding at the end the following:
                such as developing skills for employment
                preparation, job seeking, independent liv-
 
-      HR 3590 EAS/PP
-                            605
                ing, financial self-sufficiency, and work-
                place productivity.
                    ‘‘(vi) Healthy life skills, such as goal-
@@ -17301,8 +16095,6 @@ by adding at the end the following:
           ‘‘(2) OTHER RESERVATIONS   .—From the amount
       appropriated under subsection (f) for the fiscal year
 
-      HR 3590 EAS/PP
-                            606
       that remains after the application of paragraph (1),
       the Secretary shall reserve the following amounts:
                ‘‘(A) RANTS FOR INDIAN TRIBES OR TRIB    -
@@ -17329,8 +16121,6 @@ by adding at the end the following:
                broad array of teen pregnancy prevention
                strategies, including abstinence and contra-
 
-      HR 3590 EAS/PP
-                            607
                ception, and developing resources and mate-
                rials to support the activities of recipients
                of grants and other State, tribal, and com-
@@ -17357,8 +16147,6 @@ by adding at the end the following:
       TITLE.—
 
 
-      HR 3590 EAS/PP
-                            608
                ‘‘(A) N GENERAL   .—Except as provided in
           subparagraph (B), the other provisions of this
           title shall not apply to allotments or grants
@@ -17385,8 +16173,6 @@ by adding at the end the following:
                     ‘‘(vi) Section 508 (relating to non-
                discrimination).
 
-      HR 3590 EAS/PP
-                            609
       ‘‘(e)EFINITIONS .—In this section:
           ‘‘(1) AGE-APPROPRIATE  .—The term ‘age-appro-
       priate’, with respect to the information in pregnancy
@@ -17413,8 +16199,6 @@ by adding at the end the following:
       1603)).
 
 
-      HR 3590 EAS/PP
-                            610
           ‘‘(4) YOUTH .—The term ‘youth’ means an indi-
       vidual who has attained age 10 but has not attained
       age 20.
@@ -17441,8 +16225,6 @@ is amended—
           tion and Affordable Care Act in the case of fiscal
           year 2010)’’ before the period.
 
-      HR 3590 EAS/PP
-                            611
  SEC. 2955. INCLUSION OF INFORMATION ABOUT THE IM-
              PORTANCE OF HAVING A HEALTH CARE
              POWER OF ATTORNEY IN TRANSITION PLAN-
@@ -17469,8 +16251,6 @@ adding at the end the following:
           under this section are provided with education
           about the importance of designating another in-
           dividual to make health care treatment decisions
-      HR 3590 EAS/PP
-                           612
           on behalf of the adolescent if the adolescent be-
           comes unable to participate in such decisions
           and the adolescent does not have, or does not
@@ -17497,8 +16277,6 @@ Section 422(b)(15)(A) of such Act (42 U.S.C.
               other similar document recognized under
               State law, and to provide the child with the
 
-      HR 3590 EAS/PP
-                         613
              option to execute such a document, are met;
              and’’.
      (d) FFECTIVE DATE.—The amendments made by this
@@ -17525,8 +16303,6 @@ section take effect on October 1, 2010.
          ceeding provisions of this subsection, the Sec-
          retary shall establish a hospital value-based pur-
 
-     HR 3590 EAS/PP
-                            614
           chasing program (in this subsection referred to
           as the ‘Program’) under which value-based in-
           centive payments are made in a fiscal year to
@@ -17553,8 +16329,6 @@ section take effect on October 1, 2010.
                     formance period for such fiscal year,
                     the Secretary has cited deficiencies that
 
-      HR 3590 EAS/PP
-                            615
                     pose immediate jeopardy to the health
                     or safety of patients;
                         ‘‘(III) for which there are not a
@@ -17581,8 +16355,6 @@ section take effect on October 1, 2010.
                such section submits an annual report to
                the Secretary describing how a similar pro-
 
-      HR 3590 EAS/PP
-                            616
                gram in the State for a participating hos-
                pital or hospitals achieves or surpasses the
                measured results in terms of patient health
@@ -17609,8 +16381,6 @@ section take effect on October 1, 2010.
                             ‘‘(bb) Heart failure.
                             ‘‘(cc) Pneumonia.
 
-      HR 3590 EAS/PP
-                            617
                              ‘‘(dd) Surgeries, as measured
                         by the Surgical Care Improve-
                         ment Project (formerly referred to
@@ -17637,8 +16407,6 @@ section take effect on October 1, 2010.
                cal year, the Secretary shall ensure that
                measures selected under subparagraph (A)
 
-      HR 3590 EAS/PP
-                            618
                include efficiency measures, including meas-
                ures of ‘Medicare spending per beneficiary’.
                Such measures shall be adjusted for factors
@@ -17665,8 +16433,6 @@ section take effect on October 1, 2010.
                furnish services appropriate to such meas-
                ure.
 
-      HR 3590 EAS/PP
-                            619
                ‘‘(D) R EPLACING   MEASURES  .—Subclause
           (VI) of subsection (b)(3)(B)(viii) shall apply to
           measures selected under subparagraph (A) in the
@@ -17693,8 +16459,6 @@ section take effect on October 1, 2010.
           graph, the Secretary shall take into account ap-
           propriate factors, such as—
 
-      HR 3590 EAS/PP
-                            620
                    ‘‘(i) practical experience with the
                measures involved, including whether a sig-
                nificant proportion of hospitals failed to
@@ -17721,8 +16485,6 @@ section take effect on October 1, 2010.
           this subsection referred to as the ‘hospital per-
 
 
-      HR 3590 EAS/PP
-                            621
           formance score’) for each hospital for each per-
           formance period.
                ‘‘(B) PPLICATION .—
@@ -17749,8 +16511,6 @@ section take effect on October 1, 2010.
                egories of measures as the Secretary deter-
                mines appropriate.
 
-      HR 3590 EAS/PP
-                            622
                    ‘‘(iv) N O  MINIMUM    PERFORMANCE
                STANDARD .—The Secretary shall not set a
                minimum performance standard in deter-
@@ -17777,8 +16537,6 @@ section take effect on October 1, 2010.
           AMOUNT  .—The value-based incentive payment
 
 
-      HR 3590 EAS/PP
-                            623
           amount for each discharge of a hospital in a fis-
           cal year shall be equal to the product of—
                    ‘‘(i) the base operating DRG payment
@@ -17805,8 +16563,6 @@ section take effect on October 1, 2010.
                    paragraph to all hospitals in such fis-
                    cal year is equal to the total amount
 
-      HR 3590 EAS/PP
-                            624
                    available for value-based incentive
                    payments for such fiscal year under
                    paragraph (7)(A), as estimated by the
@@ -17833,8 +16589,6 @@ section take effect on October 1, 2010.
                tions for all hospitals in the fiscal year in-
                volved, regardless of whether or not the hos-
 
-      HR 3590 EAS/PP
-                            625
                pital has been determined by the Secretary
                to have earned a value-based incentive pay-
                ment under paragraph (6) for such fiscal
@@ -17861,8 +16615,6 @@ section take effect on October 1, 2010.
           AMOUNT DEFINED   .—
 
 
-      HR 3590 EAS/PP
-                            626
                    ‘‘(i) N GENERAL .—Except as provided
                in clause (ii), in this subsection, the term
                ‘base operating DRG payment amount’
@@ -17889,8 +16641,6 @@ section take effect on October 1, 2010.
                    medicare-dependent, small rural hos-
                    pital (with respect to discharges occur-
 
-      HR 3590 EAS/PP
-                            627
                    ring during fiscal year 2012 and 2013)
                    or a sole community hospital, in ap-
                    plying subparagraph (A)(i), the pay-
@@ -17917,8 +16667,6 @@ section take effect on October 1, 2010.
      paragraph (6) and the payment reduction under
      paragraph (7)(B)(i) shall each apply only with re-
 
-      HR 3590 EAS/PP
-                            628
       spect to the fiscal year involved, and the Secretary
       shall not take into account such value-based incentive
       payment or payment reduction in making payments
@@ -17945,8 +16693,6 @@ section take effect on October 1, 2010.
                to review, and submit corrections for, the
                information to be made public with respect
 
-      HR 3590 EAS/PP
-                            629
                to the hospital under clause (i) prior to
                such information being made public.
                    ‘‘(iii) W EBSITE.—Such information
@@ -17973,8 +16719,6 @@ section take effect on October 1, 2010.
           ment with respect to the performance standards
           established under paragraph (3)(A) and the hos-
 
-      HR 3590 EAS/PP
-                            630
           pital performance score under paragraph (5).
           The Secretary shall ensure that such process pro-
           vides for resolution of such appeals in a timely
@@ -18001,8 +16745,6 @@ section take effect on October 1, 2010.
                selected under paragraph (2).
 
 
-      HR 3590 EAS/PP
-                            631
                    ‘‘(v) The methodology developed under
                paragraph (5) that is used to calculate hos-
                pital performance scores and the calculation
@@ -18029,8 +16771,6 @@ section take effect on October 1, 2010.
           the following sentence: ‘‘The Secretary may re-
           quire hospitals to submit data on measures that
 
-      HR 3590 EAS/PP
-                             632
            are not used for the determination of value-based
            incentive payments under subsection (o).’’;
                 (B) in subclause (V), by striking ‘‘beginning
@@ -18057,8 +16797,6 @@ sible and practical measure has not been endorsed by the
 entity with a contract under section 1890(a), the Secretary
 may specify a measure that is not so endorsed as long as
 
-      HR 3590 EAS/PP
-                             633
 due consideration is given to measures that have been en-
 dorsed or adopted by a consensus organization identified
 by the Secretary.
@@ -18085,8 +16823,6 @@ dation of measures reported by such hospital.’’.
       ‘‘(x)(I) The Secretary shall develop standard Internet
 website reports tailored to meet the needs of various stake-
 
-      HR 3590 EAS/PP
-                            634
 holders such as hospitals, patients, researchers, and policy-
 makers. The Secretary shall seek input from such stake-
 holders in determining the type of information that is useful
@@ -18113,8 +16849,6 @@ that website readily available to individuals accessing it.’’.
                tures under Part A of title XVIII of such
                Act that are attributable to the improve-
 
-      HR 3590 EAS/PP
-                            635
                ment in the delivery of inpatient hospital
                services by reason of such hospital value-
                based purchasing program;
@@ -18141,8 +16875,6 @@ that website readily available to individuals accessing it.’’.
                priate.
 
 
-      HR 3590 EAS/PP
-                           636
                    (ii) FINAL REPORT  .—Not later than
               July 1, 2017, the Comptroller General of the
               United States shall submit to Congress a re-
@@ -18169,8 +16901,6 @@ that website readily available to individuals accessing it.’’.
               under title XVIII of such Act or other fi-
               nancial savings to hospitals;
 
-      HR 3590 EAS/PP
-                           637
                   (iii) the appropriateness of the Medi-
               care program sharing in any savings gen-
               erated through the hospital value-based pur-
@@ -18197,8 +16927,6 @@ that website readily available to individuals accessing it.’’.
               ‘‘Secretary’’) shall establish a demonstration
               program under which the Secretary estab-
 
-      HR 3590 EAS/PP
-                            638
                lishes a value-based purchasing program
                under the Medicare program under title
                XVIII of the Social Security Act for critical
@@ -18225,8 +16953,6 @@ that website readily available to individuals accessing it.’’.
           may waive such requirements of titles XI and
           XVIII of the Social Security Act as may be nec-
 
-      HR 3590 EAS/PP
-                            639
           essary to carry out the demonstration program
           under this paragraph.
                (C) BUDGET NEUTRALITY REQUIREMENT     .—
@@ -18253,8 +16979,6 @@ that website readily available to individuals accessing it.’’.
           (2) VALUE -BASED PURCHASING DEMONSTRATION
      PROGRAM FOR HOSPITALS EXCLUDED FROM HOSPITAL
 
-      HR 3590 EAS/PP
-                           640
      VALUE -BASED PURCHASING PROGRAM AS A RESULT
      OF   INSUFFICIENT  NUMBERS   OF  MEASURES    AND
      CASES .—
@@ -18281,8 +17005,6 @@ that website readily available to individuals accessing it.’’.
               rity Act, as added by subsection (a)(1).
 
 
-      HR 3590 EAS/PP
-                           641
                    (iii) DURATION .—The demonstration
               program under this paragraph shall be con-
               ducted for a 3-year period.
@@ -18309,8 +17031,6 @@ that website readily available to individuals accessing it.’’.
               (D) R  EPORT .—Not later than 18 months
           after the completion of the demonstration pro-
 
-      HR 3590 EAS/PP
-                            642
           gram under this paragraph, the Secretary shall
           submit to Congress a report on the demonstra-
           tion program together with—
@@ -18337,8 +17057,6 @@ rity Act (42 U.S.C. 1395w–4(m)) is amended—
                riod at the end and inserting a semicolon;
                and
 
-      HR 3590 EAS/PP
-                            643
                     (iii) by adding at the end the following
                new clauses:
                     ‘‘(iii) for 2011, 1.0 percent; and
@@ -18365,8 +17083,6 @@ rity Act (42 U.S.C. 1395w–4(m)) is amended—
                and
 
 
-      HR 3590 EAS/PP
-                           644
                    (ii) by striking ‘‘under subparagraph
               (D)(iii) of such subsection’’ and inserting
               ‘‘under subsection (a)(5)(D)(iii) or the qual-
@@ -18393,8 +17109,6 @@ the following new paragraph:
               ment based on such amount) shall be equal
               to the applicable percent of the fee schedule
 
-      HR 3590 EAS/PP
-                            645
                amount that would otherwise apply to such
                services under this subsection (determined
                after application of paragraphs (3), (5),
@@ -18421,8 +17135,6 @@ the following new paragraph:
           paragraph:
 
 
-      HR 3590 EAS/PP
-                           646
                    ‘‘(i) ELIGIBLE PROFESSIONAL  ;  COV-
               ERED PROFESSIONAL SERVICES   .—The terms
               ‘eligible professional’ and ‘covered profes-
@@ -18449,8 +17161,6 @@ the following new paragraph:
  AND EHR R  EPORTING .—Section 1848(m) of the Social Se-
 
 
-      HR 3590 EAS/PP
-                            647
 curity Act (42 U.S.C. 1395w–4(m)) is amended by adding
 at the end the following new paragraph:
           ‘‘(7) INTEGRATION OF PHYSICIAN QUALITY RE      -
@@ -18477,8 +17187,6 @@ ing at the end the following new subparagraph:
           vide timely feedback to eligible professionals on
           the performance of the eligible professional with
 
-      HR 3590 EAS/PP
-                           648
           respect to satisfactorily submitting data on qual-
           ity measures under this subsection.’’.
      (f) APPEALS.—Such section is further amended—
@@ -18505,8 +17213,6 @@ rity Act (42 U.S.C. 1395w–4(n)) is amended—
                    ‘‘(i) E  STABLISHMENT  .—The Sec-
               retary’’;
 
-      HR 3590 EAS/PP
-                            649
                     (ii) in clause (i), as added by clause
                (i), by striking ‘‘the ‘Program’)’’ and all
                that follows through the period at the end of
@@ -18533,8 +17239,6 @@ rity Act (42 U.S.C. 1395w–4(n)) is amended—
           paragraph (A)’’ and inserting ‘‘subparagraph
           (A)(ii)’’;
 
-      HR 3590 EAS/PP
-                            650
           (2) in paragraph (4)—
                (A) in the heading, by inserting ‘INITIAL’’
           after ‘FOCUS ’’; and
@@ -18561,8 +17265,6 @@ rity Act (42 U.S.C. 1395w–4(n)) is amended—
                     ‘‘(iii)UBLIC AVAILABILITY .—The Sec-
                retary shall make the details of the episode
 
-      HR 3590 EAS/PP
-                            651
                grouper described in subparagraph (A)
                available to the public.
                     ‘‘(iv) NDORSEMENT   .—The Secretary
@@ -18589,8 +17291,6 @@ rity Act (42 U.S.C. 1395w–4(n)) is amended—
                composite measure per individual.
 
 
-      HR 3590 EAS/PP
-                            652
                ‘‘(D) DATA ADJUSTMENT  .—In preparing re-
           ports under this paragraph, the Secretary shall
           make appropriate adjustments, including adjust-
@@ -18617,8 +17317,6 @@ rity Act (42 U.S.C. 1395w–4(n)) is amended—
                ‘‘(F) DEFINITION OF PHYSICIAN   .—In this
           paragraph:
 
-      HR 3590 EAS/PP
-                            653
                    ‘‘(i) N GENERAL   .—The term ‘physi-
                cian’ has the meaning given that term in
                section 1861(r)(1).
@@ -18645,8 +17343,6 @@ by adding at the end the following new paragraph:
       GRAM .—The entity shall provide for the review and,
       as appropriate, the endorsement of the episode group-
 
-      HR 3590 EAS/PP
-                           654
      er developed by the Secretary under section
      1848(n)(9)(A). Such review shall be conducted on an
      expedited basis.’’.
@@ -18673,8 +17369,6 @@ end the following new paragraph:
               by 2 percentage points.
 
 
-      HR 3590 EAS/PP
-                            655
                    ‘‘(ii) PECIAL RULE .—The application
                of this subparagraph may result in such an-
                nual update being less than 0.0 for a rate
@@ -18701,8 +17395,6 @@ end the following new paragraph:
                    ‘‘(i) N GENERAL  .—Subject to clause
                (ii), any measure specified by the Secretary
 
-      HR 3590 EAS/PP
-                            656
                under this subparagraph must have been
                endorsed by the entity with a contract
                under section 1890(a).
@@ -18729,8 +17421,6 @@ end the following new paragraph:
           dures shall ensure that a long-term care hospital
           has the opportunity to review the data that is to
 
-      HR 3590 EAS/PP
-                           657
           be made public with respect to the hospital prior
           to such data being made public. The Secretary
           shall report quality measures that relate to serv-
@@ -18757,8 +17447,6 @@ is amended—
               paragraph (3)(C), and after application of
               paragraph (3)(D), the Secretary shall re-
 
-      HR 3590 EAS/PP
-                            658
                duce such increase factor for payments for
                discharges occurring during such fiscal year
                by 2 percentage points.
@@ -18785,8 +17473,6 @@ is amended—
           mitted in a form and manner, and at a time,
 
 
-      HR 3590 EAS/PP
-                            659
           specified by the Secretary for purposes of this
           subparagraph.
                ‘‘(D) UALITY MEASURES   .—
@@ -18813,8 +17499,6 @@ is amended—
                fiscal year 2014.
 
 
-      HR 3590 EAS/PP
-                            660
                ‘‘(E) PUBLIC AVAILABILITY OF DATA SUB   -
           MITTED .—The Secretary shall establish proce-
           dures for making data submitted under subpara-
@@ -18841,8 +17525,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
                year, in the case of a hospice program that
                does not submit data to the Secretary in ac-
 
-      HR 3590 EAS/PP
-                            661
                cordance with subparagraph (C) with re-
                spect to such a fiscal year, after deter-
                mining the market basket percentage in-
@@ -18869,8 +17551,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
           under this subsection for a subsequent fiscal
           year.
 
-      HR 3590 EAS/PP
-                            662
                ‘‘(C) SUBMISSION OF QUALITY DATA   .—For
           fiscal year 2014 and each subsequent fiscal year,
           each hospice program shall submit to the Sec-
@@ -18897,8 +17577,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
                a consensus organization identified by the
                Secretary.
 
-      HR 3590 EAS/PP
-                            663
                     ‘‘(iii) IME FRAME  .—Not later than
                October 1, 2012, the Secretary shall publish
                the measures selected under this subpara-
@@ -18925,8 +17603,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
           at the end;
 
 
-      HR 3590 EAS/PP
-                           664
               (B) in subparagraph (V), by striking the
           period at the end and inserting ‘‘, and’’; and
               (C) by adding at the end the following new
@@ -18953,8 +17629,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
           ‘‘(3) UALITY MEASURES  .—
 
 
-      HR 3590 EAS/PP
-                            665
                ‘‘(A) IN  GENERAL  .—Subject to subpara-
           graph (B), any measure specified by the Sec-
           retary under this paragraph must have been en-
@@ -18981,8 +17655,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
       the opportunity to review the data that is to be made
       public with respect to the hospital prior to such data
 
-      HR 3590 EAS/PP
-                           666
      being made public. The Secretary shall report quality
      measures of process, structure, outcome, patients’ per-
      spective on care, efficiency, and costs of care that re-
@@ -19009,8 +17681,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
           under section 1890 of the Social Security Act (42
           U.S.C. 1395aaa) and section 1890A such Act, as
 
-      HR 3590 EAS/PP
-                            667
           added by section 3014), to the extent feasible and
           practicable, of all dimensions of quality and effi-
           ciency in skilled nursing facilities.
@@ -19037,8 +17707,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
           thresholds or improvements in quality that
           would substantiate a payment adjustment, the
 
-      HR 3590 EAS/PP
-                           668
           size of such payments, and the sources of funding
           for the value-based bonus payments.
               (D) Methods for the public disclosure of in-
@@ -19065,8 +17733,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
      value-based purchasing program for payments under
      the Medicare program under title XVIII of the Social
 
-      HR 3590 EAS/PP
-                            669
       Security Act for home health agencies (as defined in
       section 1861(o) of such Act (42 U.S.C. 1395x(o))).
           (2) D ETAILS .—In developing the plan under
@@ -19093,8 +17759,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
                (E) Any other issues determined appro-
           priate by the Secretary.
 
-      HR 3590 EAS/PP
-                           670
           (3) C ONSULTATION .—In developing the plan
      under paragraph (1), the Secretary shall—
               (A) consult with relevant affected parties;
@@ -19121,8 +17785,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
      a payment modifier that provides for differential
      payment to a physician or a group of physicians
 
-      HR 3590 EAS/PP
-                            671
       under the fee schedule established under subsection (b)
       based upon the quality of care furnished compared to
       cost (as determined under paragraphs (2) and (3), re-
@@ -19149,8 +17811,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
                ment of the measures established under this
 
 
-      HR 3590 EAS/PP
-                            672
                subparagraph by the entity with a contract
                under section 1890(a).
           ‘‘(3) COSTS .—For purposes of paragraph (1),
@@ -19177,8 +17837,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
 
 
 
-      HR 3590 EAS/PP
-                            673
                    ‘‘(ii) The dates for implementation of
                the payment modifier (as determined under
                subparagraph (B)).
@@ -19205,8 +17863,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
                    period, the Secretary shall, to the ex-
                    tent practicable, provide information
 
-      HR 3590 EAS/PP
-                            674
                     to physicians and groups of physicians
                     about the quality of care furnished by
                     the physician or group of physicians to
@@ -19233,8 +17889,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
       tablished under this subsection in a manner that pro-
       motes systems-based care.
 
-      HR 3590 EAS/PP
-                            675
           ‘‘(6) C  ONSIDERATION     OF    SPECIAL   CIR  -
       CUMSTANCES OF CERTAIN PROVIDERS      .—In applying
       the payment modifier under this subsection, the Sec-
@@ -19261,8 +17915,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
           growth in expenditures per individual for a phy-
 
 
-      HR 3590 EAS/PP
-                            676
           sician compared to the amount of such growth
           for other physicians.
                ‘‘(B) P ERFORMANCE    PERIOD .—The term
@@ -19289,8 +17941,6 @@ cial Security Act (42 U.S.C. 1395f(i)) is amended—
           priate measures of costs under such paragraph;
 
 
-      HR 3590 EAS/PP
-                           677
               ‘‘(D) the dates for implementation of the
           value-based payment modifier;
               ‘‘(E) the specification of the initial perform-
@@ -19317,8 +17967,6 @@ amended by adding at the end the following new subsection:
      1814(b)(3), as applicable, for such discharges during
      the fiscal year shall be equal to 99 percent of the
 
-      HR 3590 EAS/PP
-                            678
       amount of payment that would otherwise apply to
       such discharges under this section or section
       1814(b)(3) (determined after the application of sub-
@@ -19345,8 +17993,6 @@ amended by adding at the end the following new subsection:
                ‘‘(C) XEMPTION  .—In the case of a hospital
           that is paid under section 1814(b)(3), the Sec-
 
-      HR 3590 EAS/PP
-                            679
           retary may exempt such hospital from the appli-
           cation of this subsection if the State which is
           paid under such section submits an annual re-
@@ -19373,8 +18019,6 @@ amended by adding at the end the following new subsection:
       of the applicable hospital during the applicable pe-
       riod.
 
-      HR 3590 EAS/PP
-                            680
           ‘‘(6) REPORTING HOSPITAL SPECIFIC INFORMA     -
       TION.—
                ‘‘(A) IN  GENERAL .—The Secretary shall
@@ -19401,8 +18045,6 @@ amended by adding at the end the following new subsection:
                ‘‘(C) The specification of the applicable pe-
           riod under paragraph (4).
 
-      HR 3590 EAS/PP
-                          681
               ‘‘(D) The provision of reports to applicable
          hospitals under paragraph (5) and the informa-
          tion made available to the public under para-
@@ -19429,8 +18071,6 @@ amended by adding at the end the following new subsection:
      under the Medicare program.
 
 
-      HR 3590 EAS/PP
-                           682
           (2) REPORT.—Not later than January 1, 2012,
      the Secretary shall submit to Congress a report con-
      taining the results of the study conducted under para-
@@ -19457,8 +18097,6 @@ amended by adding at the end the following new subsection:
           ‘‘(2)DENTIFICATION OF PRIORITIES.—
 
 
-      HR 3590 EAS/PP
-                            683
                ‘‘(A) IN  GENERAL  .—The Secretary shall
           identify national priorities for improvement in
           developing the strategy under paragraph (1).
@@ -19485,8 +18123,6 @@ amended by adding at the end the following new subsection:
                parency, and outcomes;
 
 
-      HR 3590 EAS/PP
-                            684
                     ‘‘(vi) address the health care provided
                to patients with high-cost chronic diseases;
                     ‘‘(vii) improve research and dissemina-
@@ -19513,8 +18149,6 @@ amended by adding at the end the following new subsection:
           Children’s Health Insurance Program under title
           XXI of such Act with respect to developing and
 
-      HR 3590 EAS/PP
-                            685
           disseminating strategies, goals, models, and
           timetables that are consistent with the national
           priorities identified under subparagraph (A).
@@ -19541,8 +18175,6 @@ amended by adding at the end the following new subsection:
 
 
 
-      HR 3590 EAS/PP
-                           686
               ‘‘(D) A process for regular reporting by the
           agencies to the Secretary on the implementation
           of the strategic plan.
@@ -19569,8 +18201,6 @@ short- and long-term goals.
               ‘‘(A) IN GENERAL  .—The Secretary shall
           submit to the relevant committees of Congress an
 
-      HR 3590 EAS/PP
-                            687
           annual update to the strategy described in para-
           graph (1).
                ‘‘(B) NFORMATION SUBMITTED    .—Each up-
@@ -19597,8 +18227,6 @@ short- and long-term goals.
           ments of clauses (iii) and (iv) of subparagraph
           (B) shall satisfy the reporting requirements
 
-      HR 3590 EAS/PP
-                           688
           under sections 1139A(a)(6) and 1139B(b)(4), re-
           spectively, of the Social Security Act.
      ‘‘(e) EALTH  C ARE Q UALITY INTERNET  W EBSITE.—
@@ -19625,8 +18253,6 @@ to achieve the following:
      goals, models, and timetables that are consistent with
      the national priorities identified under section
 
-      HR 3590 EAS/PP
-                            689
       399HH(a)(2) of the Public Health Service Act (as
       added by section 3011).
           (2) Avoidance of inefficient duplication of qual-
@@ -19653,8 +18279,6 @@ to achieve the following:
                (H) the Office of the National Coordinator
           for Health Information Technology;
 
-      HR 3590 EAS/PP
-                            690
                (I) the Substance Abuse and Mental Health
           Services Administration;
                (J) the Administration for Children and
@@ -19681,8 +18305,6 @@ to achieve the following:
           the President.
           (2) CHAIR AND VICE -CHAIR.—
 
-      HR 3590 EAS/PP
-                           691
               (A) C HAIR.—The Working Group shall be
           chaired by the Secretary of Health and Human
           Services.
@@ -19709,8 +18331,6 @@ ed—
           (4) by inserting after section 926 the following:
 
 
-      HR 3590 EAS/PP
-                           692
  ‘‘PART D—HEALTH CARE QUALITY IMPROVEMENT
        ‘‘Subpart I—Quality Measure Development
  ‘‘SEC. 931. QUALITY MEASURE DEVELOPMENT.
@@ -19737,8 +18357,6 @@ the delivery of health care services.
           Security Act and other stakeholders;
 
 
-      HR 3590 EAS/PP
-                           693
               ‘‘(B) quality measures identified by the pe-
           diatric quality measures program under section
           1139A of the Social Security Act; and
@@ -19765,8 +18383,6 @@ the delivery of health care services.
           of patients;
 
 
-      HR 3590 EAS/PP
-                            694
                ‘‘(B) the management and coordination of
           health care across episodes of care and care tran-
           sitions for patients across the continuum of pro-
@@ -19793,8 +18409,6 @@ the delivery of health care services.
           methodologies identified under section 933; and
 
 
-      HR 3590 EAS/PP
-                            695
                ‘‘(J) other areas determined appropriate by
           the Secretary.
           ‘‘(3) ELIGIBLE ENTITIES  .—To be eligible for a
@@ -19821,8 +18435,6 @@ the delivery of health care services.
           entity with a contract under such section
           1890(a);
 
-      HR 3590 EAS/PP
-                            696
                ‘‘(D) have transparent policies regarding
           governance and conflicts of interest; and
                ‘‘(E) submit an application to the Secretary
@@ -19849,8 +18461,6 @@ the delivery of health care services.
           to users of such measure.
 
 
-      HR 3590 EAS/PP
-                           697
               ‘‘(E) Each quality measure is publicly
           available on an Internet website.
      ‘‘(d) OTHER  ACTIVITIES BY THE   SECRETARY  .—The
@@ -19877,8 +18487,6 @@ Healthcare Research and Quality.’’.
 priated to the Secretary of Health and Human Services to
 carry out this section, $75,000,000 for each of fiscal years
 
-      HR 3590 EAS/PP
-                           698
 2010 through 2014. Of the amounts appropriated under the
 preceding sentence in a fiscal year, not less than 50 percent
 of such amounts shall be used pursuant to subsection (e)
@@ -19905,8 +18513,6 @@ year shall remain available until expended.
                        ‘‘(II) such measures that have not
                    been considered for endorsement by
 
-      HR 3590 EAS/PP
-                            699
                    such entity but are used or proposed to
                    be used by the Secretary for the collec-
                    tion or reporting of quality measures;
@@ -19933,8 +18539,6 @@ year shall remain available until expended.
                    and
 
 
-      HR 3590 EAS/PP
-                            700
                         ‘‘(III) for use in health care pro-
                    grams other than for use under this
                    Act.
@@ -19961,8 +18565,6 @@ year shall remain available until expended.
                (i) shall ensure that the selection of rep-
                resentatives comprising such groups pro-
 
-      HR 3590 EAS/PP
-                            701
                vides for public nominations for, and the
                opportunity for public comment on, such se-
                lection.
@@ -19989,8 +18591,6 @@ year shall remain available until expended.
           clauses:
 
 
-      HR 3590 EAS/PP
-                           702
                    ‘‘(iv) gaps in endorsed quality meas-
               ures, which shall include measures that are
               within priority areas identified by the Sec-
@@ -20017,8 +18617,6 @@ ing after section 1890 the following:
  INTO SELECTION OF  Q UALITY M EASURES .—The Secretary
 shall establish a pre-rulemaking process under which the
 
-      HR 3590 EAS/PP
-                            703
 following steps occur with respect to the selection of quality
 measures described in section 1890(b)(7)(B):
           ‘‘(1) NPUT .—Pursuant to section 1890(b)(7), the
@@ -20045,8 +18643,6 @@ measures described in section 1890(b)(7)(B):
       the entity with a contract under section 1890 and
       measures that have not been endorsed by such entity.
 
-      HR 3590 EAS/PP
-                           704
           ‘‘(5) ATIONALE FOR USE OF QUALITY MEAS      -
      URES .—The Secretary shall publish in the Federal
      Register the rationale for the use of any quality meas-
@@ -20073,8 +18669,6 @@ measures described in section 1890(b)(7)(B):
           nation determined appropriate by the Secretary.
 
 
-      HR 3590 EAS/PP
-                           705
               ‘‘(B) The dissemination of such quality
           measures through the national strategy developed
           under section 399HH of the Public Health Serv-
@@ -20101,8 +18695,6 @@ measures described in section 1890(b)(7)(B):
               ‘‘(A) seek to avoid duplication of measures
           used; and
 
-      HR 3590 EAS/PP
-                             706
                ‘‘(B) take into consideration current inno-
            vative methodologies and strategies for quality
            improvement practices in the delivery of health
@@ -20129,8 +18721,6 @@ until expended.
 
 
 
-      HR 3590 EAS/PP
-                           707
  SEC. 3015. DATA COLLECTION; PUBLIC REPORTING.
      Title III of the Public Health Service Act (42 U.S.C.
 241 et seq.), as amended by section 3011, is further amend-
@@ -20157,8 +18747,6 @@ providers, and geographic areas over time.
      grant or contract under this subsection, an entity
      shall—
               ‘‘(A) be—
-      HR 3590 EAS/PP
-                            708
                     ‘‘(i) a multi-stakeholder entity that co-
                ordinates the development of methods and
                implementation plans for the consistent re-
@@ -20185,8 +18773,6 @@ providers, and geographic areas over time.
                ‘‘(D) agree to report, as determined by the
           Secretary, measures on quality and resource use
 
-      HR 3590 EAS/PP
-                            709
           to the public in accordance with the public re-
           porting process established under section 399JJ.
       ‘‘(c) ONSISTENT   D ATA  A GGREGATION  .—The Sec-
@@ -20213,8 +18799,6 @@ such sums as may be necessary for fiscal years 2010 through
 
 
 
-      HR 3590 EAS/PP
-                            710
  ‘‘SEC. 399JJ. PUBLIC REPORTING OF PERFORMANCE INFOR-
              MATION.
      ‘‘(a) DEVELOPMENT OF    PERFORMANCE   W EBSITES .—
@@ -20241,8 +18825,6 @@ different clinical conditions.
      Act, and other entities, as appropriate, to determine
      the type of information that is useful to stakeholders
 
-      HR 3590 EAS/PP
-                            711
       and the format that best facilitates use of the reports
       and of performance reporting Internet websites.
           ‘‘(2) CONSULTATION WITH STAKEHOLDERS     .—The
@@ -20269,8 +18851,6 @@ such sums as may be necessary for fiscal years 2010 through
 
 
 
-      HR 3590 EAS/PP
-                           712
  PART III—ENCOURAGING DEVELOPMENT OF NEW
                PATIENT CARE MODELS
  SEC. 3021. ESTABLISHMENT OF CENTER FOR MEDICARE
@@ -20297,8 +18877,6 @@ new section:
      (4)(A).
 
 
-      HR 3590 EAS/PP
-                            713
           ‘‘(2) D EADLINE .—The Secretary shall ensure
       that the CMI is carrying out the duties described in
       this section by not later than January 1, 2011.
@@ -20325,8 +18903,6 @@ new section:
           cable title’ means title XVIII, title XIX, or both.
       ‘‘(b)ESTING OF  M ODELS (PHASE  I).—
 
-      HR 3590 EAS/PP
-                            714
           ‘‘(1) N GENERAL  .—The CMI shall test payment
       and service delivery models in accordance with selec-
       tion criteria under paragraph (2) to determine the ef-
@@ -20353,8 +18929,6 @@ new section:
                patient-centered medical home models for
                high-need applicable individuals, medical
 
-      HR 3590 EAS/PP
-                            715
                homes that address women’s unique health
                care needs, and models that transition pri-
                mary care practices away from fee-for-serv-
@@ -20381,8 +18955,6 @@ new section:
                that transition health care providers away
 
 
-      HR 3590 EAS/PP
-                            716
                from fee-for-service based reimbursement
                and toward salary-based payment.
                     ‘‘(v) Supporting care coordination for
@@ -20409,8 +18981,6 @@ new section:
                ical homes by assisting the primary care
                practitioner in chronic care management,
 
-      HR 3590 EAS/PP
-                            717
                including patient self-management, activi-
                ties.
                     ‘‘(ix) Assisting applicable individuals
@@ -20437,8 +19007,6 @@ new section:
                evidence-based guidelines of cancer care
                with payment incentives under title XVIII
 
-      HR 3590 EAS/PP
-                            718
                in the areas of treatment planning and fol-
                low-up care planning for applicable indi-
                viduals described in clause (i) or (iii) of
@@ -20465,8 +19033,6 @@ new section:
                         ‘‘(II) implementing such best
                     practices and proven care methods
 
-      HR 3590 EAS/PP
-                            719
                     within such institutions to demonstrate
                     further improvements in quality and
                     efficiency; and
@@ -20493,8 +19059,6 @@ new section:
                sional who has the authority to furnish the
                service under existing State law.
 
-      HR 3590 EAS/PP
-                            720
                     ‘‘(xviii) Establishing comprehensive
                payments to Healthcare Innovation Zones,
                consisting of groups of providers that in-
@@ -20521,8 +19085,6 @@ new section:
                applicable individual, at the center of the
                care team of the applicable individual.
 
-      HR 3590 EAS/PP
-                            721
                     ‘‘(iii) Whether the model provides for
                in-person contact with applicable individ-
                uals.
@@ -20549,8 +19111,6 @@ new section:
           ‘‘(3) BUDGET NEUTRALITY  .—
 
 
-      HR 3590 EAS/PP
-                            722
                ‘‘(A) NITIAL PERIOD .—The Secretary shall
           not require, as a condition for testing a model
           under paragraph (1), that the design of such
@@ -20577,8 +19137,6 @@ new section:
                reduce spending.
 
 
-      HR 3590 EAS/PP
-                            723
           Such termination may occur at any time after
           such testing has begun and before completion of
           the testing.
@@ -20605,8 +19163,6 @@ new section:
           els.
 
 
-      HR 3590 EAS/PP
-                            724
      ‘‘(c) EXPANSION OF   M ODELS  (P HASE  II).—Taking
 into account the evaluation under subsection (b)(4), the Sec-
 retary may, through rulemaking, expand (including imple-
@@ -20633,8 +19189,6 @@ tent determined appropriate by the Secretary, if—
      testing models described in subsection (b).
 
 
-      HR 3590 EAS/PP
-                            725
           ‘‘(2) LIMITATIONS ON REVIEW   .—There shall be
       no administrative or judicial review under section
       1869, section 1878, or otherwise of—
@@ -20661,8 +19215,6 @@ tent determined appropriate by the Secretary, if—
       under this section.
 
 
-      HR 3590 EAS/PP
-                            726
       ‘‘(e) PPLICATION TO  CHIP.—The Center may carry
 out activities under this section with respect to title XXI
 in the same manner as provided under this section with
@@ -20689,8 +19241,6 @@ respect to the program under the applicable titles.
       paragraph (1), not less than $25,000,000 shall be
 
 
-      HR 3590 EAS/PP
-                            727
       made available each such fiscal year to design, imple-
       ment, and evaluate models under subsection (b).
       ‘‘(g) EPORT TO  CONGRESS  .—Beginning in 2012, and
@@ -20717,8 +19267,6 @@ as amended by section 8002(b), is amended—
           (3) by inserting after paragraph (82) the fol-
       lowing new paragraph:
 
-      HR 3590 EAS/PP
-                           728
           ‘‘(83) provide for implementation of the payment
      models specified by the Secretary under section
      1115A(c) for implementation on a nationwide basis
@@ -20745,8 +19293,6 @@ section:
      redesigned care processes for high quality and effi-
      cient service delivery. Under such program—
 
-      HR 3590 EAS/PP
-                            729
                ‘‘(A) groups of providers of services and
           suppliers meeting criteria specified by the Sec-
           retary may work together to manage and coordi-
@@ -20773,8 +19319,6 @@ section:
                ‘‘(C) Partnerships or joint venture arrange-
           ments between hospitals and ACO professionals.
 
-      HR 3590 EAS/PP
-                            730
                ‘‘(D) Hospitals employing ACO profes-
           sionals.
                ‘‘(E) Such other groups of providers of serv-
@@ -20801,8 +19345,6 @@ section:
           number of Medicare fee-for-service beneficiaries
           assigned to the ACO under subsection (c). At a
 
-      HR 3590 EAS/PP
-                            731
           minimum, the ACO shall have at least 5,000
           such beneficiaries assigned to it under subsection
           (c) in order to be eligible to participate in the
@@ -20829,8 +19371,6 @@ section:
           retary that it meets patient-centeredness criteria
           specified by the Secretary, such as the use of pa-
 
-      HR 3590 EAS/PP
-                            732
           tient and caregiver assessments or the use of in-
           dividualized care plans.
           ‘‘(3) UALITY AND OTHER REPORTING REQUIRE      -
@@ -20857,8 +19397,6 @@ section:
           Secretary determines appropriate.
 
 
-      HR 3590 EAS/PP
-                            733
                ‘‘(C) Q  UALITY   PERFORMANCE     STAND  -
           ARDS .—The Secretary shall establish quality
           performance standards to assess the quality of
@@ -20885,8 +19423,6 @@ section:
           ‘‘(4) NO  DUPLICATION   IN  PARTICIPATION  IN
       SHARED SAVINGS PROGRAMS    .—A provider of services
 
-      HR 3590 EAS/PP
-                           734
      or supplier that participates in any of the following
      shall not be eligible to participate in an ACO under
      this section:
@@ -20913,8 +19449,6 @@ fessional described in subsection (h)(1)(A).
           would otherwise be made except that a partici-
 
 
-      HR 3590 EAS/PP
-                            735
           pating ACO is eligible to receive payment for
           shared savings under paragraph (2) if—
                    ‘‘(i) the ACO meets quality perform-
@@ -20941,8 +19475,6 @@ fessional described in subsection (h)(1)(A).
                title, based upon the number of Medicare
 
 
-      HR 3590 EAS/PP
-                            736
                fee-for-service beneficiaries assigned to an
                ACO.
                    ‘‘(ii) STABLISH AND UPDATE BENCH     -
@@ -20969,8 +19501,6 @@ fessional described in subsection (h)(1)(A).
       under paragraph (1), a percent (as determined appro-
       priate by the Secretary) of the difference between such
 
-      HR 3590 EAS/PP
-                            737
       estimated average per capita Medicare expenditures
       in a year, adjusted for beneficiary characteristics,
       under the ACO and such benchmark for the ACO may
@@ -20997,8 +19527,6 @@ XVIII of this Act as may be necessary to carry out the pro-
 visions of this section.
 
 
-      HR 3590 EAS/PP
-                            738
       ‘‘(g) IMITATIONS ON  REVIEW .—There shall be no ad-
 ministrative or judicial review under section 1869, section
 1878, or otherwise of—
@@ -21025,8 +19553,6 @@ ministrative or judicial review under section 1869, section
       (d)(4).
       ‘‘(h) EFINITIONS.—In this section:
 
-      HR 3590 EAS/PP
-                            739
           ‘‘(1) ACO  PROFESSIONAL  .—The term ‘ACO pro-
       fessional’ means—
                ‘‘(A) a physician (as defined in section
@@ -21053,8 +19579,6 @@ the following new section:
           ‘‘(1) N GENERAL  .—The Secretary shall establish
       a pilot program for integrated care during an episode
       of care provided to an applicable beneficiary around
-      HR 3590 EAS/PP
-                            740
       a hospitalization in order to improve the coordina-
       tion, quality, and efficiency of health care services
       under this title.
@@ -21081,8 +19605,6 @@ the following new section:
                include a mix of surgical and medical con-
                ditions.
 
-      HR 3590 EAS/PP
-                            741
                     ‘‘(iii) Whether a condition is one for
                which there is evidence of an opportunity
                for providers of services and suppliers to
@@ -21109,8 +19631,6 @@ the following new section:
                and outside of an acute care hospital set-
                ting.
 
-      HR 3590 EAS/PP
-                            742
                     ‘‘(iii) Outpatient hospital services, in-
                cluding emergency department services.
                     ‘‘(iv) Post-acute care services, includ-
@@ -21137,8 +19657,6 @@ the following new section:
                     from such hospital.
 
 
-      HR 3590 EAS/PP
-                            743
                    ‘‘(ii) STABLISHMENT OF PERIOD BY
                THE SECRETARY  .—The Secretary, as appro-
                priate, may establish a period (other than
@@ -21165,8 +19683,6 @@ the following new section:
           ‘‘(1) DETERMINATION OF PATIENT ASSESSMENT
      INSTRUMENT  .—The Secretary shall determine which
 
-      HR 3590 EAS/PP
-                            744
       patient assessment instrument (such as the Con-
       tinuity Assessment Record and Evaluation (CARE)
       tool) shall be used under the pilot program to evaluate
@@ -21193,8 +19709,6 @@ the following new section:
           DURES  .—The Secretary shall ensure that the de-
           velopment of quality measures under subpara-
 
-      HR 3590 EAS/PP
-                            745
           graph (A) is done in a manner that is consistent
           with the measures developed and endorsed under
           section 1890 and 1890A that are applicable to
@@ -21221,8 +19735,6 @@ the following new section:
           hospital, a physician group, a skilled nursing fa-
           cility, and a home health agency, who are other-
 
-      HR 3590 EAS/PP
-                            746
           wise participating under this title, may submit
           an application to the Secretary to provide appli-
           cable services to applicable individuals under
@@ -21249,8 +19761,6 @@ the following new section:
                for applicable items and services under this
                title (including payment for services de-
 
-      HR 3590 EAS/PP
-                            747
                scribed in subparagraph (B)) for applicable
                beneficiaries for a year shall be established
                in a manner that does not result in spend-
@@ -21277,8 +19787,6 @@ the following new section:
                    care (as determined by the Secretary);
                    and
 
-      HR 3590 EAS/PP
-                            748
                         ‘‘(II) be made to the entity which
                    is participating in the pilot program.
                    ‘‘(ii) EQUIREMENT FOR PROVISION OF
@@ -21305,8 +19813,6 @@ the following new section:
           measures of the following:
                    ‘‘(i) Functional status improvement.
 
-      HR 3590 EAS/PP
-                            749
                     ‘‘(ii) Reducing rates of avoidable hos-
                pital readmissions.
                     ‘‘(iii) Rates of discharge to the commu-
@@ -21333,8 +19839,6 @@ the following new section:
                     ‘‘(ii) UBMISSION OF DATA THROUGH
                ELECTRONIC HEALTH RECORD     .—To the ex-
 
-      HR 3590 EAS/PP
-                           750
               tent practicable, the Secretary shall specify
               that data on measures be submitted under
               clause (i) through the use of an qualified
@@ -21361,8 +19865,6 @@ out the pilot program.
               ‘‘(A) NTERIM REPORT   .—Not later than 2
           years after the implementation of the pilot pro-
 
-      HR 3590 EAS/PP
-                            751
           gram, the Secretary shall submit to Congress a
           report on the initial results of the independent
           evaluation conducted under paragraph (1).
@@ -21389,8 +19891,6 @@ ices provided by such hospitals.
       care and reducing spending under this title.
 
 
-      HR 3590 EAS/PP
-                            752
       ‘‘(h) DMINISTRATION .—Chapter 35 of title 44, United
 States Code, shall not apply to the selection, testing, and
 evaluation of models or the expansion of such models under
@@ -21417,8 +19917,6 @@ the following new section:
       graph (1), which is accountable for providing com-
       prehensive, coordinated, continuous, and accessible
       care to high-need populations at home and coordi-
-      HR 3590 EAS/PP
-                           753
      nating health care across all treatment settings, re-
      sults in—
               ‘‘(A) reducing preventable hospitalizations;
@@ -21445,8 +19943,6 @@ the following new section:
               physicians and nurse practitioners that
               provides care as part of a team that in-
 
-      HR 3590 EAS/PP
-                            754
                cludes physicians, nurses, physician assist-
                ants, pharmacists, and other health and so-
                cial services staff as appropriate who have
@@ -21473,8 +19969,6 @@ the following new section:
                with the Secretary;
 
 
-      HR 3590 EAS/PP
-                            755
                     ‘‘(vi) uses electronic health information
                systems, remote monitoring, and mobile di-
                agnostic technology; and
@@ -21501,8 +19995,6 @@ the following new section:
       AND PHYSICIAN ASSISTANTS  .—Nothing in this section
       shall be construed to prevent a nurse practitioner or
 
-      HR 3590 EAS/PP
-                            756
       physician assistant from participating in, or leading,
       a home-based primary care team as part of an inde-
       pendence at home medical practice if—
@@ -21529,8 +20021,6 @@ the following new section:
       The Secretary shall develop quality performance
 
 
-      HR 3590 EAS/PP
-                           757
      standards for independence at home medical practices
      participating in the demonstration program.
      ‘‘(c) AYMENT  M ETHODOLOGY  .—
@@ -21557,8 +20047,6 @@ the following new section:
      at home medical practice is eligible to receive an in-
      centive payment under this section if actual expendi-
 
-      HR 3590 EAS/PP
-                            758
       tures for a year for the applicable beneficiaries it en-
       rolls are less than the estimated spending target estab-
       lished under paragraph (1) for such year. An incen-
@@ -21585,8 +20073,6 @@ the following new section:
           designated by the Secretary, chronic obstructive
           pulmonary disease, ischemic heart disease,
 
-      HR 3590 EAS/PP
-                            759
           stroke, Alzheimer’s Disease and
           neurodegenerative diseases, and other diseases
           and conditions designated by the Secretary
@@ -21613,8 +20099,6 @@ the following new section:
       beneficiary access to services covered under this title
       and applicable beneficiaries shall not be required to
 
-      HR 3590 EAS/PP
-                            760
       relinquish access to any benefit under this title as a
       condition of receiving services from an independence
       at home medical practice.
@@ -21641,8 +20125,6 @@ the following new section:
           try;
 
 
-      HR 3590 EAS/PP
-                            761
                ‘‘(B) have experience in furnishing health
           care services to applicable beneficiaries in the
           home; and
@@ -21669,8 +20151,6 @@ the following new section:
      achieved the results described in subsection (a).
 
 
-      HR 3590 EAS/PP
-                             762
            ‘‘(2) M   ONITORING     APPLICABLE      BENE  -
       FICIARIES.—The Secretary may monitor data on ex-
       penditures and quality of services under this title
@@ -21697,8 +20177,6 @@ Federal Supplementary Medical Insurance Trust Fund
 under section 1841 (in proportions determined appropriate
 by the Secretary) $5,000,000 for each of fiscal years 2010
 
-      HR 3590 EAS/PP
-                           763
 through 2015. Amounts transferred under this subsection
 for a fiscal year shall be available until expended.
      ‘‘(i) ERMINATION .—
@@ -21725,8 +20203,6 @@ subsection:
      ‘‘(q) H OSPITAL  READMISSIONS   R EDUCTION   PRO-
  GRAM .—
 
-      HR 3590 EAS/PP
-                            764
           ‘‘(1) N GENERAL  .—With respect to payment for
       discharges from an applicable hospital (as defined in
       paragraph (5)(C)) occurring during a fiscal year be-
@@ -21753,8 +20229,6 @@ subsection:
                termined without regard to subsection (o))
 
 
-      HR 3590 EAS/PP
-                            765
                for a discharge if this subsection did not
                apply; reduced by
                     ‘‘(ii) any portion of such payment
@@ -21781,8 +20255,6 @@ subsection:
                exempt such hospitals provided that States
                paid under such section submit an annual
 
-      HR 3590 EAS/PP
-                            766
                report to the Secretary describing how a
                similar program in the State for a partici-
                pating hospital or hospitals achieves or sur-
@@ -21809,8 +20281,6 @@ subsection:
                pital for the applicable period; and
 
 
-      HR 3590 EAS/PP
-                            767
                     ‘‘(ii) the aggregate payments for all
                discharges (as defined in paragraph (4)(B))
                with respect to such applicable hospital for
@@ -21837,8 +20307,6 @@ subsection:
 
 
 
-      HR 3590 EAS/PP
-                            768
                     ‘‘(ii) the number of admissions for such
                condition for such hospital for such applica-
                ble period; and
@@ -21865,8 +20333,6 @@ subsection:
                     been endorsed under paragraph
                     (5)(A)(ii)(I), for an applicable hospital
 
-      HR 3590 EAS/PP
-                            769
                     for such condition with respect to such
                     applicable period; to
                         ‘‘(II) the risk adjusted expected re-
@@ -21893,8 +20359,6 @@ subsection:
                     ‘‘(i) readmissions (as defined in sub-
                paragraph (E)) that represent conditions or
 
-      HR 3590 EAS/PP
-                            770
                procedures that are high volume or high ex-
                penditures under this title (or other criteria
                specified by the Secretary); and
@@ -21921,8 +20385,6 @@ subsection:
           priate by the Secretary. In expanding such ap-
           plicable conditions, the Secretary shall seek the
 
-      HR 3590 EAS/PP
-                            771
           endorsement described in subparagraph
           (A)(ii)(I) but may apply such measures without
           such an endorsement in the case of a specified
@@ -21949,8 +20411,6 @@ subsection:
           charge. Insofar as the discharge relates to an ap-
           plicable condition for which there is an endorsed
 
-      HR 3590 EAS/PP
-                            772
           measure described in subparagraph (A)(ii)(I),
           such time period (such as 30 days) shall be con-
           sistent with the time period specified for such
@@ -21977,8 +20437,6 @@ subsection:
                ‘‘(A) The determination of base operating
           DRG payment amounts.
 
-      HR 3590 EAS/PP
-                            773
                ‘‘(B) The methodology for determining the
           adjustment factor under paragraph (3), includ-
           ing excess readmissions ratio under paragraph
@@ -22005,8 +20463,6 @@ subsection:
                ‘‘(B) OSTING OF HOSPITAL SPECIFIC ALL
           PATIENT READMISSION RATES    .—The Secretary
 
-      HR 3590 EAS/PP
-                            774
           shall make information on all patient readmis-
           sion rates calculated under subparagraph (A)
           available on the CMS Hospital Compare website
@@ -22033,8 +20489,6 @@ subsection:
                hospital, by a state or an entity determined
                appropriate by the Secretary.
 
-      HR 3590 EAS/PP
-                            775
                ‘‘(D) DEFINITIONS .—For purposes of this
           paragraph:
                    ‘‘(i) The term ‘all patients’ means pa-
@@ -22061,8 +20515,6 @@ further amended by adding at the end the following:
       to improve their readmission rates through the use of
 
 
-      HR 3590 EAS/PP
-                            776
       patient safety organizations (as defined in section
       921(4)).
           ‘‘(2) ELIGIBLE  HOSPITAL   DEFINED  .—In this
@@ -22089,8 +20541,6 @@ processes on readmission rates.’’.
 Community-Based Care Transitions Program under which
 the Secretary provides funding to eligible entities that fur-
 
-      HR 3590 EAS/PP
-                            777
 nish improved care transition services to high-risk Medicare
 beneficiaries.
       (b) DEFINITIONS.—In this section:
@@ -22117,8 +20567,6 @@ beneficiaries.
       archical condition category score, as determined by
       the Secretary, based on a diagnosis of multiple chron-
 
-      HR 3590 EAS/PP
-                            778
      ic conditions or other risk factors associated with a
      hospital readmission or substandard transition into
      post-hospitalization care, which may include 1 or
@@ -22145,8 +20593,6 @@ beneficiaries.
           (1) DURATION .—
 
 
-      HR 3590 EAS/PP
-                            779
                (A) IN GENERAL   .—The program shall be
           conducted for a 5-year period, beginning Janu-
           ary 1, 2011.
@@ -22173,8 +20619,6 @@ beneficiaries.
                organization to participate in the program.
 
 
-      HR 3590 EAS/PP
-                            780
                (B) INTERVENTION PROPOSAL    .—Subject to
           subparagraph (C), an application submitted
           under subparagraph (A)(i) shall include a de-
@@ -22201,8 +20645,6 @@ beneficiaries.
                     (iv) Assessing and actively engaging
                with a high-risk Medicare beneficiary (and,
 
-      HR 3590 EAS/PP
-                            781
                as appropriate, the primary caregiver of the
                beneficiary) through the provision of self-
                management support and relevant informa-
@@ -22229,8 +20671,6 @@ beneficiaries.
           served populations, small communities, and
           rural areas.
 
-      HR 3590 EAS/PP
-                            782
       (d) IMPLEMENTATION   .—Notwithstanding any other
 provision of law, the Secretary may implement the provi-
 sions of this section by program instruction or otherwise.
@@ -22257,8 +20697,6 @@ case of a demonstration project in operation as of October
 1, 2008)’’ after ‘‘December 31, 2009’’.
       (b) UNDING .—
 
-      HR 3590 EAS/PP
-                           783
           (1) N GENERAL  .—Subsection (f)(1) of such sec-
      tion is amended by inserting ‘‘and for fiscal year
      2010, $1,600,000,’’ after ‘‘$6,000,000,’’.
@@ -22285,8 +20723,6 @@ new paragraph:
           (7)(B), (8)(B), and (9)(B), in lieu of the update
           to the single conversion factor established in
 
-      HR 3590 EAS/PP
-                          784
          paragraph (1)(C) that would otherwise apply for
          2010, the update to the single conversion factor
          shall be 0.5 percent.
@@ -22313,8 +20749,6 @@ ed—
          (2) by adding at the end the following new sub-
      paragraph:
 
-      HR 3590 EAS/PP
-                              785
                 ‘‘(H) P RACTICE EXPENSE GEOGRAPHIC AD       -
            JUSTMENT FOR 2010 AND SUBSEQUENT YEARS        .—
                      ‘‘(i) OR 2010 .—Subject to clause (iii),
@@ -22341,8 +20775,6 @@ ed—
                 for services furnished in 2010 or 2011 shall
                 not, as a result of the application of clause
 
-      HR 3590 EAS/PP
-                            786
                (i) or (ii), be reduced below the practice ex-
                pense portion of the geographic adjustment
                factor under subparagraph (A)(i) (as cal-
@@ -22369,8 +20801,6 @@ ed—
                     the practice expense geographic adjust-
                     ment described in subparagraph (A)(i),
 
-      HR 3590 EAS/PP
-                            787
                     including the extent to which types of
                     office expenses are determined in local
                     markets instead of national markets.
@@ -22397,8 +20827,6 @@ ed—
                     ical office based on the use of the
                     American Community Survey data or
 
-      HR 3590 EAS/PP
-                            788
                    other reliable data for wage adjust-
                    ments.
                Such adjustments shall be made without re-
@@ -22425,8 +20853,6 @@ Extension Act of 2007 (Public Law 110–173), and section
 136 of the Medicare Improvements for Patients and Pro-
 
 
-      HR 3590 EAS/PP
-                           789
 viders Act of 2008 (Public Law 110–275), is amended by
 striking ‘‘and 2009’’ and inserting ‘‘2009, and 2010’’.
  SEC. 3105. EXTENSION OF AMBULANCE ADD-ONS.
@@ -22453,8 +20879,6 @@ ary 1, 2011’’.
      (c) S    UPER     R URAL     A MBULANCE .—Section
 1834(l)(12)(A) of the Social Security Act (42 U.S.C.
 
-      HR 3590 EAS/PP
-                           790
 1395m(l)(12)(A)) is amended by striking ‘‘2010’’ and in-
 serting ‘‘2010, and on or after April 1, 2010, and before
 January 1, 2011’’.
@@ -22481,8 +20905,6 @@ is amended by striking ‘‘December 31, 2009’’ and inserting
 ‘‘December 31, 2010’’.
 
 
-      HR 3590 EAS/PP
-                           791
  SEC. 3108. PERMITTING PHYSICIAN ASSISTANTS TO ORDER
              POST-HOSPITAL EXTENDED CARE SERVICES.
      (a) O RDERING   POST-H OSPITAL  E XTENDED   CARE
@@ -22509,8 +20931,6 @@ after January 1, 2011.
 Security Act (42 U.S.C. 1395m(a)(20)), as added by section
 154(b)(1)(A) of the Medicare Improvements for Patients
 
-      HR 3590 EAS/PP
-                            792
 and Providers Act of 2008 (Public Law 100–275), is
 amended—
           (1) in subparagraph (F)(i)—
@@ -22537,8 +20957,6 @@ amended—
                    nishing such items and services, such
                    standards and accreditation require-
 
-      HR 3590 EAS/PP
-                            793
                    ment shall not apply to such phar-
                    macies; and
                         ‘‘(II) the Secretary may apply to
@@ -22565,8 +20983,6 @@ amended—
                    plier of durable medical equipment,
                    prosthetics, orthotics, and supplies, has
 
-      HR 3590 EAS/PP
-                            794
                     been issued (which may include the re-
                     newal of) a provider number for at
                     least 5 years, and for which a final ad-
@@ -22593,8 +21009,6 @@ amended—
                     preceding sentence shall include a cer-
                     tification by an accountant on behalf
 
-      HR 3590 EAS/PP
-                            795
                    of the pharmacy or the submission of
                    tax returns filed by the pharmacy dur-
                    ing the relevant periods, as requested
@@ -22621,8 +21035,6 @@ States Code) at the time the individual is entitled to part
 A under section 226(b) or section 226A and who is eligible
 to enroll but who has elected not to enroll (or to be deemed
 
-      HR 3590 EAS/PP
-                              796
 enrolled) during the individual’s initial enrollment period,
 there shall be a special enrollment period described in para-
 graph (2).
@@ -22649,8 +21061,6 @@ cerning the impact of not enrolling under this part, includ-
 ing the impact on health care benefits under the TRICARE
 program under chapter 55 of title 10, United States Code.
 
-      HR 3590 EAS/PP
-                            797
       ‘‘(6) The Secretary of Defense shall collaborate with
 the Secretary of Health and Human Services and the Com-
 missioner of Social Security to provide for the accurate
@@ -22677,8 +21087,6 @@ amended by striking ‘‘section 1837(i)(4)’’ and inserting
                    (i) in paragraph (4)(B), by inserting
                ‘‘, and for 2010 and 2011, dual-energy x-
 
-      HR 3590 EAS/PP
-                            798
                ray absorptiometry services (as described in
                paragraph (6))’’ before the period at the
                end; and
@@ -22705,8 +21113,6 @@ amended by striking ‘‘section 1837(i)(4)’’ and inserting
                at the end;
 
 
-      HR 3590 EAS/PP
-                           799
                    (ii) in subclause (III), by striking the
               period at the end and inserting ‘‘; and’’;
               and
@@ -22733,8 +21139,6 @@ amended by striking ‘‘section 1837(i)(4)’’ and inserting
           (2) REPORT .—An agreement entered into under
      paragraph (1) shall provide for the Institute of Medi-
 
-      HR 3590 EAS/PP
-                           800
      cine to submit to the Secretary and to Congress a re-
      port containing the results of the study conducted
      under such paragraph.
@@ -22761,8 +21165,6 @@ and inserting ‘‘$0’’.
      oratory test—
 
 
-      HR 3590 EAS/PP
-                            801
                (A) that is an analysis of gene protein ex-
           pression, topographic genotyping, or a cancer
           chemotherapy sensitivity assay;
@@ -22789,8 +21191,6 @@ and inserting ‘‘$0’’.
       performed after such period of hospitalization and if
       separate payment would not otherwise be made under
 
-      HR 3590 EAS/PP
-                            802
       title XVIII of the Social Security Act by reason of
       sections 1862(a)(14) and 1866(a)(1)(H)(i) of the such
       Act (42 U.S.C. 1395y(a)(14); 42 U.S.C.
@@ -22817,8 +21217,6 @@ report shall include—
       mines appropriate.
 
 
-      HR 3590 EAS/PP
-                           803
      (e) IMPLEMENTATION   FUNDING .—For purposes of ad-
 ministering this section (including preparing and submit-
 ting the report under subsection (d)), the Secretary shall
@@ -22845,8 +21243,6 @@ ed—
           ‘‘2010’’and inserting ‘‘2011’’; and
 
 
-      HR 3590 EAS/PP
-                          804
              (B) in the second sentence, by striking ‘‘or
          2009’’ and inserting ‘‘, 2009, or 2010’’; and
          (2) in subclause (III), by striking ‘‘January 1,
@@ -22873,8 +21269,6 @@ SCHIP Extension Act of 2007 (42 U.S.C. 1395l note), is
 amended by inserting ‘‘or during the 1-year period begin-
 ning on July 1, 2010’’ before the period at the end.
 
-     HR 3590 EAS/PP
-                           805
  SEC. 3123. EXTENSION OF THE RURAL COMMUNITY HOS-
              PITAL DEMONSTRATION PROGRAM.
      (a) ONE-YEAR E XTENSION .—Section 410A of the Medi-
@@ -22901,8 +21295,6 @@ amended by adding at the end the following new subsection:
      under such subsection for purposes of the initial 5-
      year period.
 
-      HR 3590 EAS/PP
-                            806
           ‘‘(3) NCREASE IN MAXIMUM NUMBER OF HOS        -
       PITALS PARTICIPATING IN THE DEMONSTRATION PRO     -
       GRAM .—Notwithstanding subsection (a)(4), during the
@@ -22929,8 +21321,6 @@ vided in subsection (g), for the 1-year extension period’’
 after ‘‘5-year period’’.
       (c) ECHNICAL  AMENDMENTS   .—
 
-      HR 3590 EAS/PP
-                           807
           (1) Subsection (b) of section 410A of the Medi-
      care Prescription Drug, Improvement, and Mod-
      ernization Act of 2003 (Public Law 108–173; 117
@@ -22957,8 +21347,6 @@ after ‘‘5-year period’’.
 tion 1886(d)(5)(G) of the Social Security Act (42 U.S.C.
 1395ww(d)(5)(G)) is amended—
 
-      HR 3590 EAS/PP
-                           808
           (1) in clause (i), by striking ‘‘October 1, 2011’’
      and inserting ‘‘October 1, 2012’’; and
           (2) in clause (ii)(II), by striking ‘‘October 1,
@@ -22985,8 +21373,6 @@ tion 1886(d)(5)(G) of the Social Security Act (42 U.S.C.
 U.S.C. 1395ww(d)(12)) is amended—
 
 
-      HR 3590 EAS/PP
-                            809
           (1) in subparagraph (A), by inserting ‘‘or (D)’’
       after ‘‘subparagraph (B)’’;
           (2) in subparagraph (B), in the matter pre-
@@ -23013,8 +21399,6 @@ U.S.C. 1395ww(d)(12)) is amended—
           low-volume hospitals with 200 or fewer dis-
           charges of individuals entitled to, or enrolled for,
 
-      HR 3590 EAS/PP
-                          810
          benefits under part A in the fiscal year to 0 per-
          cent for low-volume hospitals with greater than
          1,500 discharges of such individuals in the fiscal
@@ -23041,8 +21425,6 @@ tion 123 is amended—
          U.S.C. 1395x(q)).’’;
               (B) by striking paragraph (9); and
 
-      HR 3590 EAS/PP
-                            811
                (C) by redesignating paragraph (10) as
           paragraph (9).
  SEC. 3127. MEDPAC STUDY ON ADEQUACY OF MEDICARE
@@ -23069,8 +21451,6 @@ Congress a report containing the results of the study con-
 ducted under subsection (a). Such report shall include rec-
 ommendations on appropriate modifications to any adjust-
 
-      HR 3590 EAS/PP
-                            812
 ments in payments to providers of services and suppliers
 that furnish items and services in rural areas, together with
 recommendations for such legislation and administrative
@@ -23097,8 +21477,6 @@ Security Act (42 U.S.C. 1395i–4(j)) is amended—
      States under subsection (g), such sums as may be nec-
      essary in each of fiscal years 2011 and 2012, to re-
 
-      HR 3590 EAS/PP
-                            813
       main available until expended’’ before the period at
       the end.
       (b) USE OF F UNDS .—Section 1820(g)(3) of the Social
@@ -23125,8 +21503,6 @@ Security Act (42 U.S.C. 1395i–4(g)(3)) is amended—
           gram on payment bundling under section
           1866D, and other delivery system reform pro-
 
-      HR 3590 EAS/PP
-                          814
          grams determined appropriate by the Secretary’’
          before the period at the end.
      (c) FFECTIVE D ATE.—The amendments made by this
@@ -23153,8 +21529,6 @@ section shall apply to grants made on or after January 1,
                   would otherwise be applicable under
                   clause (i)(III) shall be adjusted by a
 
-      HR 3590 EAS/PP
-                            815
                     percentage determined appropriate by
                     the Secretary to reflect such factors as
                     changes in the number of visits in an
@@ -23181,8 +21555,6 @@ section shall apply to grants made on or after January 1,
                     2016. During each year of such phase-
                     in, the amount of any adjustment
 
-      HR 3590 EAS/PP
-                           816
                    under subclause (I) for the year may
                    not exceed 3.5 percent of the amount
                    (or amounts) applicable under clause
@@ -23209,8 +21581,6 @@ section shall apply to grants made on or after January 1,
           and administrative action as the Commission
           determines appropriate.
 
-      HR 3590 EAS/PP
-                           817
      (b) P  ROGRAM  SPECIFIC   O UTLIER   C AP.—Section
 1895(b) of the Social Security Act (42 U.S.C. 1395fff(b))
 is amended—
@@ -23237,8 +21607,6 @@ is amended—
           agency for a year (beginning with 2011) may
           not exceed an amount equal to 10 percent of the
 
-      HR 3590 EAS/PP
-                          818
          estimated total amount of payments made under
          this section (without regard to this paragraph)
          with respect to the home health agency for the
@@ -23265,8 +21633,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
 
 
 
-      HR 3590 EAS/PP
-                         819
      (d) STUDY AND R EPORT ON THE  D EVELOPMENT OF
  HOME  HEALTH P AYMENT R EFORMS INO RDER TO ENSURE
  ACCESS TOC ARE AND QUALITY SERVICES.—
@@ -23293,8 +21659,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
              medically underserved areas;
 
 
-     HR 3590 EAS/PP
-                            820
                     (iii) ways the outlier payment may be
                improved to more accurately reflect the cost
                of treating Medicare beneficiaries with high
@@ -23321,8 +21685,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
           care.
 
 
-      HR 3590 EAS/PP
-                            821
                (D) A timetable for implementation of any
           appropriate changes based on the analysis of the
           matters described in subparagraphs (A), (B),
@@ -23349,8 +21711,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
                (G) atypical transportation costs;
                (H) security costs; and
 
-      HR 3590 EAS/PP
-                           822
               (I) other factors determined appropriate by
           the Secretary.
           (3) REPORT .—Not later than March 1, 2011, the
@@ -23377,8 +21737,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
      Security Act (42 U.S.C. 1395f(i)), as amended by sec-
      tion 3004(c), is amended—
 
-      HR 3590 EAS/PP
-                            823
                (A) by redesignating paragraph (6) as
           paragraph (7); and
                (B) by inserting after paragraph (5) the fol-
@@ -23405,8 +21763,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
                    ‘‘(II) the cost of the type of service; and
 
 
-      HR 3590 EAS/PP
-                            824
                     ‘‘(III) the amount of payment for the
                type of service;
                ‘‘(iv) charitable contributions and other rev-
@@ -23433,8 +21789,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
       changes in resource intensity in providing such care
 
 
-      HR 3590 EAS/PP
-                            825
       and services during the course of the entire episode of
       hospice care.
           ‘‘(ii) Revisions in payment implemented pursu-
@@ -23461,8 +21815,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
                ‘‘subsequent fiscal year’’; and
 
 
-      HR 3590 EAS/PP
-                           826
                    (ii) in subclause (VII), by inserting
               ‘‘(before the first fiscal year in which the
               payment revisions described in paragraph
@@ -23489,8 +21841,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
           (1) in subparagraph (B), by striking ‘‘and’’ at
      the end; and
 
-      HR 3590 EAS/PP
-                            827
           (2) by adding at the end the following new sub-
       paragraph:
                ‘‘(D) on and after January 1, 2011—
@@ -23517,8 +21867,6 @@ by section 5201(b) of the Deficit Reduction Act of 2005
 
 
 
-      HR 3590 EAS/PP
-                           828
  SEC. 3133. IMPROVEMENT TO MEDICARE DISPROPOR-
              TIONATE SHARE HOSPITAL (DSH) PAYMENTS.
      Section 1886 of the Social Security Act (42 U.S.C.
@@ -23545,8 +21893,6 @@ is amended—
      paragraph (1), for fiscal year 2015 and each subse-
      quent fiscal year, the Secretary shall pay to such sub-
 
-      HR 3590 EAS/PP
-                            829
       section (d) hospitals an additional amount equal to
       the product of the following factors:
                ‘‘(A) FACTOR ONE  .—A factor equal to the
@@ -23573,8 +21919,6 @@ is amended—
                     under the Patient Protection and Af-
                     fordable Care Act (as calculated by the
 
-      HR 3590 EAS/PP
-                            830
                    Secretary based on the most recent esti-
                    mates available from the Director of
                    the Congressional Budget Office before
@@ -23601,8 +21945,6 @@ is amended—
                    Medicaid Services); and
 
 
-      HR 3590 EAS/PP
-                            831
                          ‘‘(II) who are uninsured in the
                     most recent period for which data is
                     available (as so estimated and cer-
@@ -23629,8 +21971,6 @@ is amended—
       1869, section 1878, or otherwise of the following:
 
 
-      HR 3590 EAS/PP
-                            832
                ‘‘(A) Any estimate of the Secretary for pur-
           poses of determining the factors described in
           paragraph (2).
@@ -23657,8 +21997,6 @@ ing at the end the following new subparagraphs:
                tifying potentially misvalued services pur-
                suant to clause (i)(I), the Secretary shall ex-
 
-      HR 3590 EAS/PP
-                            833
                amine (as the Secretary determines to be
                appropriate) codes (and families of codes as
                appropriate) for which there has been the
@@ -23685,8 +22023,6 @@ ing at the end the following new subparagraphs:
                     adjustment of potentially misvalued
                     services described in clause (i)(II).
 
-      HR 3590 EAS/PP
-                            834
                         ‘‘(II) The Secretary may conduct
                     surveys, other data collection activities,
                     studies, or other analyses as the Sec-
@@ -23713,8 +22049,6 @@ ing at the end the following new subparagraphs:
                     priate coding revisions (including
                     using existing processes for consider-
 
-      HR 3590 EAS/PP
-                            835
                    ation of coding changes) which may
                    include consolidation of individual
                    services into bundled codes for payment
@@ -23741,8 +22075,6 @@ ing at the end the following new subparagraphs:
                ical effort, and stress due to risk) involved
                with furnishing a service and may include
 
-      HR 3590 EAS/PP
-                            836
                validation of the pre-, post-, and intra-serv-
                ice components of work.
                    ‘‘(iii) COPE OF CODES  .—The valida-
@@ -23769,8 +22101,6 @@ ing at the end the following new subparagraphs:
           (1) ADMINISTRATION .—
 
 
-      HR 3590 EAS/PP
-                          837
               (A) Chapter 35 of title 44, United States
          Code and the provisions of the Federal Advisory
          Committee Act (5 U.S.C. App.) shall not apply
@@ -23797,8 +22127,6 @@ ing at the end the following new subparagraphs:
  HIGHER  P RESUMED  U TILIZATION.—Section 1848 of the
 Social Security Act (42 U.S.C. 1395w–4) is amended—
 
-      HR 3590 EAS/PP
-                            838
           (1) in subsection (b)(4)—
                (A) in subparagraph (B), by striking ‘‘sub-
           paragraph (A)’’ and inserting ‘‘this paragraph’’;
@@ -23825,8 +22153,6 @@ Social Security Act (42 U.S.C. 1395w–4) is amended—
                50 percent) presumed rate of utilization of
                imaging equipment; and
 
-      HR 3590 EAS/PP
-                            839
                     ‘‘(iii) in the case of services furnished
                on or after January 1, 2014, a 75 percent
                (rather than 50 percent) presumed rate of
@@ -23854,8 +22180,6 @@ Social Security Act (42 U.S.C. 1395w–4) is amended—
                     penditures attributable to the presumed
                     rate of utilization of imaging equip-
 
-      HR 3590 EAS/PP
-                            840
                    ment of 70 percent under subsection
                    (b)(4)(C)(ii) instead of a presumed
                    rate of utilization of such equipment of
@@ -23883,8 +22207,6 @@ ed—
                ‘‘(D) ADJUSTMENT IN TECHNICAL COMPO     -
           NENT DISCOUNT ON SINGLE  -SESSION IMAGING IN -
 
-      HR 3590 EAS/PP
-                           841
           VOLVING CONSECUTIVE BODY PARTS   .—For serv-
           ices furnished on or after July 1, 2010, the Sec-
           retary shall increase the reduction in payments
@@ -23911,8 +22233,6 @@ ed—
  TERS FOR  M EDICARE  & M EDICAID  SERVICES .—Not later
 than January 1, 2013, the Chief Actuary of the Centers for
 
-      HR 3590 EAS/PP
-                            842
 Medicare & Medicaid Services shall make publicly available
 an analysis of whether, for the period of 2010 through 2019,
 the cumulative expenditure reductions under title XVIII of
@@ -23939,8 +22259,6 @@ Security Act (42 U.S.C. 1395m(a)(7)(A)) is amended—
                (A) in the heading, by inserting COMPLEX  ,
           REHABILITATIVE  ’’ beforePOWER  -DRIVEN ’’; and
 
-      HR 3590 EAS/PP
-                           843
               (B) by inserting ‘‘complex, rehabilitative’’
           before ‘‘power-driven’’.
      (b) T       ECHNICAL        A MENDMENT  .—Section
@@ -23967,8 +22285,6 @@ or’’.
      of division B of the Tax Relief and Health Care Act
      of 2006 (42 U.S.C. 1395 note), as amended by section
 
-      HR 3590 EAS/PP
-                          844
      117 of the Medicare, Medicaid, and SCHIP Extension
      Act of 2007 (Public Law 110–173) and section 124
      of the Medicare Improvements for Patients and Pro-
@@ -23995,8 +22311,6 @@ or’’.
      the goals for reforming such system set forth in the
      Medicare Payment Advisory Commission June 2007
 
-      HR 3590 EAS/PP
-                            845
       report entitled ‘‘Report to Congress: Promoting Great-
       er Efficiency in Medicare’’, including establishing a
       new hospital compensation index system that—
@@ -24023,8 +22337,6 @@ or’’.
       under paragraph (1), the Secretary shall consult with
       relevant affected parties.
 
-      HR 3590 EAS/PP
-                           846
      (c) USE OF PARTICULAR  C RITERIA FOR DETERMINING
  RECLASSIFICATIONS .—Notwithstanding any other provi-
 sion of law, in making decisions on applications for reclas-
@@ -24051,8 +22363,6 @@ new paragraph:
           a study to determine if, under the system under
           this subsection, costs incurred by hospitals de-
 
-      HR 3590 EAS/PP
-                            847
           scribed in section 1886(d)(1)(B)(v) with respect
           to ambulatory payment classification groups ex-
           ceed those costs incurred by other hospitals fur-
@@ -24079,8 +22389,6 @@ rity Act (42 U.S.C. 1395w–3a) is amended—
                (A) in paragraph (1)—
 
 
-      HR 3590 EAS/PP
-                            848
                    (i) in subparagraph (A), by striking
                ‘‘or’’ at the end;
                    (ii) in subparagraph (B), by striking
@@ -24107,8 +22415,6 @@ rity Act (42 U.S.C. 1395w–3a) is amended—
                ‘‘(B) 6 percent of the amount determined
           under paragraph (4) for the reference biological
 
-      HR 3590 EAS/PP
-                           849
           product (as defined in subsection (c)(6)(I)).’’;
           and
           (2) in subsection (c)(6), by adding at the end the
@@ -24135,8 +22441,6 @@ similar pathway (as determined by the Secretary).
 
 
 
-      HR 3590 EAS/PP
-                           850
  SEC. 3140. MEDICARE HOSPICE CONCURRENT CARE DEM-
              ONSTRATION PROGRAM.
      (a) ESTABLISHMENT  .—
@@ -24163,8 +22467,6 @@ similar pathway (as determined by the Secretary).
      shall provide for the conduct of an independent eval-
      uation of the demonstration program under this sec-
      tion. Such independent evaluation shall determine
-      HR 3590 EAS/PP
-                            851
       whether the demonstration program has improved pa-
       tient care, quality of life, and cost-effectiveness for
       Medicare beneficiaries participating in the dem-
@@ -24191,8 +22493,6 @@ paragraph (h)(4) of section 412.64 of title 42, Code of Fed-
 eral Regulations, the Secretary of Health and Human Serv-
 ices shall administer subsection (b) of such section 4410 and
 
-      HR 3590 EAS/PP
-                            852
 paragraph (e) of such section 412.64 in the same manner
 as the Secretary administered such subsection (b) and para-
 graph (e) for discharges occurring during fiscal year 2008
@@ -24219,8 +22519,6 @@ index).
           (d)(5)(G) of such section should be applied to
           urban Medicare-dependent hospitals.
 
-      HR 3590 EAS/PP
-                            853
           (2) U  RBAN  MEDICARE  -DEPENDENT    HOSPITAL
       DEFINED .—For purposes of this section, the term
       ‘‘urban Medicare-dependent hospital’’ means a sub-
@@ -24247,8 +22545,6 @@ index).
           attributable to inpatients entitled to benefits
           under part A of title XVIII of such Act.
 
-      HR 3590 EAS/PP
-                           854
      (b) REPORT .—Not later than 9 months after the date
 of enactment of this Act, the Secretary shall submit to Con-
 gress a report containing the results of the study conducted
@@ -24275,8 +22571,6 @@ health benefits under title XVIII of the Social Security Act.
               (C) in subparagraph (A), as redesignated
           by subparagraph (B)—
 
-      HR 3590 EAS/PP
-                              855
                      (i) by redesignating subparagraphs (A)
                 and (B) as clauses (i) and (ii), respectively,
                 and indenting the clauses appropriately;
@@ -24304,8 +22598,6 @@ health benefits under title XVIII of the Social Security Act.
                                      ‘‘(BB) 12; and
 
 
-      HR 3590 EAS/PP
-                              856
                                ‘‘(bb) 3  of the MA competi-
                           tive benchmark amount (deter-
                           mined under paragraph (2)) for
@@ -24333,8 +22625,6 @@ health benefits under title XVIII of the Social Security Act.
                      for a year before 2004; and
 
 
-      HR 3590 EAS/PP
-                            857
                         ‘‘(VI) for 2015 and each subse-
                    quent year, the MA competitive bench-
                    mark amount (as so determined) for
@@ -24361,8 +22651,6 @@ health benefits under title XVIII of the Social Security Act.
           ing such definition for purposes of this para-
           graph, ‘to compute the MA competitive bench-
 
-      HR 3590 EAS/PP
-                           858
           mark amount under section 1853(j)(2)’ shall be
           substituted for ‘to compute the percentage speci-
           fied in subparagraph (A) and other relevant per-
@@ -24389,8 +22677,6 @@ health benefits under title XVIII of the Social Security Act.
      greater than the applicable amount that would (but
      for the application of this subsection) be determined
 
-      HR 3590 EAS/PP
-                            859
       under subsection (k)(1) for the area for the month in
       the year.’’; and
                (E) in subsection (k)(2)(B)(ii)(III), by
@@ -24417,8 +22703,6 @@ health benefits under title XVIII of the Social Security Act.
 
 
 
-      HR 3590 EAS/PP
-                           860
                    (i) in paragraph (3)(B)(i), by striking
               ‘‘1853(j)(1)’’ and inserting ‘‘1853(j)(1)(A)’’;
               and
@@ -24445,8 +22729,6 @@ Security Act (42 U.S.C. 1395w–23(c)(6)) is amended—
           inserting ‘‘for 2003 through 2010’’; and
 
 
-      HR 3590 EAS/PP
-                           861
               (B) by striking the period at the end and
           inserting a comma; and
               (C) by adding at the end the following new
@@ -24473,8 +22755,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
      (B)(v).’’.
 
 
-      HR 3590 EAS/PP
-                            862
           (2) E  STABLISHMENT   OF   ACTUARIAL   GUIDE  -
       LINES.—Section 1854(a)(6)(B) of the Social Security
       Act (42 U.S.C. 1395w–24(a)(6)(B)) is amended—
@@ -24501,8 +22781,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
                         MA plans.
 
 
-      HR 3590 EAS/PP
-                            863
                         ‘‘(II) ENIAL OF BID AMOUNTS   .—
                    The Secretary shall deny monthly bid
                    amounts submitted under subpara-
@@ -24529,8 +22807,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
                    those actuaries to the Actuarial Board
                    for Counseling and Discipline.’’.
 
-      HR 3590 EAS/PP
-                           864
           (3) EFFECTIVE DATE .—The amendments made
      by this subsection shall apply to bid amounts sub-
      mitted on or after January 1, 2012.
@@ -24557,8 +22833,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
      State as follows:
               ‘‘(A) RBAN AREAS .—
 
-      HR 3590 EAS/PP
-                            865
                    ‘‘(i) N GENERAL   .—Subject to clause
                (ii) and subparagraphs (C) and (D), the
                service area for an MA local plan in an
@@ -24585,8 +22859,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
                ‘‘(C) REFINEMENTS TO SERVICE AREAS     .—
           For 2015 and succeeding years, in order to re-
 
-      HR 3590 EAS/PP
-                            866
           flect actual patterns of health care service utili-
           zation, the Secretary may adjust the boundaries
           of service areas for MA local plans in urban
@@ -24613,8 +22885,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
                plan.’’.
           (2) CONFORMING AMENDMENTS    .—
 
-      HR 3590 EAS/PP
-                            867
                (A) N GENERAL  .—
                    (i) Section 1851(b)(1) of the Social Se-
                curity Act (42 U.S.C. 1395w–21(b)(1)) is
@@ -24641,8 +22911,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
                    and
 
 
-      HR 3590 EAS/PP
-                           868
                        (II) in subparagraph (D)(i), by
                   striking ‘‘MA payment area’’ and in-
                   serting ‘‘MA local area (as defined in
@@ -24669,8 +22937,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
           spect to the year, the Secretary shall, in addition
           to any other payment provided under this part,
 
-      HR 3590 EAS/PP
-                            869
           make monthly payments, with respect to cov-
           erage of an individual under this part, to the
           MA plan in an amount equal to the product of—
@@ -24697,8 +22963,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
                    ‘‘(i) Care management programs
                that—
 
-      HR 3590 EAS/PP
-                            870
                          ‘‘(I) target individuals with 1 or
                     more chronic conditions;
                          ‘‘(II) identify gaps in care; and
@@ -24725,8 +22989,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
                ing provisions for hospital-based patient
                safety programs in contracts that the Medi-
 
-      HR 3590 EAS/PP
-                            871
                care Advantage organization offering the
                MA plan has with hospitals.
                    ‘‘(v) Financial policies that promote
@@ -24753,8 +23015,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
                ‘‘(D) ONDUCT OF PROGRAM IN URBAN AND
           RURAL AREAS   .—An MA plan may conduct a
 
-      HR 3590 EAS/PP
-                            872
           program described in subparagraph (C) in a
           manner appropriate for an urban or rural area,
           as applicable.
@@ -24781,8 +23041,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
           plan that achieves at least a 3 star rating (or
 
 
-      HR 3590 EAS/PP
-                            873
           comparable rating) on a rating system described
           in subparagraph (C) in an amount equal to—
                    ‘‘(i) in the case of a plan that achieves
@@ -24809,8 +23067,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
           such national monthly per capita cost for the
           year.
 
-      HR 3590 EAS/PP
-                            874
                ‘‘(C) USE OF RATING SYSTEM   .—For pur-
           poses of subparagraph (A), a rating system de-
           scribed in this paragraph is—
@@ -24837,8 +23093,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
                plan for purposes of subparagraph (A) or
                identify the plan for purposes of subpara-
 
-      HR 3590 EAS/PP
-                            875
                graph (B) shall be counted, for purposes of
                such rating or identification, as having the
                lowest plan performance rating and the
@@ -24865,8 +23119,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
           MA plans with comparable enrollment.
 
 
-      HR 3590 EAS/PP
-                            876
                ‘‘(B) LOW ENROLLMENT PLANS    .—For years
           beginning with 2014, in the case of an MA plan
           that has low enrollment (as defined by the Sec-
@@ -24893,8 +23145,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
       tify the Medicare Advantage organization of any per-
       formance bonus (including a care coordination and
 
-      HR 3590 EAS/PP
-                            877
       management performance bonus under paragraph (1),
       a quality performance bonus under paragraph (2),
       and a quality bonus for new and low enrollment
@@ -24921,8 +23171,6 @@ uary 1, 2014)’’ after ‘‘75 percent’’.
           section (e)’’ and inserting ‘‘subsections (e) and
           (i)’’; and
 
-      HR 3590 EAS/PP
-                         878
              (B) by adding at the end the following new
          subsection:
      ‘‘(i)PPLICATION OFP ERFORMANCE  BONUSES TO MA
@@ -24950,8 +23198,6 @@ section:
      area are not greater than 75 percent of the adjusted
      average per capita cost for the year involved, deter-
 
-     HR 3590 EAS/PP
-                            879
      mined under section 1876(a)(4), for the area for indi-
      viduals who are not enrolled in an MA plan under
      this part for the year, but adjusted to exclude costs at-
@@ -24978,8 +23224,6 @@ section:
                spect to 2011; and
 
 
-      HR 3590 EAS/PP
-                            880
                    ‘‘(ii) for a subsequent year, 95 percent
                of the amount determined under this sub-
                paragraph for the preceding year.
@@ -25006,8 +23250,6 @@ section:
                         ‘‘(I) the MA competitive bench-
                    mark amount under subsection
 
-      HR 3590 EAS/PP
-                            881
                    (j)(1)(A)(i) for the area for the month,
                    adjusted, only to the extent the Sec-
                    retary determines necessary, to account
@@ -25034,8 +23276,6 @@ section:
           shall not be eligible for any bonus payment
           under subsection (n) or any rebate under this
 
-      HR 3590 EAS/PP
-                            882
           part (other than as provided under this sub-
           section) with respect to grandfathered enrollees.
                ‘‘(D) NONAPPLICATION   OF  UNIFORM  BID
@@ -25062,8 +23302,6 @@ section:
      Secretary under paragraph (1).’’.
 
 
-      HR 3590 EAS/PP
-                           883
      (h) T RANSITIONAL  EXTRA  B ENEFITS.—Section 1853
 of the Social Security Act (42 U.S.C. 1395w–23), as amend-
 ed by subsections (f) and (g), is amended by adding at the
@@ -25090,8 +23328,6 @@ end the following new subsection:
           for the month in those areas is greater than
           $100.
 
-      HR 3590 EAS/PP
-                            884
                ‘‘(B) A county where—
                     ‘‘(i) the MA area-specific non-drug
                monthly benchmark amount for a month in
@@ -25118,8 +23354,6 @@ end the following new subsection:
                ‘‘(C) If the Secretary determines appro-
           priate, a county contiguous to an area or county
 
-      HR 3590 EAS/PP
-                           885
           described in subparagraph (A) or (B), respec-
           tively.
           ‘‘(4) EVIEW OF PLAN BIDS  .—In the case of a
@@ -25146,8 +23380,6 @@ end the following new subsection:
      Section 1894 of the Social Security Act (42 U.S.C.
      1395eee) is amended—
 
-      HR 3590 EAS/PP
-                           886
               (A) by redesignating subsections (h) and (i)
           as subsections (i) and (j), respectively;
               (B) by inserting after subsection (g) the fol-
@@ -25174,8 +23406,6 @@ apply:
      curity Act (42 U.S.C. 1395w–23(d)), as amended by
 
 
-      HR 3590 EAS/PP
-                           887
      subsection (e), is amended by adding at the end the
      following new paragraph:
           ‘‘(6) PECIAL RULE FOR MA PAYMENT AREA FOR
@@ -25202,8 +23432,6 @@ apply:
                    ‘‘(iv)ERVICES DESCRIBED  .—The fol-
               lowing services are described in this clause:
 
-      HR 3590 EAS/PP
-                           888
                         ‘‘(I) Chemotherapy administra-
                    tion services.
                         ‘‘(II) Renal dialysis services (as
@@ -25230,8 +23458,6 @@ apply:
      1854(b)(1)(C) of the Social Security Act (42 U.S.C.
      1395w–24(b)(1)(C)) is amended—
 
-      HR 3590 EAS/PP
-                            889
                (A) in clause (ii), by strikingREBATE .—
           A rebate’’ and inserting ‘‘REBATE FOR PLAN
           YEARS  BEFORE   2012.—For plan years before
@@ -25258,8 +23484,6 @@ apply:
                    coverage under part D, including the
                    reduction of any deductibles, copay-
 
-      HR 3590 EAS/PP
-                            890
                     ments, and maximum limitations on
                     out-of-pocket expenses otherwise appli-
                     cable. Any reduction of maximum lim-
@@ -25286,8 +23510,6 @@ apply:
                     share to meaningfully provide coverage
                     of other health care benefits which are
 
-      HR 3590 EAS/PP
-                           891
                    not benefits under the original medi-
                    care fee-for-service program, such as
                    eye examinations and dental coverage,
@@ -25314,8 +23536,6 @@ apply:
               (B) by adding at the end the following new
           clause:
 
-      HR 3590 EAS/PP
-                            892
                    ‘‘(ii) PPLICATION OF MA MONTHLY
                SUPPLEMENTARY BENEFICIARY PREMIUM     .—
                For plan years beginning on or after Janu-
@@ -25342,8 +23562,6 @@ end the following new clause:
                    of such analysis are incorporated into
 
 
-      HR 3590 EAS/PP
-                          893
                   the risk scores for 2011, 2012, and
                   2013.
                       ‘‘(II) UTHORITY  TO  APPLY  IN
@@ -25372,8 +23590,6 @@ end the following new clause:
          dividual who is enrolled in a Medicare Advan-
          tage plan may change the election under sub-
 
-      HR 3590 EAS/PP
-                           894
           section (a)(1), but only with respect to coverage
           under the original medicare fee-for-service pro-
           gram under parts A and B, and may elect quali-
@@ -25400,8 +23616,6 @@ is amended—
               year before such year.’’.
 
 
-      HR 3590 EAS/PP
-                          895
  SEC. 3205. EXTENSION FOR SPECIALIZED MA PLANS FOR
              SPECIAL NEEDS INDIVIDUALS.
      (a) E  XTENSION  OF   SNP A   UTHORITY .—Section
@@ -25428,8 +23642,6 @@ amended by adding at the end the following new clause:
                   paragraph (3) of such section) rather
                   than the payment rules that would oth-
                   erwise apply under this part, but only
-      HR 3590 EAS/PP
-                           896
                    to the extent necessary to reflect the
                    costs of treating high concentrations of
                    frail individuals.
@@ -25456,8 +23668,6 @@ ing at the end the following new paragraph:
           to—
 
 
-      HR 3590 EAS/PP
-                            897
                     ‘‘(i) a Medicare Advantage plan that is
                not a specialized MA plan for special needs
                individuals (as defined in subsection
@@ -25484,8 +23694,6 @@ ing at the end the following new paragraph:
           The Secretary shall ensure that applicable indi-
           viduals enrolled in a specialized MA plan for
 
-      HR 3590 EAS/PP
-                         898
          special needs individuals (as defined in sub-
          section (b)(6)) prior to January 1, 2010, are
          transitioned to a plan or the program described
@@ -25513,8 +23721,6 @@ sections (a) and (c), is amended—
          quirement described in paragraph (7).’’;
 
 
-     HR 3590 EAS/PP
-                            899
           (3) in paragraph (4), by adding at the end the
      following new subparagraph:
                ‘‘(C) If applicable, the plan meets the re-
@@ -25541,8 +23747,6 @@ amended by adding at the end the following new clause:
                    spect to individuals described in sub-
                    clause (II), the Secretary shall use a
 
-      HR 3590 EAS/PP
-                            900
                     risk score that reflects the known un-
                     derlying risk profile and chronic health
                     status of similar individuals. Such risk
@@ -25569,8 +23773,6 @@ amended by adding at the end the following new clause:
                     with frailty, individuals with multiple,
                     comorbid chronic conditions, and indi-
 
-      HR 3590 EAS/PP
-                            901
                     viduals with a diagnosis of mental ill-
                     ness, and also to account for costs that
                     may be associated with higher con-
@@ -25597,8 +23799,6 @@ inserting ‘‘January 1, 2013’’.
 
 
 
-      HR 3590 EAS/PP
-                           902
  SEC. 3207. TECHNICAL CORRECTION TO MA PRIVATE FEE-
              FOR-SERVICE PLANS.
      For plan year 2011 and subsequent plan years, to the
@@ -25625,8 +23825,6 @@ end the following new subsection:
           ‘‘(1)N GENERAL  .—In the case of a Medicare
      Advantage senior housing facility plan described in
      paragraph (2), notwithstanding any other provision
-      HR 3590 EAS/PP
-                            903
       of this part to the contrary and in accordance with
       regulations of the Secretary, the service area of such
       plan may be limited to a senior housing facility in
@@ -25653,8 +23851,6 @@ end the following new subsection:
 
 
 
-      HR 3590 EAS/PP
-                           904
      (b) EFFECTIVE D ATE.—The amendment made by this
 section shall take effect on January 1, 2010, and shall apply
 to plan years beginning on or after such date.
@@ -25681,8 +23877,6 @@ ing at the end the following new subparagraph:
 by adding at the end the following new paragraph:
 
 
-      HR 3590 EAS/PP
-                           905
           ‘‘(3) EJECTION OF BIDS.—Paragraph (5)(C) of
      section 1854(a) shall apply with respect to bids sub-
      mitted by a PDP sponsor under subsection (b) in the
@@ -25709,8 +23903,6 @@ the following new subsection:
      Such revisions shall be based on evidence published in
      peer-reviewed journals or current examples used by
 
-      HR 3590 EAS/PP
-                          906
      integrated delivery systems and made consistent with
      the rules applicable under subsection (p)(1)(E) with
      the reference to the ‘1991 NAIC Model Regulation’
@@ -25737,8 +23929,6 @@ by striking ‘‘, and (w)’’ and inserting ‘‘(w), and (y)’’.
      (a) CONDITION FOR  C OVERAGE OF   DRUGS  U NDER
  PART D.—Part D of Title XVIII of the Social Security Act
 
-      HR 3590 EAS/PP
-                           907
 (42 U.S.C. 1395w–101 et seq.), is amended by adding at
 the end the following new section:
   ‘CONDITION FOR COVERAGE OF DRUGS UNDER THIS PART
@@ -25765,8 +23955,6 @@ apply to the dispensing of a covered part D drug if—
           ‘‘(1) the Secretary has made a determination
      that the availability of the drug is essential to the
      health of beneficiaries under this part; or
-      HR 3590 EAS/PP
-                           908
           ‘‘(2) the Secretary determines that in the period
      beginning on July 1, 2010, and ending on December
      31, 2010, there were extenuating circumstances.
@@ -25793,8 +23981,6 @@ and allow for comment on such model agreement.
               ‘‘(A) AGREEMENT  .—An agreement under
           this section shall require the manufacturer to
           provide applicable beneficiaries access to dis-
-      HR 3590 EAS/PP
-                            909
           counted prices for applicable drugs of the manu-
           facturer.
                ‘‘(B) ROVISION OF DISCOUNTED PRICES AT
@@ -25821,8 +24007,6 @@ and allow for comment on such model agreement.
                than January 30 of the preceding year.
 
 
-      HR 3590 EAS/PP
-                            910
           ‘‘(2) PROVISION OF APPROPRIATE DATA   .—Each
      manufacturer with an agreement in effect under this
      section shall collect and have available appropriate
@@ -25849,8 +24033,6 @@ and allow for comment on such model agreement.
                    ‘‘(i) BY THE SECRETARY   .—The Sec-
                retary may provide for termination of an
 
-      HR 3590 EAS/PP
-                            911
                agreement under this section for a knowing
                and willful violation of the requirements of
                the agreement or other good cause shown.
@@ -25877,8 +24059,6 @@ and allow for comment on such model agreement.
                    or after January 30 of a plan year, as
 
 
-      HR 3590 EAS/PP
-                           912
                    of the day after the end of the suc-
                    ceeding plan year.
                    ‘‘(iii) FFECTIVENESS   OF   TERMI -
@@ -25905,8 +24085,6 @@ and allow for comment on such model agreement.
                    ‘‘(ii) except as provided in clause (iii),
               the establishment of procedures under which
 
-      HR 3590 EAS/PP
-                            913
                discounted prices are provided to applicable
                beneficiaries at pharmacies or by mail
                order service at the point-of-sale of an ap-
@@ -25933,8 +24111,6 @@ and allow for comment on such model agreement.
                     ‘‘(v) the establishment of procedures to
                ensure that the discounted price for an ap-
 
-      HR 3590 EAS/PP
-                            914
                plicable drug under this section is applied
                before any coverage or financial assistance
                under other health benefit plans or pro-
@@ -25961,8 +24137,6 @@ and allow for comment on such model agreement.
                termines that the manufacturer is not in
                compliance with such agreement, the third
 
-      HR 3590 EAS/PP
-                            915
                party shall notify the Secretary of such
                noncompliance for appropriate enforcement
                under subsection (e).
@@ -25989,8 +24163,6 @@ and allow for comment on such model agreement.
      scribed in subsection (c)(1).
           ‘‘(2) IMITATION .—
 
-      HR 3590 EAS/PP
-                            916
                ‘‘(A) IN  GENERAL .—Subject to subpara-
           graph (B), in providing for such implementa-
           tion, the Secretary shall not receive or distribute
@@ -26017,8 +24189,6 @@ and allow for comment on such model agreement.
           individuals or entities the Secretary determines
           appropriate;
 
-      HR 3590 EAS/PP
-                            917
                ‘‘(B) receive, distribute, or facilitate the dis-
           tribution of funds of manufacturers to appro-
           priate individuals or entities in order to meet
@@ -26045,8 +24215,6 @@ and allow for comment on such model agreement.
       instruction or otherwise.
 
 
-      HR 3590 EAS/PP
-                            918
           ‘‘(6) ADMINISTRATION .—Chapter 35 of title 44,
       United States Code, shall not apply to the program
       under this section.
@@ -26073,8 +24241,6 @@ and allow for comment on such model agreement.
           shall apply to a civil money penalty under this
           paragraph in the same manner as such provi-
 
-      HR 3590 EAS/PP
-                           919
           sions apply to a penalty or proceeding under
           section 1128A(a).
      ‘‘(f) CLARIFICATION  REGARDING   A VAILABILITY OF
@@ -26101,8 +24267,6 @@ plicable beneficiary is enrolled in).
               coverage limit under section 1860D–2(b)(3)
               during the year; and
 
-      HR 3590 EAS/PP
-                            920
                     ‘‘(ii) has not incurred costs for covered
                part D drugs in the year equal to the an-
                nual out-of-pocket threshold specified in sec-
@@ -26129,8 +24293,6 @@ plicable beneficiary is enrolled in).
           which benefits are available under the prescrip-
 
 
-      HR 3590 EAS/PP
-                            921
           tion drug plan or MA–PD plan that the applica-
           ble beneficiary is enrolled in; or
                ‘‘(iii) is provided through an exception or
@@ -26157,8 +24319,6 @@ plicable beneficiary is enrolled in).
           beneficiary does not fall at or above the initial
           coverage limit under section 1860D–2(b)(3) and
 
-      HR 3590 EAS/PP
-                            922
           below the annual out-of-pocket threshold specified
           in section 1860D–2(b)(4)(B) for the year, the
           manufacturer of the applicable drug shall pro-
@@ -26185,8 +24345,6 @@ plicable beneficiary is enrolled in).
       dispensing fee for the applicable drug.
 
 
-      HR 3590 EAS/PP
-                           923
           ‘‘(7) QUALIFIED RETIREE PRESCRIPTION DRUG
      PLAN .—The term ‘qualified retiree prescription drug
      plan’ has the meaning given such term in section
@@ -26213,8 +24371,6 @@ plicable beneficiary is enrolled in).
           tion) under the Medicare coverage gap discount
           program under section 1860D–14A, regardless of
 
-      HR 3590 EAS/PP
-                           924
           whether part of such costs were paid by a manu-
           facturer under such program.’’.
           (2) EFFECTIVE DATE .—The amendments made
@@ -26241,8 +24397,6 @@ plicable beneficiary is enrolled in).
               as subparagraph (I);
 
 
-      HR 3590 EAS/PP
-                            925
                    (ii) by moving such subparagraph 2
                ems to the left; and
                    (iii) by striking the period at the end
@@ -26269,8 +24423,6 @@ plicable beneficiary is enrolled in).
      or after July 1, 2010.
 
 
-      HR 3590 EAS/PP
-                           926
  SEC. 3302. IMPROVEMENT IN DETERMINATION OF MEDI-
              CARE PART D LOW-INCOME BENCHMARK PRE-
              MIUM.
@@ -26297,8 +24449,6 @@ ing at the end the following new paragraph:
      mium for a subsidy eligible individual if the amount
      of such premium is de minimis. If such premium is
      waived under the plan, the Secretary shall not reas-
-      HR 3590 EAS/PP
-                          927
      sign subsidy eligible individuals enrolled in the plan
      to other plans based on the fact that the monthly ben-
      eficiary premium under the plan was greater than the
@@ -26325,8 +24475,6 @@ ed—
          vidual under section 1860D–14(a)(5). If there is
          more than one such plan available, the Secretary
 
-     HR 3590 EAS/PP
-                           928
           shall enroll such an individual under the pre-
           ceding sentence on a random basis among all
           such plans in the PDP region. Nothing in the
@@ -26353,8 +24501,6 @@ amended by adding at the end the following new clause:
               shall be extended through the date that is 1
               year after the date on which the determina-
 
-      HR 3590 EAS/PP
-                            929
                tion or redetermination would (but for the
                application of this clause) otherwise cease to
                be effective.’’.
@@ -26381,8 +24527,6 @@ individual, within 30 days of such reassignment, with—
      individual’s drug regimens; and
 
 
-      HR 3590 EAS/PP
-                          930
          ‘‘(2) a description of the individual’s right to re-
      quest a coverage determination, exception, or recon-
      sideration under section 1860D–4(g), bring an appeal
@@ -26409,8 +24553,6 @@ Management Account—
 ed by striking ‘‘(42 U.S.C. 1395w–23(f))’’ and all that fol-
 
 
-      HR 3590 EAS/PP
-                         931
 lows through the period at the end and inserting ‘‘(42
 U.S.C. 1395w–23(f)), to the Administration on Aging—
                  ‘‘(i) for fiscal year 2009, of $7,500,000;
@@ -26437,8 +24579,6 @@ Aging—
 amended by striking ‘‘(42 U.S.C. 1395w–23(f))’’ and all
 that follows through the period at the end and inserting
 
-     HR 3590 EAS/PP
-                         932
 ‘‘(42 U.S.C. 1395w–23(f)), to the Administration on
 Aging—
                  ‘‘(i) for fiscal year 2009, of $5,000,000;
@@ -26465,8 +24605,6 @@ tence.’’.
 
 
 
-     HR 3590 EAS/PP
-                           933
  SEC. 3307. IMPROVING FORMULARY REQUIREMENTS FOR
              PRESCRIPTION DRUG PLANS AND MA–PD
              PLANS WITH RESPECT TO CERTAIN CAT-
@@ -26493,8 +24631,6 @@ ed to read as follows:
                    erwise required to be included in the
                    formulary under subclause (I) (or to
                    otherwise limit access to such a drug,
-      HR 3590 EAS/PP
-                            934
                    including through prior authorization
                    or utilization management).
                    ‘‘(ii) DENTIFICATION  OF  DRUGS   IN
@@ -26521,8 +24657,6 @@ ed to read as follows:
                (ii)(II) the following categories and classes
 
 
-      HR 3590 EAS/PP
-                           935
               of drugs shall be identified under clause
               (ii)(I):
                        ‘‘(I) Anticonvulsants.
@@ -26549,8 +24683,6 @@ years.
           vidual whose modified adjusted gross income ex-
           ceeds the threshold amount applicable under
 
-      HR 3590 EAS/PP
-                            936
           paragraph (2) of section 1839(i) (including ap-
           plication of paragraph (5) of such section) for
           the calendar year, the monthly amount of the
@@ -26577,8 +24709,6 @@ years.
           COME .—For purposes of this paragraph, the
           term ‘modified adjusted gross income’ has the
 
-      HR 3590 EAS/PP
-                            937
           meaning given such term in subparagraph (A) of
           section 1839(i)(4), determined for the taxable
           year applicable under subparagraphs (B) and
@@ -26605,8 +24735,6 @@ years.
                    ‘‘(ii) ADDITIONAL  DISCLOSURE  .—Not
                later than October 15 of each year begin-
 
-      HR 3590 EAS/PP
-                            938
                ning with 2010, the Secretary shall disclose
                to the Commissioner of Social Security the
                following information for the purpose of
@@ -26633,8 +24761,6 @@ years.
                ‘‘(F) RULE OF CONSTRUCTION    .—The for-
           mula used to determine the monthly adjustment
 
-      HR 3590 EAS/PP
-                           939
           amount specified under subparagraph (B) shall
           only be used for the purpose of determining such
           monthly adjustment amount under such sub-
@@ -26661,8 +24787,6 @@ years.
           are withheld under subparagraph (A) are insuf-
           ficient to pay the amount described in such sub-
 
-      HR 3590 EAS/PP
-                           940
           paragraph, the Commissioner of Social Security
           shall enter into agreements with the Secretary,
           the Director of the Office of Personnel Manage-
@@ -26689,8 +24813,6 @@ years.
      6103(l)(20) of the Internal Revenue Code of 1986 (re-
      lating to disclosure of return information to carry out
 
-      HR 3590 EAS/PP
-                            941
       Medicare part B premium subsidy adjustment) is
       amended—
                (A) in the heading, by inserting AND PART
@@ -26717,8 +24839,6 @@ years.
                payer appeals with respect to any such pre-
 
 
-      HR 3590 EAS/PP
-                            942
                mium adjustment or increase’’ before the pe-
                riod at the end; and
                     (iv) by adding at the end the following
@@ -26745,8 +24865,6 @@ years.
                     to a taxpayer described in subpara-
                     graph (A) to officers and employees of
 
-      HR 3590 EAS/PP
-                            943
                    the Office of Personnel Management
                    and the Railroad Retirement Board, to
                    the extent that such disclosure is nec-
@@ -26773,8 +24891,6 @@ years.
       Section 1860D–14(a)(1)(D)(i) of the Social Security
 Act (42 U.S.C. 1395w–114(a)(1)(D)(i)) is amended by in-
 
-      HR 3590 EAS/PP
-                            944
 serting ‘‘or, effective on a date specified by the Secretary
 (but in no case earlier than January 1, 2012), who would
 be such an institutionalized individual or couple, if the full-
@@ -26801,8 +24917,6 @@ ing at the end the following new paragraph:
       retary, in consultation with relevant stakeholders (in-
       cluding representatives of nursing facilities, residents
 
-      HR 3590 EAS/PP
-                            945
      of nursing facilities, pharmacists, the pharmacy in-
      dustry (including retail and long-term care phar-
      macy), prescription drug plans, MA–PD plans, and
@@ -26829,8 +24943,6 @@ tractor under section 1874A of the Social Security Act (42
 U.S.C. 1395kk)) through the date on which the complaint
 is resolved. The system shall be able to report and initiate
 
-      HR 3590 EAS/PP
-                           946
 appropriate interventions and monitoring based on sub-
 stantial complaints and to guide quality improvement.
      (b) MODEL  ELECTRONIC  COMPLAINT  FORM .—The Sec-
@@ -26857,8 +24969,6 @@ such complaints.
           (3) SECRETARY .—The term ‘‘Secretary’’ means
      the Secretary of Health and Human Services.
 
-      HR 3590 EAS/PP
-                            947
           (4) S YSTEM .—The term ‘‘system’’ means the
      plan complaint system developed and maintained
      under subsection (a).
@@ -26885,8 +24995,6 @@ by adding at the end the following new subparagraph:
 
 
 
-      HR 3590 EAS/PP
-                         948
      (b) FFECTIVED ATE.—The amendment made by sub-
 section (a) shall apply to exceptions and appeals on or after
 January 1, 2012.
@@ -26914,8 +25022,6 @@ D UAL ELIGIBLES.—
 P RICESU NDER MEDICARE PART D AND MEDICAID.—
          (1) TUDY.—
 
-     HR 3590 EAS/PP
-                            949
                (A) IN GENERAL .—The Inspector General of
           the Department of Health and Human Services
           shall conduct a study on prices for covered part
@@ -26942,8 +25048,6 @@ P RICESU NDER MEDICARE PART D AND MEDICAID.—
 
 
 
-      HR 3590 EAS/PP
-                            950
                         (I) the financial impact of any
                    discrepancies in such prices on the
                    Federal Government; and
@@ -26970,8 +25074,6 @@ P RICESU NDER MEDICARE PART D AND MEDICAID.—
           the prices of covered part D drugs under such
           program and covered outpatient drugs under
 
-      HR 3590 EAS/PP
-                           951
           such title XIX necessary to carry out the com-
           parison under subparagraph (A).
           (2) REPORT .—
@@ -26998,8 +25100,6 @@ P RICESU NDER MEDICARE PART D AND MEDICAID.—
               (B) C  OVERED   OUTPATIENT   DRUG  .—The
           term ‘‘covered outpatient drug’’ has the meaning
 
-      HR 3590 EAS/PP
-                           952
           given such term in section 1927(k) of such Act
           (42 U.S.C. 1396r(k)).
               (C) MA–PD     PLAN .—The term ‘‘MA–PD
@@ -27026,8 +25126,6 @@ P RICESU NDER MEDICARE PART D AND MEDICAID.—
 
 
 
-      HR 3590 EAS/PP
-                           953
  SEC. 3314. INCLUDING COSTS INCURRED BY AIDS DRUG AS-
              SISTANCE PROGRAMS AND INDIAN HEALTH
              SERVICE IN PROVIDING PRESCRIPTION
@@ -27054,8 +25152,6 @@ amended—
               imbursed under clause (ii) if such costs are
               borne or paid—
                         ‘‘(I) under section 1860D–14;
-      HR 3590 EAS/PP
-                            954
                         ‘‘(II) under a State Pharma-
                    ceutical Assistance Program;
                         ‘‘(III) by the Indian Health Serv-
@@ -27082,8 +25178,6 @@ U.S.C. 1395w–102(b)) is amended—
      2010.—
 
 
-      HR 3590 EAS/PP
-                            955
                ‘‘(A) N GENERAL  .—For the plan year be-
           ginning on January 1, 2010, the initial coverage
           limit described in paragraph (3)(B) otherwise
@@ -27110,8 +25204,6 @@ U.S.C. 1395w–102(b)) is amended—
                     ‘‘(iv) the Secretary shall develop an es-
                timate of the additional increased costs at-
 
-      HR 3590 EAS/PP
-                            956
                tributable to the application of this para-
                graph for increased drug utilization and fi-
                nancing and administrative costs and shall
@@ -27138,8 +25230,6 @@ U.S.C. 1395w–102(b)) is amended—
           had never applied.’’.
 
 
-      HR 3590 EAS/PP
-                           957
      Subtitle E—Ensuring Medicare
                  Sustainability
  SEC. 3401. REVISION OF CERTAIN MARKET BASKET UP-
@@ -27166,8 +25256,6 @@ further amended—
      ‘‘(xi)(I) For 2012 and each subsequent fiscal year,
 after determining the applicable percentage increase de-
 
-      HR 3590 EAS/PP
-                              958
 scribed in clause (i) and after application of clauses (viii)
 and (ix), such percentage increase shall be reduced by the
 productivity adjustment described in subclause (II).
@@ -27194,8 +25282,6 @@ applicable percentage increase—
            ‘‘(II) subject to clause (xiii), for each of fiscal
       years 2012 through 2019, by 0.2 percentage point.
 
-      HR 3590 EAS/PP
-                            959
 The application of this clause may result in the applicable
 percentage increase described in clause (i) being less than
 0.0 for a fiscal year, and may result in payment rates
@@ -27222,8 +25308,6 @@ year—
 1888(e)(5)(B) of the Social Security Act (42 U.S.C.
 1395yy(e)(5)(B)) is amended—
 
-      HR 3590 EAS/PP
-                           960
           (1) by striking PERCENTAGE  .—The term’’ and
      inserting PERCENTAGE  .—
                    ‘‘(i) N GENERAL  .—Subject to clause
@@ -27250,8 +25334,6 @@ graphs:
      SUBSEQUENT YEARS   .—
 
 
-      HR 3590 EAS/PP
-                            961
                ‘‘(A) N GENERAL  .—In implementing the
           system described in paragraph (1) for rate year
           2010 and each subsequent rate year, any annual
@@ -27278,8 +25360,6 @@ graphs:
           in this paragraph is—
 
 
-      HR 3590 EAS/PP
-                            962
                     ‘‘(i) for each of rate years 2010 and
                2011, 0.25 percentage point; and
                     ‘‘(ii) subject to subparagraph (B), for
@@ -27306,8 +25386,6 @@ graphs:
                     preceding rate year (as estimated by
                     the Secretary); exceeds
 
-      HR 3590 EAS/PP
-                            963
                    ‘‘(ii) 5 percentage points.’’.
       (d) NPATIENT  REHABILITATION  F ACILITIES.—Section
 1886(j)(3) of the Social Security Act (42 U.S.C.
@@ -27334,8 +25412,6 @@ graphs:
                    through 2019, by the other adjustment
                    described in subparagraph (D).
 
-      HR 3590 EAS/PP
-                            964
                The application of this clause may result in
                the increase factor under this subparagraph
                being less than 0.0 for a fiscal year, and
@@ -27362,8 +25438,6 @@ graphs:
                year—
                         ‘‘(I) the excess (if any) of—
 
-      HR 3590 EAS/PP
-                            965
                             ‘‘(aa) the total percentage of
                         the non-elderly insured popu-
                         lation for the preceding fiscal year
@@ -27390,8 +25464,6 @@ amended—
      clause:
 
 
-      HR 3590 EAS/PP
-                           966
                    ‘‘(vi) A DJUSTMENTS .—After deter-
               mining the home health market basket per-
               centage increase under clause (iii), and
@@ -27418,8 +25490,6 @@ new subsection:
  PITALS.—
 
 
-      HR 3590 EAS/PP
-                            967
           ‘‘(1) REFERENCE TO ESTABLISHMENT AND IM       -
       PLEMENTATION OF SYSTEM    .—For provisions related
       to the establishment and implementation of a prospec-
@@ -27446,8 +25516,6 @@ new subsection:
                ning in 2010 through 2019, by the other ad-
                justment described in paragraph (3).
 
-      HR 3590 EAS/PP
-                            968
                ‘‘(B) SPECIAL RULE  .—The application of
           this paragraph may result in such update being
           less than 0.0 for a rate year, and may result in
@@ -27474,8 +25542,6 @@ new subsection:
                    non-elderly insured population for the
                    preceding rate year (based on the most
 
-      HR 3590 EAS/PP
-                            969
                     recent estimates available from the Di-
                     rector of the Congressional Budget Of-
                     fice before a vote in either House on
@@ -27502,8 +25568,6 @@ the Secretary shall reduce such percentage—
           ‘‘(II) subject to clause (v), for each of fiscal years
       2013 through 2019, by 0.5 percentage point.
 
-      HR 3590 EAS/PP
-                             970
 The application of this clause may result in the market bas-
 ket percentage increase under clause (ii)(VII) or (iii), as
 applicable, being less than 0.0 for a fiscal year, and may
@@ -27530,8 +25594,6 @@ cal year—
       (h) D IALYSIS.—Section 1881(b)(14)(F) of the Social
 Security Act (42 U.S.C. 1395rr(b)(14)(F)) is amended—
 
-      HR 3590 EAS/PP
-                             971
            (1) in clause (i)—
                 (A) by inserting ‘‘(I)’’ after ‘‘(F)(i)’’
                 (B) in subclause (I), as inserted by sub-
@@ -27558,8 +25620,6 @@ than such payment rates for the preceding year.’’; and
            centage point’’ and inserting ‘‘clause (i)(I)’’.
 
 
-      HR 3590 EAS/PP
-                           972
      (i) O UTPATIENT  H OSPITALS.—Section 1833(t)(3) of
 the Social Security Act (42 U.S.C. 1395l(t)(3)) is amend-
 ed—
@@ -27586,8 +25646,6 @@ ed—
           than such payment rates for the preceding year.
               ‘‘(G) OTHER ADJUSTMENT   .—
 
-      HR 3590 EAS/PP
-                            973
                     ‘‘(i) ADJUSTMENT  .—For purposes of
                subparagraph (F)(ii), the adjustment de-
                scribed in this subparagraph is—
@@ -27614,8 +25672,6 @@ ed—
                          in the affirmative, would clear
                          such Act for enrollment); over
 
-      HR 3590 EAS/PP
-                            974
                              ‘‘(bb) the total percentage of
                         the non-elderly insured popu-
                         lation for such preceding year (as
@@ -27642,8 +25698,6 @@ Social Security Act (42 U.S.C. 1395m(l)(3)) is amended—
           (4) by adding at the end the following flush sen-
       tence:
 
-      HR 3590 EAS/PP
-                           975
      ‘‘The application of subparagraph (C) may result in
      the percentage increase under subparagraph (B) being
      less than 0.0 for a year, and may result in payment
@@ -27670,8 +25724,6 @@ tion 1833(i)(2)(D) of the Social Security Act (42 U.S.C.
               tem described in clause (i) for a year being
 
 
-      HR 3590 EAS/PP
-                            976
                less than such payment rates for the pre-
                ceding year.’’.
       (l) ABORATORY   SERVICES .—Section 1833(h)(2)(A) of
@@ -27698,8 +25750,6 @@ amended—
                termined under clause (i) is 0.0 or a per-
                centage decrease for a year. The application
 
-      HR 3590 EAS/PP
-                           977
               of the productivity adjustment under sub-
               clause (I) shall not result in an adjustment
               to the fee schedules under clause (i) being
@@ -27726,8 +25776,6 @@ tion 1834(a)(14) of the Social Security Act (42 U.S.C.
               month period ending with June of the pre-
               vious year, reduced by—
 
-      HR 3590 EAS/PP
-                            978
                    ‘‘(ii) the productivity adjustment de-
                scribed in section 1886(b)(3)(B)(xi)(II).’’;
                and
@@ -27754,8 +25802,6 @@ tion 1834(a)(14) of the Social Security Act (42 U.S.C.
           clause:
 
 
-      HR 3590 EAS/PP
-                            979
                    ‘‘(xi) for 2011 and each subsequent
                year—
                         ‘‘(I) the percentage increase in the
@@ -27782,8 +25828,6 @@ Security Act (42 U.S.C. 1395u(s)(1)) is amended—
           (2) by striking the second sentence and inserting
      the following new subparagraph:
 
-      HR 3590 EAS/PP
-                            980
                ‘‘(B) Any fee schedule established under this
           paragraph for such item or service shall be up-
           dated—
@@ -27810,8 +25854,6 @@ Security Act (42 U.S.C. 1395u(s)(1)) is amended—
 
 
 
-      HR 3590 EAS/PP
-                            981
                         ‘‘(II) the productivity adjustment
                    described in section
                    1886(b)(3)(B)(xi)(II).’’; and
@@ -27838,8 +25880,6 @@ apply to discharges occurring before April 1, 2010.
      plicable’’ and inserting ‘‘Subject to paragraph (6), the
      applicable’’;
 
-      HR 3590 EAS/PP
-                            982
           (3) by redesignating paragraph (6) as para-
      graph (7); and
           (4) by inserting after paragraph (5) the fol-
@@ -27866,8 +25906,6 @@ apply to discharges occurring before April 1, 2010.
 lished an independent board to be known as the ‘Inde-
 pendent Medicare Advisory Board’.
 
-      HR 3590 EAS/PP
-                            983
      ‘‘(b) PURPOSE .—It is the purpose of this section to,
 in accordance with the following provisions of this section,
 reduce the per capita rate of growth in Medicare spend-
@@ -27894,8 +25932,6 @@ ing—
           ‘‘(1) EVELOPMENT  .—
 
 
-      HR 3590 EAS/PP
-                            984
                ‘‘(A) N GENERAL   .—The Board shall de-
           velop detailed and specific proposals related to
           the Medicare program in accordance with the
@@ -27922,8 +25958,6 @@ ing—
                for Medicare & Medicaid Services has made
                a determination under paragraph (7)(A) in
 
-      HR 3590 EAS/PP
-                            985
                the determination year, the proposal shall
                include recommendations so that the pro-
                posal as a whole (after taking into account
@@ -27950,8 +25984,6 @@ ing—
                miums under section 1818, 1818A, or 1839,
                increase Medicare beneficiary cost-sharing
 
-      HR 3590 EAS/PP
-                            986
                (including deductibles, coinsurance, and co-
                payments), or otherwise restrict benefits or
                modify eligibility criteria.
@@ -27978,8 +26010,6 @@ ing—
                ments to Medicare Advantage and prescrip-
                tion drug plans specified under paragraph
 
-      HR 3590 EAS/PP
-                            987
                (1) and (2) of section 1860D–15(a) that are
                related to administrative expenses (includ-
                ing profits) for basic coverage, denying high
@@ -28006,8 +26036,6 @@ ing—
                program.
 
 
-      HR 3590 EAS/PP
-                            988
                ‘‘(B) ADDITIONAL CONSIDERATIONS  .—In de-
           veloping and submitting each proposal under
           this section in a proposal year, the Board shall,
@@ -28034,8 +26062,6 @@ ing—
                1861(u)) and suppliers (as defined in sec-
                tion 1861(d));
 
-      HR 3590 EAS/PP
-                            989
                    ‘‘(v) consider the effects of the rec-
                ommendations on providers of services and
                suppliers with actual or projected negative
@@ -28062,8 +26088,6 @@ ing—
           under section 1805 for its review. The Board
 
 
-      HR 3590 EAS/PP
-                            990
           shall submit such draft copy by not later than
           September 1 of the determination year.
                ‘‘(E) REVIEW AND COMMENT BY THE SEC     -
@@ -28090,8 +26114,6 @@ ing—
                in clause (ii) and subsection (f)(3)(B), the
                Board shall transmit a proposal under this
 
-      HR 3590 EAS/PP
-                            991
                section to the President on January 15 of
                each year (beginning with 2014).
                     ‘‘(ii) XCEPTION  .—The Board shall
@@ -28118,8 +26140,6 @@ ing—
                     year is less than the projected percent-
                     age increase (if any) in the Consumer
 
-      HR 3590 EAS/PP
-                            992
                    Price Index for All Urban Consumers
                    (all items; United States city average)
                    for such implementation year; or
@@ -28146,8 +26166,6 @@ ing—
                tion;
 
 
-      HR 3590 EAS/PP
-                            993
                    ‘‘(iii) an actuarial opinion by the
                Chief Actuary of the Centers for Medicare &
                Medicaid Services certifying that the pro-
@@ -28174,8 +26192,6 @@ ing—
       (3)(B)). By not later than January 25 of the year,
       the Secretary shall transmit—
 
-      HR 3590 EAS/PP
-                           994
               ‘‘(A) such proposal to the President; and
               ‘‘(B) a copy of such proposal to the Medi-
           care Payment Advisory Commission for its re-
@@ -28202,8 +26218,6 @@ ing—
               rate for an implementation year shall be
               calculated as the projected 5-year average
 
-      HR 3590 EAS/PP
-                            995
                (ending with such year) of the growth in
                Medicare program spending per
                unduplicated enrollee.
@@ -28230,8 +26244,6 @@ ing—
           Medicare per capita target growth rate for an
           implementation year shall be calculated as the
 
-      HR 3590 EAS/PP
-                            996
           projected 5-year average (ending with such year)
           percentage increase in—
                    ‘‘(i) with respect to a determination
@@ -28258,8 +26270,6 @@ ing—
           graph exceeds the growth rate described in clause
           (ii) of such paragraph, the Chief Actuary shall
 
-      HR 3590 EAS/PP
-                            997
           establish an applicable savings target for the im-
           plementation year.
                ‘‘(B) APPLICABLE SAVINGS TARGET    .—For
@@ -28286,8 +26296,6 @@ ing—
                    year, 1.5 percent; and
 
 
-      HR 3590 EAS/PP
-                            998
                    ‘‘(ii) the projected excess for the imple-
                mentation year (expressed as a percent) de-
                termined under subparagraph (A).
@@ -28314,8 +26322,6 @@ ing—
           majority leader of the Senate and shall be intro-
           duced (by request) in the House by the majority
 
-      HR 3590 EAS/PP
-                            999
           leader of the House or by Members of the House
           designated by the majority leader of the House.
                ‘‘(B) NOT IN SESSION .—If either House is
@@ -28342,8 +26348,6 @@ ing—
                ‘‘(A) R EPORTING  BILL .—Not later than
           April 1 of any proposal year in which a pro-
 
-      HR 3590 EAS/PP
-                           1000
           posal is submitted by the President to Congress
           under this section, the Committee on Ways and
           Means and the Committee on Energy and Com-
@@ -28370,8 +26374,6 @@ ing—
           in the jurisdiction of the Committee on Finance
 
 
-      HR 3590 EAS/PP
-                           1001
           if that matter is relevant to a proposal contained
           in the bill submitted under subsection (c)(3).
                ‘‘(D) DISCHARGE .—If, with respect to the
@@ -28398,8 +26400,6 @@ ing—
           of the Board if that change would fail to satisfy
 
 
-      HR 3590 EAS/PP
-                           1002
           the requirements of subparagraphs (A)(i) and
           (C) of subsection (c)(2).
                ‘‘(C) LIMITATION ON CHANGES TO THIS
@@ -28426,8 +26426,6 @@ ing—
                    ‘‘(i) IME LIMITATION .—Debate in the
                Senate on any amendment to a bill under
 
-      HR 3590 EAS/PP
-                            1003
                this section shall be limited to 1 hour, to be
                equally divided between, and controlled by,
                the mover and the manager of the bill, and
@@ -28454,8 +26452,6 @@ ing—
                shall not be in order to consider an amend-
                ment that would cause the bill to result in
 
-      HR 3590 EAS/PP
-                           1004
                a net reduction in total Medicare program
                spending in the implementation year that is
                less than the applicable savings target estab-
@@ -28482,8 +26478,6 @@ ing—
                duced in the receiving House.
 
 
-      HR 3590 EAS/PP
-                            1005
                     ‘‘(ii) EFORE PASSAGE  .—If a bill that
                is introduced pursuant to paragraph (1) is
                received by one House from the other House,
@@ -28510,8 +26504,6 @@ ing—
                amended by the language of the receiving
                House.
 
-      HR 3590 EAS/PP
-                            1006
                     ‘‘(iv) ISPOSITION .—Upon disposition
                of a bill introduced pursuant to paragraph
                (1) that is received by one House from the
@@ -28538,8 +26530,6 @@ ing—
 
 
 
-      HR 3590 EAS/PP
-                            1007
                     ‘‘(ii) OTION TO FURTHER LIMIT DE    -
                BATE .—A motion to further limit debate on
                the bill is in order and is not debatable.
@@ -28566,8 +26556,6 @@ ing—
                on the conference report or any messages be-
                tween Houses shall be limited to 10 hours,
 
-      HR 3590 EAS/PP
-                            1008
                equally divided and controlled by the major-
                ity and minority leaders of the Senate or
                their designees and the Speaker of the
@@ -28594,8 +26582,6 @@ ing—
                ceed, without any further debate on any
                question, to vote on the final disposition
 
-      HR 3590 EAS/PP
-                            1009
                thereof to the exclusion of all motions not
                then pending before the Senate at that time
                or necessary to resolve the differences be-
@@ -28622,8 +26608,6 @@ ing—
           between the majority and minority leaders or
           their designees.
 
-      HR 3590 EAS/PP
-                           1010
           ‘‘(5) RULES OF THE SENATE AND HOUSE OF
      REPRESENTATIVES   .—This subsection and subsection
      (f)(2) are enacted by Congress—
@@ -28650,8 +26634,6 @@ ing—
      15 of the year in which the proposal is so submitted.
           ‘‘(2) PPLICATION .—
 
-      HR 3590 EAS/PP
-                            1011
                ‘‘(A) N GENERAL  .—A recommendation de-
           scribed in paragraph (1) shall apply as follows:
                     ‘‘(i) In the case of a recommendation
@@ -28678,8 +26660,6 @@ ing—
                ommendation, such recommendation shall
                be addressed in the regular regulatory proc-
 
-      HR 3590 EAS/PP
-                           1012
                ess timeframe and shall apply as soon as
                practicable.
                ‘‘(B) INTERIM  FINAL  RULEMAKING   .—The
@@ -28706,8 +26686,6 @@ ing—
       CERTAIN  PROVISIONS .—Nothing in paragraph (3)
       shall be construed to affect the authority of the Sec-
 
-      HR 3590 EAS/PP
-                          1013
      retary to implement any recommendation contained
      in a proposal or advisory report under this section to
      the extent that the Secretary otherwise has the author-
@@ -28734,8 +26712,6 @@ ing—
           1899A of the Social Security Act’; and
 
 
-      HR 3590 EAS/PP
-                           1014
                ‘‘(D) the matter after the resolving clause of
           which is as follows: ‘That Congress approves the
           discontinuation of the process for consideration
@@ -28762,8 +26738,6 @@ ing—
           Senate, and such joint resolution shall be placed
           on the calendar.
 
-      HR 3590 EAS/PP
-                            1015
                ‘‘(C) ONSIDERATION  .—
                     ‘‘(i) N  GENERAL  .—In the Senate,
                when the committee to which a joint resolu-
@@ -28790,8 +26764,6 @@ ing—
                ness of the Senate until disposed of.
 
 
-      HR 3590 EAS/PP
-                            1016
                     ‘‘(ii) DEBATE   LIMITATION .—In the
                Senate, consideration of the joint resolution,
                and on all debatable motions and appeals
@@ -28818,8 +26790,6 @@ ing—
                tion of the rules of the Senate to the proce-
                dure relating to a joint resolution described
 
-      HR 3590 EAS/PP
-                            1017
                in paragraph (1) shall be decided without
                debate.
                ‘‘(D) OTHER HOUSE ACTS FIRST   .—If, before
@@ -28846,8 +26816,6 @@ ing—
           House of Congress is adjourned for more than 3
           days during a session of Congress.
 
-      HR 3590 EAS/PP
-                           1018
               ‘‘(F) M  AJORITY  REQUIRED   FOR   ADOP  -
           TION.—A joint resolution considered under this
           subsection shall require an affirmative vote of
@@ -28874,8 +26842,6 @@ ing—
           ‘‘(1) EMBERSHIP  .—
 
 
-      HR 3590 EAS/PP
-                           1019
                ‘‘(A) IN GENERAL  .—The Board shall be
           composed of—
                    ‘‘(i) 15 members appointed by the
@@ -28902,8 +26868,6 @@ ing—
                tion, and a balance between urban and
                rural representatives.
 
-      HR 3590 EAS/PP
-                            1020
                     ‘‘(ii) INCLUSION  .—The appointed
                membership of the Board shall include (but
                not be limited to) physicians and other
@@ -28930,8 +26894,6 @@ ing—
           such members. Appointed members of the Board
           shall be treated as officers in the executive
 
-      HR 3590 EAS/PP
-                           1021
           branch for purposes of applying title I of the
           Ethics in Government Act of 1978 (Public Law
           95–521).
@@ -28958,8 +26920,6 @@ ing—
      shall hold office for a term of 6 years except that—
 
 
-      HR 3590 EAS/PP
-                           1022
                ‘‘(A) a member may not serve more than 2
           full consecutive terms (but may be reappointed to
           2 full consecutive terms after being appointed to
@@ -28986,8 +26946,6 @@ ing—
                ‘‘(B) DUTIES .—The Chairperson shall be
           the principal executive officer of the Board, and
 
-      HR 3590 EAS/PP
-                           1023
           shall exercise all of the executive and administra-
           tive functions of the Board, including functions
           of the Board with respect to—
@@ -29014,8 +26972,6 @@ ing—
       removed by the President for neglect of duty or mal-
       feasance in office, but for no other cause.
 
-      HR 3590 EAS/PP
-                           1024
      ‘‘(h) ACANCIES ; QUORUM  ; EAL ; ICE C HAIRPERSON ;
  VOTING ON R EPORTS .—
           ‘‘(1) VACANCIES .—No vacancy on the Board
@@ -29042,8 +26998,6 @@ ing—
           ‘‘(2) UTHORITY TO INFORM RESEARCH PRIOR      -
      ITIES FOR DATA COLLECTION   .—The Board may ad-
 
-      HR 3590 EAS/PP
-                           1025
      vise the Secretary on priorities for health services re-
      search, particularly as such priorities pertain to nec-
      essary changes and issues regarding payment reforms
@@ -29070,8 +27024,6 @@ ing—
      PERSON  .—Each appointed member, other than the
      Chairperson, shall be compensated at a rate equal to
 
-      HR 3590 EAS/PP
-                           1026
       the annual rate of basic pay prescribed for level III
       of the Executive Schedule under section 5315 of title
       5, United States Code. The Chairperson shall be com-
@@ -29098,8 +27050,6 @@ ing—
           may fix the compensation of the executive direc-
           tor and other personnel without regard to chap-
 
-      HR 3590 EAS/PP
-                           1027
           ter 51 and subchapter III of chapter 53 of title
           5, United States Code, relating to classification
           of positions and General Schedule pay rates, ex-
@@ -29126,8 +27076,6 @@ ing—
      impact of payment policies under this title on con-
      sumers.
 
-      HR 3590 EAS/PP
-                           1028
           ‘‘(2) MEMBERSHIP  .—
                ‘‘(A) N UMBER   AND   APPOINTMENT  .—The
           consumer advisory council shall be composed of
@@ -29154,8 +27102,6 @@ ing—
       of such Act shall not apply.
       ‘‘(l)EFINITIONS .—In this section:
 
-      HR 3590 EAS/PP
-                           1029
           ‘‘(1) B OARD ;  CHAIRPERSON  ;  MEMBER  .—The
       terms ‘Board’, ‘Chairperson’, and ‘Member’ mean the
       Independent Medicare Advisory Board established
@@ -29182,8 +27128,6 @@ ing—
           for All Urban Consumers (all items; United
 
 
-      HR 3590 EAS/PP
-                           1030
           States city average) as of June of the previous
           fiscal year.
           ‘‘(2) FROM  TRUST   FUNDS .—Sixty percent of
@@ -29210,8 +27154,6 @@ ing—
           shall be considered to be the Independent Medi-
           care Advisory Board, the Department of Health
 
-      HR 3590 EAS/PP
-                         1031
          and Human Services, and the relevant commit-
          tees of jurisdiction of Congress, including the
          Committee on Ways and Means and the Com-
@@ -29238,8 +27180,6 @@ ing—
               viders and items and services;
 
 
-      HR 3590 EAS/PP
-                           1032
                    (ii) the affordability of Medicare pre-
                miums and cost-sharing (including
                deductibles, coinsurance, and copayments);
@@ -29266,8 +27206,6 @@ ing—
      and the Committee on Energy and Commerce of the
 
 
-      HR 3590 EAS/PP
-                           1033
      House of Representatives and the Committee on Fi-
      nance of the Senate.
      (c) CONFORMING   A MENDMENTS  .—Section 1805(b) of
@@ -29294,8 +27232,6 @@ ed—
 
 
 
-      HR 3590 EAS/PP
-                          1034
     Subtitle F—Health Care Quality
                  Improvements
  SEC. 3501. HEALTH CARE DELIVERY SYSTEM RESEARCH;
@@ -29322,8 +27258,6 @@ at the end the following:
      ‘‘(b) GENERAL  FUNCTIONS OF THE    C ENTER .—The
 Center for Quality Improvement and Patient Safety of the
 
-      HR 3590 EAS/PP
-                            1035
 Agency for Healthcare Research and Quality (referred to
 in this section as the ‘Center’), or any other relevant agency
 or department designated by the Director, shall—
@@ -29350,8 +27284,6 @@ or department designated by the Director, shall—
       vidual providers, that—
 
 
-      HR 3590 EAS/PP
-                            1036
                ‘‘(A) deliver consistently high-quality, effi-
           cient health care services (as determined by the
           Secretary); and
@@ -29378,8 +27310,6 @@ or department designated by the Director, shall—
           ‘‘(8) provide for the development of best practices
       in the delivery of health care services that—
 
-      HR 3590 EAS/PP
-                            1037
                ‘‘(A) have a high likelihood of success, based
           on structured review of empirical evidence;
                ‘‘(B) are specified with sufficient detail of
@@ -29406,8 +27336,6 @@ or department designated by the Director, shall—
       quality improvement practices and to promote excel-
       lence in the delivery of health care services; and
 
-      HR 3590 EAS/PP
-                           1038
           ‘‘(10) build capacity at the State and commu-
      nity level to lead quality and safety efforts through
      education, training, and mentoring programs to
@@ -29434,8 +27362,6 @@ or department designated by the Director, shall—
           lished under section 399HH;
 
 
-      HR 3590 EAS/PP
-                            1039
                ‘‘(B) identify areas in which evidence is in-
           sufficient to identify strategies and methodolo-
           gies, taking into consideration areas of insuffi-
@@ -29462,8 +27388,6 @@ or department designated by the Director, shall—
           settings, and which, as soon as practicable after
           the establishment of the Center, shall include—
 
-      HR 3590 EAS/PP
-                            1040
                     ‘‘(i) the implementation of a national
                application of Intensive Care Unit improve-
                ment projects relating to the adult (includ-
@@ -29490,8 +27414,6 @@ or department designated by the Director, shall—
                tient safety reporting systems and patient
                safety organizations; and
 
-      HR 3590 EAS/PP
-                           1041
                    ‘‘(ii) using the results of such analyses
                to develop scientific methods of response to
                such events;
@@ -29518,8 +27440,6 @@ or department designated by the Director, shall—
       the activities of the health information technology ex-
       tension program under section 3012, as well as any
 
-      HR 3590 EAS/PP
-                            1042
       relevant standards, certification criteria, or imple-
       mentation specifications.
       ‘‘(e) PRIORITIZATION .—The Director shall identify
@@ -29546,8 +27466,6 @@ care and Medicaid Innovation established under section
 
 
 
-      HR 3590 EAS/PP
-                           1043
       ‘‘(g) UNDING .—There is authorized to be appro-
 priated to carry out this section $20,000,000 for fiscal years
 2010 through 2014.
@@ -29574,8 +27492,6 @@ section as the ‘Center’), shall award—
 
 
 
-      HR 3590 EAS/PP
-                           1044
           ‘‘(2) implementation grants or contracts to eligi-
      ble entities to implement the models and practices de-
      scribed under paragraph (1).
@@ -29602,8 +27518,6 @@ section as the ‘Center’), shall award—
           and assistance to health care providers regarding
           quality improvement.
 
-      HR 3590 EAS/PP
-                           1045
           ‘‘(2) MPLEMENTATION AWARD    .—To be eligible to
       receive an implementation grant or contract under
       subsection (a)(2), an entity—
@@ -29630,8 +27544,6 @@ section as the ‘Center’), shall award—
                serve low-income populations; and
 
 
-      HR 3590 EAS/PP
-                           1046
                ‘‘(B) such other information as the Director
           may require.
           ‘‘(2) IMPLEMENTATION AWARD    .—To receive a
@@ -29658,8 +27570,6 @@ ties) non-Federal contributions toward the activities to be
 carried out under the grant or contract in an amount equal
 to $1 for each $5 of Federal funds provided under the grant
 
-      HR 3590 EAS/PP
-                            1047
 or contract. Such non-Federal matching funds may be pro-
 vided directly or through donations from public or private
 entities and may be in cash or in-kind, fairly evaluated,
@@ -29686,8 +27596,6 @@ including plant, equipment, or services.
       graph (1), the Director shall determine whether to
 
 
-      HR 3590 EAS/PP
-                            1048
       renew a grant or contract with such entity under this
       section.
       ‘‘(f)OORDINATION  .—The entities that receive a grant
@@ -29714,8 +27622,6 @@ eligible entities. Grants or contracts shall be used to—
           (2) provide capitated payments to primary care
       providers as determined by the Secretary.
 
-      HR 3590 EAS/PP
-                            1049
       (b) ELIGIBLE  ENTITIES .—To be eligible to receive a
 grant or contract under subsection (a), an entity shall—
           (1)(A) be a State or State-designated entity; or
@@ -29742,8 +27648,6 @@ grant or contract under subsection (a), an entity shall—
           (5) agree to provide services to eligible individ-
       uals with chronic conditions, as described in section
 
-      HR 3590 EAS/PP
-                           1050
      1945 of the Social Security Act (as added by section
      2703), in accordance with the payment methodology
      established under subsection (c) of such section; and
@@ -29770,8 +27674,6 @@ section (a) shall—
           care;
 
 
-      HR 3590 EAS/PP
-                            1051
           (3) collaborate with local primary care providers
       and existing State and community based resources to
       coordinate disease prevention, chronic disease man-
@@ -29798,8 +27700,6 @@ section (a) shall—
                (B) coordinate and provide access to pre-
           ventive and health promotion services;
 
-      HR 3590 EAS/PP
-                            1052
                (C) provide access to appropriate specialty
           care and inpatient services;
                (D) provide quality-driven, cost-effective,
@@ -29826,8 +27726,6 @@ section (a) shall—
           tioners;
 
 
-      HR 3590 EAS/PP
-                            1053
                (I) collect and report data that permits
           evaluation of the success of the collaborative ef-
           fort on patient outcomes, including collection of
@@ -29854,8 +27752,6 @@ section (a) shall—
           include medication management, as appropriate;
 
 
-      HR 3590 EAS/PP
-                          1054
               (D) referrals for mental and behavioral
           health services, which may include the use of
           infolines; and
@@ -29882,8 +27778,6 @@ A provider who contracts with a care team shall—
           (3) meet regularly with the care team to ensure
      integration of care.
 
-      HR 3590 EAS/PP
-                           1055
      (e) R EPORTING TO  S ECRETARY .—An entity that re-
 ceives a grant or contract under subsection (a) shall submit
 to the Secretary a report that describes and evaluates, as
@@ -29910,8 +27804,6 @@ Patient Safety Research Center established in section 933
 a program to provide grants or contracts to eligible entities
 to implement medication management (referred to in this
 
-      HR 3590 EAS/PP
-                            1056
 section as ‘MTM’) services provided by licensed phar-
 macists, as a collaborative, multidisciplinary, inter-profes-
 sional approach to the treatment of chronic diseases for tar-
@@ -29938,8 +27830,6 @@ grant or contract under subsection (a), an entity shall—
       tion as the Secretary may require.
 
 
-      HR 3590 EAS/PP
-                           1057
       ‘‘(c) MTM S ERVICES TO  T ARGETED   NDIVIDUALS  .—
 The MTM services provided with the assistance of a grant
 or contract awarded under subsection (a) shall, as allowed
@@ -29966,8 +27856,6 @@ practice agreements, include—
       monitoring, and additional followup interventions on
 
 
-      HR 3590 EAS/PP
-                            1058
       a schedule developed collaboratively with the pre-
       scriber;
           ‘‘(6) documenting the care delivered and commu-
@@ -29994,8 +27882,6 @@ practice agreements, include—
 vided by licensed pharmacists under a grant or contract
 
 
-      HR 3590 EAS/PP
-                           1059
 awarded under subsection (a) shall be offered to targeted
 individuals who—
           ‘‘(1) take 4 or more prescribed medications (in-
@@ -30022,8 +27908,6 @@ group, shall determine whether it is possible to incorporate
 rapid cycle process improvement concepts in use in other
 Federal programs that have implemented MTM services.
 
-      HR 3590 EAS/PP
-                            1060
       ‘‘(f)EPORTING TO THE   S ECRETARY  .—An entity that
 receives a grant or contract under subsection (a) shall sub-
 mit to the Secretary a report that describes and evaluates,
@@ -30050,8 +27934,6 @@ which shall—
           ‘‘(5) identify and evaluate other factors that may
       impact clinical and economic outcomes, including de-
 
-      HR 3590 EAS/PP
-                          1061
      mographic characteristics, clinical characteristics,
      and health services use of the patient, as well as char-
      acteristics of the regimen, pharmacy benefit, and
@@ -30078,8 +27960,6 @@ ice Act (42 U.S.C. 300d et seq.) is amended—
 
 
 
-      HR 3590 EAS/PP
-                           1062
                (A) in the section heading, by inserting
           ‘FOR TRAUMA SYSTEMS        ’’ after GRANTS   ’’;
           and
@@ -30106,8 +27986,6 @@ trauma systems.
           4 of the Indian Health Care Improvement Act)
           or a partnership of 1 or more Indian tribes.
 
-      HR 3590 EAS/PP
-                            1063
           ‘‘(2) REGION.—The term ‘region’ means an area
       within a State, an area that lies within multiple
       States, or a similar area (such as a multicounty
@@ -30134,8 +28012,6 @@ evaluate an emergency medical and trauma system that—
       facility) in a timely fashion;
 
 
-      HR 3590 EAS/PP
-                           1064
           ‘‘(3) allows for the tracking of prehospital and
       hospital resources, including inpatient bed capacity,
       emergency department capacity, trauma center capac-
@@ -30162,8 +28038,6 @@ evaluate an emergency medical and trauma system that—
       submit to the Secretary an application at such time
       and in such manner as the Secretary may require.
 
-      HR 3590 EAS/PP
-                            1065
           ‘‘(2) APPLICATION INFORMATION    .—Each appli-
       cation shall include—
                ‘‘(A) an assurance from the eligible entity
@@ -30190,8 +28064,6 @@ evaluate an emergency medical and trauma system that—
                grated with other components of the na-
 
 
-      HR 3590 EAS/PP
-                           1066
               tional and State emergency preparedness
               system; and
                    ‘‘(vi) addresses pediatric concerns re-
@@ -30218,8 +28090,6 @@ evaluate an emergency medical and trauma system that—
      in cash or in kind, fairly evaluated, including equip-
      ment or services (and excluding indirect or overhead
 
-      HR 3590 EAS/PP
-                            1067
       costs). Amounts provided by the Federal Government,
       or services assisted or subsidized to any significant
       extent by the Federal Government, may not be in-
@@ -30246,8 +28116,6 @@ of the program, including an identification of—
 
 
 
-      HR 3590 EAS/PP
-                            1068
           ‘‘(3) methods of assuring the long-term financial
       sustainability of the emergency care and trauma sys-
       tem;
@@ -30274,8 +28142,6 @@ contained in a report made under subsection (g).’’; and
 parts A through C, beginning on the date of enactment of
 the Patient Protection and Affordable Care Act, the Sec-
 
-      HR 3590 EAS/PP
-                          1069
 retary shall transfer authority in administering grants and
 related authorities under such parts from the Administrator
 of the Health Resources and Services Administration to the
@@ -30302,8 +28168,6 @@ including—
           ‘‘(3) the translation of basic scientific research
      into improved practice; and
 
-      HR 3590 EAS/PP
-                           1070
           ‘‘(4) the development of timely and efficient de-
      livery of health services.
      ‘‘(b) EDIATRIC  EMERGENCY   M EDICAL R ESEARCH .—
@@ -30330,8 +28194,6 @@ and pediatric emergency medicine, including—
      cents in emergency care settings in order to improve
      patient safety.
 
-      HR 3590 EAS/PP
-                          1071
      ‘‘(c)MPACT  RESEARCH  .—The Secretary shall support
 research to determine the estimated economic impact of, and
 savings that result from, the implementation of coordinated
@@ -30358,8 +28220,6 @@ ma centers—
      patient stabilization and transfer, trauma education
      and outreach, coordination with local and regional
 
-      HR 3590 EAS/PP
-                           1072
      trauma systems, essential personnel and other fixed
      costs, and expenses associated with employee and non-
      employee physician services; and
@@ -30386,8 +28246,6 @@ ma centers—
           egory A are as follows:
 
 
-      HR 3590 EAS/PP
-                            1073
                     ‘‘(i) At least 40 percent of the visits in
                the emergency department of the hospital in
                which the trauma center is located were
@@ -30414,8 +28272,6 @@ ma centers—
                the emergency department were Medicaid
                and charity and self-pay patients combined.
 
-      HR 3590 EAS/PP
-                           1074
           ‘‘(4) T RAUMA    CENTERS    IN  1115  WAIVER
       STATES.—Notwithstanding paragraph (3), the Sec-
       retary may award a substantial uncompensated care
@@ -30442,8 +28298,6 @@ may not award a grant to a trauma center under subsection
           (2) CONSIDERATIONS IN MAKING GRANTS     .—Sec-
       tion 1242 of the Public Health Service Act (42 U.S.C.
 
-      HR 3590 EAS/PP
-                          1075
      300d–42) is amended by striking subsections (a) and
      (b) and inserting the following:
      ‘‘(a) S  UBSTANTIAL     U NCOMPENSATED      C ARE
@@ -30470,8 +28324,6 @@ may not award a grant to a trauma center under subsection
 
 
 
-      HR 3590 EAS/PP
-                           1076
                ‘‘(A) reserve 25 percent of the amount allo-
           cated for core mission awards for Level III and
           Level IV trauma centers; and
@@ -30498,8 +28350,6 @@ under section 1241(a)(3), the Secretary shall—
       geographic area in which the availability of trauma
       care has significantly decreased or will significantly
 
-      HR 3590 EAS/PP
-                           1077
      decrease if the center is forced to close or downgrade
      service or growth in demand for trauma services ex-
      ceeds capacity; and
@@ -30526,8 +28376,6 @@ retary may otherwise require.’’.
      Public Health Service Act (42 U.S.C. 300d–44) is
 
 
-      HR 3590 EAS/PP
-                            1078
       amended by striking subsections (a), (b), and (c) and
       inserting the following:
       ‘‘(a) PPLICATION .—The Secretary may not award a
@@ -30554,8 +28402,6 @@ from being eligible for other grants described in such sec-
 tion.
 
 
-      HR 3590 EAS/PP
-                          1079
      ‘‘(e) UNDING  D ISTRIBUTION.—Of the total amount
 appropriated for a fiscal year under section 1245, 70 per-
 cent shall be used for substantial uncompensated care
@@ -30582,8 +28428,6 @@ Secretary shall—
           C trauma center grantees; and
 
 
-      HR 3590 EAS/PP
-                            1080
            ‘‘(2) provide available funds within each cat-
       egory in a manner proportional to the award basis
       specified in section 1242(a)(2) to each eligible trauma
@@ -30610,8 +28454,6 @@ priations or amounts that are available for such purpose.’’.
 
 
 
-      HR 3590 EAS/PP
-                           1081
  ‘‘SEC. 1246. DEFINITION.
      ‘‘In this part, the term ‘uncompensated care costs’
 means unreimbursed costs from serving self-pay, charity,
@@ -30638,8 +28480,6 @@ the purposes described in subparagraph (d).
      grant under subsection (b) an entity shall—
                ‘‘(A) be—
 
-      HR 3590 EAS/PP
-                            1082
                     ‘‘(i) a public or nonprofit trauma cen-
                ter or consortium thereof that meets that re-
                quirements of paragraphs (1), (2), and (5)
@@ -30666,8 +28506,6 @@ activities consistent with subsection (b):
       physician specialties where shortages exist in the re-
 
 
-      HR 3590 EAS/PP
-                            1083
       gion involved, with priority provided to safety net
       trauma centers described in subsection (c)(1)(A)(ii).
           ‘‘(2) Providing for individual safety net trauma
@@ -30694,8 +28532,6 @@ activities consistent with subsection (b):
       tients transported by ground or air to the appropriate
       trauma center.
 
-      HR 3590 EAS/PP
-                            1084
            ‘‘(9) Enhancing interstate trauma center collabo-
       ration.
       ‘‘(e) IMITATION .—
@@ -30722,8 +28558,6 @@ apply with respect to grants provided in this part:
       appropriations in a fiscal year is less than
       $20,000,000, the Secretary shall divide such funding
 
-      HR 3590 EAS/PP
-                            1085
       evenly among only those States that have 1 or more
       trauma centers eligible for funding under subpara-
       graphs (A) and (B) of section 1241(b)(3).
@@ -30750,8 +28584,6 @@ at the end the following:
 
 
 
-      HR 3590 EAS/PP
-                            1086
  ‘‘SEC. 936. PROGRAM TO FACILITATE SHARED DECISION-
               MAKING.
       ‘‘(a) URPOSE  .—The purpose of this section is to fa-
@@ -30778,8 +28610,6 @@ preferences and values into the medical plan.
       of treatment depends on the values of the patient or
       the preferences of the patient, caregivers or authorized
       representatives regarding the benefits, harms and sci-
-      HR 3590 EAS/PP
-                          1087
      entific evidence for each treatment option, the use of
      such care should depend on the informed patient
      choice among clinically appropriate treatment op-
@@ -30806,8 +28636,6 @@ preferences and values into the medical plan.
               ‘‘(C) PERIOD OF CONTRACT   .—A contract
           under subparagraph (A) shall be for a period of
 
-      HR 3590 EAS/PP
-                         1088
          18 months (except such contract may be renewed
          after a subsequent bidding process).
          ‘‘(2) DUTIES.—The following duties are de-
@@ -30834,8 +28662,6 @@ preferences and values into the medical plan.
      of other relevant agencies, such as the Director of the
      Centers for Disease Control and Prevention and the
 
-      HR 3590 EAS/PP
-                           1089
       Director of the National Institutes of Health, shall es-
       tablish a program to award grants or contracts—
                ‘‘(A) to develop, update, and produce pa-
@@ -30862,8 +28688,6 @@ preferences and values into the medical plan.
       (1)—
 
 
-      HR 3590 EAS/PP
-                            1090
                ‘‘(A) shall be designed to engage patients,
           caregivers, and authorized representatives in in-
           formed decisionmaking with health care pro-
@@ -30890,8 +28714,6 @@ preferences and values into the medical plan.
       tor shall ensure that the activities under this section
       of the Agency and other agencies, including the Cen-
 
-      HR 3590 EAS/PP
-                          1091
      ters for Disease Control and Prevention and the Na-
      tional Institutes of Health, are free of unnecessary du-
      plication of effort.
@@ -30918,8 +28740,6 @@ preferences and values into the medical plan.
               ‘‘(B) OBJECTIVES.—The objective of a Cen-
           ter is to enhance and promote the adoption of
 
-      HR 3590 EAS/PP
-                           1092
           patient decision aids and shared decisionmaking
           through—
                    ‘‘(i) providing assistance to eligible
@@ -30946,8 +28766,6 @@ preferences and values into the medical plan.
           graph shall not be used to purchase or imple-
           ment use of patient decision aids other than
 
-      HR 3590 EAS/PP
-                            1093
           those certified under the process identified in
           subsection (c).
           ‘‘(4) GUIDANCE .—The Secretary may issue guid-
@@ -30974,8 +28792,6 @@ all available scientific evidence and research on decision-
 making and social and cognitive psychology and consult
 with drug manufacturers, clinicians, patients and con-
 
-      HR 3590 EAS/PP
-                             1094
 sumers, experts in health literacy, representatives of racial
 and ethnic minorities, and experts in women’s and pedi-
 atric health.
@@ -31002,8 +28818,6 @@ with respect to benefit and risk information.
 
 
 
-      HR 3590 EAS/PP
-                           1095
  SEC. 3508. DEMONSTRATION PROGRAM TO INTEGRATE
               QUALITY IMPROVEMENT AND PATIENT SAFE-
               TY TRAINING INTO CLINICAL EDUCATION OF
@@ -31030,8 +28844,6 @@ under subsection (a), an entity or consortium shall—
           education program; or
                (G) a school of health care administration;
 
-      HR 3590 EAS/PP
-                           1096
           (3) collaborate in the development of curricula
      described in subsection (a) with an organization that
      accredits such school or institution;
@@ -31058,8 +28870,6 @@ under subsection (a), an entity or consortium shall—
      (d) E VALUATION .—The Secretary shall take such ac-
 tion as may be necessary to evaluate the projects funded
 
-      HR 3590 EAS/PP
-                          1097
 under this section and publish, make publicly available,
 and disseminate the results of such evaluations on as wide
 a basis as is practicable.
@@ -31086,8 +28896,6 @@ Representatives a report that—
 lished within the Office of the Secretary, an Office on Wom-
 en’s Health (referred to in this section as the ‘Office’). The
 
-      HR 3590 EAS/PP
-                            1098
 Office shall be headed by a Deputy Assistant Secretary for
 Women’s Health who may report to the Secretary.
       ‘‘(b) UTIES .—The Secretary, acting through the Of-
@@ -31114,8 +28922,6 @@ fice, with respect to the health concerns of women, shall—
       Human Services Coordinating Committee on Wom-
       en’s Health, which shall be chaired by the Deputy As-
 
-      HR 3590 EAS/PP
-                            1099
       sistant Secretary for Women’s Health and composed
       of senior level representatives from each of the agen-
       cies and offices of the Department of Health and
@@ -31142,8 +28948,6 @@ fice, with respect to the health concerns of women, shall—
       between the Office and recipients of grants, contracts,
 
 
-      HR 3590 EAS/PP
-                           1100
      and agreements under subsection (c), and between the
      Office and health professionals and the general public.
      ‘‘(c) RANTS AND  C ONTRACTS  REGARDING  D UTIES.—
@@ -31170,8 +28974,6 @@ purpose of carrying out this section, there are authorized
 to be appropriated such sums as may be necessary for each
 of the fiscal years 2010 through 2014.’’.
 
-      HR 3590 EAS/PP
-                            1101
           (2) T RANSFER OF FUNCTIONS   .—There are trans-
       ferred to the Office on Women’s Health (established
       under section 229 of the Public Health Service Act,
@@ -31198,8 +29000,6 @@ of the fiscal years 2010 through 2014.’’.
       in accordance with law by the President, the Sec-
 
 
-      HR 3590 EAS/PP
-                          1102
      retary, or other authorized official, a court of com-
      petent jurisdiction, or by operation of law.
      (b) CENTERS FOR   D ISEASE C ONTROL AND   PREVEN -
@@ -31226,8 +29026,6 @@ by the Director of such Centers.
      and objectives within the Centers for women’s health
      and, as relevant and appropriate, coordinate with
 
-      HR 3590 EAS/PP
-                            1103
       other appropriate offices on activities within the Cen-
       ters that relate to prevention, research, education and
       training, service delivery, and policy development, for
@@ -31254,8 +29052,6 @@ and conditions—
       which there is reasonable evidence that indicates that
       such factors or types may be different for women.
 
-      HR 3590 EAS/PP
-                         1104
      ‘‘(d) UTHORIZATION OF A PPROPRIATIONS.—For the
 purpose of carrying out this section, there are authorized
 to be appropriated such sums as may be necessary for each
@@ -31283,8 +29079,6 @@ Health Service Act (42 U.S.C. 290aa(f)) is amended—
  ITYA CTIVITIESREGARDING  W OMEN’S H EALTH.—Part C
 
 
-     HR 3590 EAS/PP
-                            1105
 of title IX of the Public Health Service Act (42 U.S.C. 299c
 et seq.) is amended—
            (1) by redesignating sections 925 and 926 as sec-
@@ -31311,8 +29105,6 @@ section (a) shall—
       and objectives within the Agency for research impor-
       tant to women’s health and, as relevant and appro-
 
-      HR 3590 EAS/PP
-                          1106
      priate, coordinate with other appropriate offices on
      activities within the Agency that relate to health serv-
      ices and medical effectiveness research, for issues of
@@ -31339,8 +29131,6 @@ adding at the end the following:
 
 
 
-      HR 3590 EAS/PP
-                            1107
  ‘‘SEC. 713. OFFICE OF WOMEN’S HEALTH.
       ‘‘(a) STABLISHMENT   .—The Secretary shall establish
 within the Office of the Administrator of the Health Re-
@@ -31367,8 +29157,6 @@ by a director who shall be appointed by the Administrator.
       governmental organizations, consumer organizations,
       women’s health professionals, and other individuals
 
-      HR 3590 EAS/PP
-                           1108
      and groups, as appropriate, on Administration policy
      with regard to women; and
           ‘‘(5) serve as a member of the Department of
@@ -31395,8 +29183,6 @@ women’s health on the date of enactment of this section.
 purpose of carrying out this section, there are authorized
 
 
-      HR 3590 EAS/PP
-                          1109
 to be appropriated such sums as may be necessary for each
 of the fiscal years 2010 through 2014.’’.
      (g) F OOD AND   DRUG  A DMINISTRATION  O FFICE OF
@@ -31423,8 +29209,6 @@ shall be appointed by the Commissioner of Food and Drugs.
      particular concern to women’s health within the juris-
      diction of the Administration, including, where rel-
 
-      HR 3590 EAS/PP
-                          1110
      evant and appropriate, adequate inclusion of women
      and analysis of data by sex in Administration proto-
      cols and policies;
@@ -31451,8 +29235,6 @@ of the fiscal years 2010 through 2014.’’.
 this section and the amendments made by this section may
 
 
-      HR 3590 EAS/PP
-                            1111
 be construed as establishing regulatory authority or modi-
 fying any existing regulatory authority.
       (i) LIMITATION ON   T ERMINATION .—Notwithstanding
@@ -31479,8 +29261,6 @@ this section.
       Section 340A of the Public Health Service Act (42
 U.S.C. 256a) is amended—
 
-      HR 3590 EAS/PP
-                            1112
           (1) by striking subsection (d)(3) and inserting
       the following:
           ‘‘(3) LIMITATIONS ON GRANT PERIOD    .—In car-
@@ -31507,8 +29287,6 @@ U.S.C. 256a) is amended—
 
 
 
-      HR 3590 EAS/PP
-                        1113
  SEC. 3511. AUTHORIZATION OF APPROPRIATIONS.
      Except where otherwise provided in this subtitle (or
 an amendment made by this subtitle), there is authorized
@@ -31535,8 +29313,6 @@ prove or expand guaranteed Medicare benefits and protect
 access to Medicare providers.
 
 
-     HR 3590 EAS/PP
-                         1114
  SEC. 3602. NO CUTS IN GUARANTEED BENEFITS.
      Nothing in this Act shall result in the reduction or
 elimination of any benefits guaranteed by law to partici-
@@ -31563,8 +29339,6 @@ of—
          (2) the Secretary of Agriculture;
          (3) the Secretary of Education;
 
-     HR 3590 EAS/PP
-                           1115
           (4) the Chairman of the Federal Trade Commis-
      sion;
           (5) the Secretary of Transportation;
@@ -31591,8 +29365,6 @@ of—
      motion, public health, and integrative health care
      strategy that incorporates the most effective and
 
-      HR 3590 EAS/PP
-                            1116
       achievable means of improving the health status of
       Americans and reducing the incidence of preventable
       illness and disability in the United States;
@@ -31619,8 +29391,6 @@ of—
       (e) MEETINGS .—The Council shall meet at the call of
 the Chairperson.
 
-      HR 3590 EAS/PP
-                          1117
      (f) ADVISORY GROUP .—
           (1) N GENERAL  .—The President shall establish
      an Advisory Group to the Council to be known as the
@@ -31647,8 +29417,6 @@ the Chairperson.
                    (iv) health coaching;
                    (v) public health education;
 
-      HR 3590 EAS/PP
-                          1118
                    (vi) geriatrics; and
                    (vii) rehabilitation medicine.
           (3) P URPOSES   AND  DUTIES  .—The Advisory
@@ -31675,8 +29443,6 @@ shall—
           (3) make recommendations to improve Federal
      efforts relating to prevention, health promotion, pub-
 
-      HR 3590 EAS/PP
-                            1119
       lic health, and integrative health care practices to en-
       sure Federal efforts are consistent with available
       standards and evidence.
@@ -31703,8 +29469,6 @@ gress, a report that—
       tic violence screenings) and the prevention measures
       for the 5 leading disease killers in the United States;
 
-      HR 3590 EAS/PP
-                           1120
           (4) contains specific science-based initiatives to
       achieve the measurable goals of Healthy People 2010
       regarding nutrition, exercise, and smoking cessation,
@@ -31731,8 +29495,6 @@ Comptroller General of the United States shall jointly con-
 duct periodic reviews, not less than every 5 years, and eval-
 uations of every Federal disease prevention and health pro-
 
-      HR 3590 EAS/PP
-                            1121
 motion initiative, program, and agency. Such reviews shall
 be evaluated based on effectiveness in meeting metrics-based
 goals with an analysis posted on such agencies’ public
@@ -31759,8 +29521,6 @@ ies in the Treasury not otherwise appropriated—
       (c) U SE OF   FUND .—The Secretary shall transfer
 amounts in the Fund to accounts within the Department
 
-      HR 3590 EAS/PP
-                          1122
 of Health and Human Services to increase funding, over
 the fiscal year 2008 level, for programs authorized by the
 Public Health Service Act, for prevention, wellness, and
@@ -31787,8 +29547,6 @@ lowing:
      propriate expertise. Such Task Force shall review the
      scientific evidence related to the effectiveness, appro-
 
-      HR 3590 EAS/PP
-                            1123
       priateness, and cost-effectiveness of clinical preventive
       services for the purpose of developing recommenda-
       tions for the health care community, and updating
@@ -31815,8 +29573,6 @@ lowing:
           areas for new recommendations and interven-
           tions related to those topic areas, including those
 
-      HR 3590 EAS/PP
-                            1124
           related to specific sub-populations and age
           groups;
                ‘‘(B) at least once during every 5-year pe-
@@ -31843,8 +29599,6 @@ lowing:
           by current recommendations.
 
 
-      HR 3590 EAS/PP
-                            1125
           ‘‘(3) ROLE OF AGENCY  .—The Agency shall pro-
       vide ongoing administrative, research, and technical
       support for the operations of the Task Force, includ-
@@ -31871,8 +29625,6 @@ lowing:
       pendent and, to the extent practicable, not subject to
       political pressure.
 
-      HR 3590 EAS/PP
-                          1126
           ‘‘(7) AUTHORIZATION   OF  APPROPRIATIONS  .—
      There are authorized to be appropriated such sums as
      may be necessary for each fiscal year to carry out the
@@ -31899,8 +29651,6 @@ livering population-based services, including primary care
 professionals, health care systems, professional societies, em-
 ployers, community organizations, non-profit organiza-
 
-      HR 3590 EAS/PP
-                            1127
 tions, schools, governmental public health agencies, Indian
 tribes, tribal organizations and urban Indian organiza-
 tions, medical groups, Congress and other policy-makers.
@@ -31927,8 +29677,6 @@ clude—
       ment health objectives and related target setting for
       health improvement;
 
-      HR 3590 EAS/PP
-                          1128
           ‘‘(4) the enhanced dissemination of recommenda-
      tions;
           ‘‘(5) the provision of technical assistance to those
@@ -31955,8 +29703,6 @@ Task Force and the Advisory Committee on Immunization
 Practices, including the examination of how each task
 
 
-      HR 3590 EAS/PP
-                           1129
 force’s recommendations interact at the nexus of clinic and
 community.
      ‘‘(e) OPERATION .—In carrying out the duties under
@@ -31983,8 +29729,6 @@ Human Services (referred to in this section as the ‘‘Sec-
 retary’’) shall provide for the planning and implementation
 of a national public–private partnership for a prevention
 
-      HR 3590 EAS/PP
-                            1130
 and health promotion outreach and education campaign to
 raise public awareness of health improvement across the life
 span. Such campaign shall include the dissemination of in-
@@ -32011,8 +29755,6 @@ formation that—
       (b) CONSULTATION  .—In coordinating the campaign
 under subsection (a), the Secretary shall consult with the
 
-      HR 3590 EAS/PP
-                           1131
 Institute of Medicine to provide ongoing advice on evidence-
 based scientific information for policy, program develop-
 ment, and evaluation.
@@ -32039,8 +29781,6 @@ ment, and evaluation.
           and may be targeted to specific age groups based
           on peer-reviewed social research;
 
-      HR 3590 EAS/PP
-                            1132
                (D) shall not be duplicative of any other
           Federal efforts relating to health promotion and
           disease prevention; and
@@ -32067,8 +29807,6 @@ ment a plan for the dissemination of health promotion and
 disease prevention information consistent with national
 priorities, to health care providers who participate in Fed-
 
-      HR 3590 EAS/PP
-                           1133
 eral programs, including programs administered by the In-
 dian Health Service, the Department of Veterans Affairs,
 the Department of Defense, and the Health Resources and
@@ -32095,8 +29833,6 @@ an Internet portal for accessing risk-assessment tools devel-
 oped and maintained by private and academic entities.
 
 
-      HR 3590 EAS/PP
-                           1134
      (h) P RIORITY F UNDING .—Funding for the activities
 authorized under this section shall take priority over fund-
 ing provided through the Centers for Disease Control and
@@ -32123,8 +29859,6 @@ and activities required under this section.
      2017, the Secretary of Health and Human Services
      shall report to Congress on the status and effectiveness
 
-      HR 3590 EAS/PP
-                          1135
      of efforts under paragraphs (1) and (2), including
      summaries of the States’ efforts to increase awareness
      of coverage of obesity-related services.
@@ -32151,8 +29885,6 @@ essary to carry out this section.
           as the Secretary may require, including at a
           minimum an assurance that funds awarded
 
-      HR 3590 EAS/PP
-                            1136
           under the grant shall not be used to provide any
           service that is not authorized or allowed by Fed-
           eral, State, or local law.
@@ -32179,8 +29911,6 @@ essary to carry out this section.
           (5) A PPROPRIATIONS .—Out of any funds in the
       Treasury not otherwise appropriated, there is appro-
 
-      HR 3590 EAS/PP
-                           1137
      priated for each of fiscal years 2010 through 2013,
      $50,000,000 for the purpose of carrying out this sub-
      section. Funds appropriated under this paragraph
@@ -32207,8 +29937,6 @@ In this section:
           rals to, and follow-up for, specialty care and oral
           health services.
 
-      HR 3590 EAS/PP
-                           1138
                ‘‘(B) MENTAL HEALTH  .—Mental health and
           substance use disorder assessments, crisis inter-
           vention, counseling, treatment, and referral to a
@@ -32235,8 +29963,6 @@ In this section:
                    ‘‘(ii) include factors indicative of the
                health status of such children and adoles-
 
-      HR 3590 EAS/PP
-                           1139
               cents of an area, including the ability of the
               residents of such area to pay for health serv-
               ices, the accessibility of such services, the
@@ -32263,8 +29989,6 @@ In this section:
      ‘‘(b) UTHORITY  T O AWARD  G RANTS .—The Secretary
 shall award grants for the costs of the operation of school-
 
-      HR 3590 EAS/PP
-                            1140
 based health centers (referred to in this section as ‘SBHCs’)
 that meet the requirements of this section.
       ‘‘(c) PPLICATIONS .—To be eligible to receive a grant
@@ -32291,8 +30015,6 @@ under this section, an entity shall—
                in the catchment area of the SBHC;
 
 
-      HR 3590 EAS/PP
-                            1141
                     ‘‘(iii) the SBHC will provide on-site
                access during the academic day when school
                is in session and 24-hour coverage through
@@ -32319,8 +30041,6 @@ under this section, an entity shall—
                Education Provisions Act; and
 
 
-      HR 3590 EAS/PP
-                           1142
               ‘‘(D) such other information as the Sec-
           retary may require.
      ‘‘(d) REFERENCES AND   C ONSIDERATION .—In review-
@@ -32347,8 +30067,6 @@ ing applications:
      ‘‘(e) W AIVER  OF  R EQUIREMENTS  .—The Secretary
 may—
 
-      HR 3590 EAS/PP
-                           1143
           ‘‘(1) under appropriate circumstances, waive the
      application of all or part of the requirements of this
      subsection with respect to an SBHC for not to exceed
@@ -32375,8 +30093,6 @@ may—
                cians, nurses, and other personnel of the
                SBHC; and
 
-      HR 3590 EAS/PP
-                           1144
                ‘‘(B) may not be used to provide abortions.
           ‘‘(2) ONSTRUCTION  .—The Secretary may award
      grants which may be used to pay the costs associated
@@ -32403,8 +30119,6 @@ may—
      of the amount of the grant (which may be provided
 
 
-      HR 3590 EAS/PP
-                           1145
       in cash or in-kind) to carry out the activities sup-
       ported by the grant.
           ‘‘(2) WAIVER.—The Secretary may waive all or
@@ -32431,8 +30145,6 @@ through a SBHC funded under this section to an individual
 without the consent of the parent or guardian of such indi-
 
 
-      HR 3590 EAS/PP
-                           1146
 vidual if such individual is considered a minor under ap-
 plicable State law.
       ‘‘(l)UTHORIZATION OF   A PPROPRIATIONS .—For pur-
@@ -32459,8 +30171,6 @@ and other caries, periodontal disease, and oral cancer.
       ‘‘(b) EQUIREMENTS  .—In establishing the campaign,
 the Secretary shall—
 
-      HR 3590 EAS/PP
-                            1147
           ‘‘(1) ensure that activities are targeted towards
       specific populations such as children, pregnant
       women, parents, the elderly, individuals with disabil-
@@ -32487,8 +30197,6 @@ shall award demonstration grants to eligible entities to
 demonstrate the effectiveness of research-based dental caries
 disease management activities.
 
-      HR 3590 EAS/PP
-                            1148
       ‘‘(b) LIGIBILITY.—To be eligible for a grant under
 this section, an entity shall—
           ‘‘(1) be a community-based provider of dental
@@ -32515,8 +30223,6 @@ ment activities.
       ‘‘(d) SE OF  INFORMATION  .—The Secretary shall uti-
 lize information generated from grantees under this section
 
-      HR 3590 EAS/PP
-                          1149
 in planning and implementing the public education cam-
 paign under section 399LL.
  ‘‘SEC. 399LL–2. AUTHORIZATION OF APPROPRIATIONS.
@@ -32543,8 +30249,6 @@ amended—
      Disease Control and Prevention, shall enter into coop-
      erative agreements with State, territorial, and Indian
 
-      HR 3590 EAS/PP
-                          1150
      tribes or tribal organizations (as those terms are de-
      fined in section 4 of the Indian Health Care Improve-
      ment Act) to establish oral health leadership and pro-
@@ -32571,8 +30275,6 @@ amended—
           healthcare.
 
 
-      HR 3590 EAS/PP
-                           1151
               (B) S  TATE   REPORTS   AND  MANDATORY
           MEASUREMENTS   .—
                    (i) IN GENERAL  .—Not later than 5
@@ -32599,8 +30301,6 @@ amended—
      ‘‘tooth-level surveillance’’ means a clinical examina-
      tion where an examiner looks at each dental surface,
 
-      HR 3590 EAS/PP
-                           1152
      on each tooth in the mouth and as expanded by the
      Division of Oral Health of the Centers for Disease
      Control and Prevention.
@@ -32627,8 +30327,6 @@ amended—
 
 
 
-      HR 3590 EAS/PP
-                          1153
  SEC. 4103. MEDICARE COVERAGE OF ANNUAL WELLNESS
              VISIT PROVIDING A PERSONALIZED PREVEN-
              TION PLAN.
@@ -32655,8 +30353,6 @@ amended—
 1395x) is amended by adding at the end the following new
 subsection:
 
-      HR 3590 EAS/PP
-                            1154
                   ‘‘Annual Wellness Visit
       ‘‘(hhh)(1) The term ‘personalized prevention plan serv-
 ices’ means the creation of a plan for an individual—
@@ -32683,8 +30379,6 @@ scribed in this paragraph are the following:
       blood pressure, and other routine measurements.
           ‘‘(D) Detection of any cognitive impairment.
 
-      HR 3590 EAS/PP
-                            1155
           ‘‘(E) The establishment of, or an update to, the
       following:
                ‘‘(i) A screening schedule for the next 5 to
@@ -32711,8 +30405,6 @@ scribed in this paragraph are the following:
       tions to reduce health risks and promote self-manage-
       ment and wellness, including weight loss, physical ac-
 
-      HR 3590 EAS/PP
-                            1156
       tivity, smoking cessation, fall prevention, and nutri-
       tion.
           ‘‘(G) Any other element determined appropriate
@@ -32739,8 +30431,6 @@ and shall provide that a health risk assessment—
           ‘‘(ii) may be furnished—
 
 
-      HR 3590 EAS/PP
-                            1157
                 ‘‘(I) through an interactive telephonic or
            web-based program that meets the standards es-
            tablished under subparagraph (B);
@@ -32767,8 +30457,6 @@ make available to the public a health risk assessment model.
 Such model shall meet the guidelines under subparagraph
 
 
-      HR 3590 EAS/PP
-                             1158
 (A) and may be used to meet the requirement under para-
 graph (1)(A).
       ‘‘(ii) Any health risk assessment that meets the guide-
@@ -32795,8 +30483,6 @@ that is compatible with electronic medical records and per-
 sonal health records) and may experiment with the use of
 personalized technology to aid in the development of self-
 
-      HR 3590 EAS/PP
-                             1159
 management skills and management of and adherence to
 provider recommendations in order to improve the health
 status of beneficiaries.
@@ -32823,8 +30509,6 @@ tween such services.
            ‘‘(ii) establishes a yearly schedule for appro-
       priate provision of such elements thereafter.’’.
 
-      HR 3590 EAS/PP
-                           1160
      (c) PAYMENT AND   ELIMINATION OF  COST-SHARING .—
           (1) P AYMENT AND ELIMINATION OF COINSUR      -
      ANCE .—Section 1833(a)(1) of the Social Security Act
@@ -32851,8 +30535,6 @@ tween such services.
               (A) E  XCLUSION FROM OPD FEE SCHED       -
           ULE .—Section 1833(t)(1)(B)(iv) of the Social
 
-      HR 3590 EAS/PP
-                           1161
           Security Act (42 U.S.C. 1395l(t)(1)(B)(iv)) is
           amended by striking ‘‘and diagnostic mammog-
           raphy’’ and inserting ‘‘, diagnostic mammog-
@@ -32879,8 +30561,6 @@ tween such services.
                (A) by striking ‘‘and’’ before ‘‘(9)’’; and
 
 
-      HR 3590 EAS/PP
-                           1162
                (B) by inserting before the period the fol-
           lowing: ‘‘, and (10) such deductible shall not
           apply with respect to personalized prevention
@@ -32907,8 +30587,6 @@ section shall apply to services furnished on or after January
 
 
 
-      HR 3590 EAS/PP
-                           1163
  SEC. 4104. REMOVAL OF BARRIERS TO PREVENTIVE SERV-
              ICES IN MEDICARE.
      (a) D EFINITION OF P REVENTIVE  SERVICES .—Section
@@ -32935,8 +30613,6 @@ lowing:
               (A) IN GENERAL  .—Section 1833(a)(1) of the
           Social Security Act (42 U.S.C. 1395l(a)(1)), as
           amended by section 4103(c)(1), is amended—
-      HR 3590 EAS/PP
-                            1164
                     (i) in subparagraph (T), by inserting
                ‘‘(or 100 percent if such services are rec-
                ommended with a grade of A or B by the
@@ -32963,8 +30639,6 @@ lowing:
                ommended with a grade of A or B by the
                United States Preventive Services Task
 
-      HR 3590 EAS/PP
-                           1165
                Force for any indication or population, the
                amount paid shall be 100 percent of the
                lesser of the actual charge for the services or
@@ -32991,8 +30665,6 @@ lowing:
                (B) C ONFORMING    AMENDMENTS   .—Section
           1833(a)(2) of the Social Security Act (42 U.S.C.
 
-      HR 3590 EAS/PP
-                          1166
          1395l(a)(2)), as amended by section
          4103(c)(3)(B), is amended—
                   (i) in subparagraph (G)(ii), by strik-
@@ -33019,8 +30691,6 @@ Act (42 U.S.C. 1395l(b)), as amended by section 4103(c)(4),
 is amended—
 
 
-      HR 3590 EAS/PP
-                          1167
           (1) in paragraph (1), by striking ‘‘items and
      services described in section 1861(s)(10)(A)’’ and in-
      serting ‘‘preventive services described in subparagraph
@@ -33047,8 +30717,6 @@ after January 1, 2011.
 Social Security Act (42 U.S.C. 1395m) is amended by add-
 ing at the end the following new subsection:
 
-      HR 3590 EAS/PP
-                          1168
      ‘‘(n) AUTHORITY  TO  M ODIFY OR  ELIMINATE  C OV-
  ERAGE OF   CERTAIN   PREVENTIVE  S ERVICES.—Notwith-
 standing any other provision of this title, effective begin-
@@ -33075,8 +30743,6 @@ Social Security Act.
 
 
 
-      HR 3590 EAS/PP
-                           1169
  SEC. 4106. IMPROVING ACCESS TO PREVENTIVE SERVICES
               FOR ELIGIBLE ADULTS IN MEDICAID.
       (a) LARIFICATION OF  INCLUSION OF  SERVICES .—Sec-
@@ -33103,8 +30769,6 @@ tion 1905(a)(13) of the Social Security Act (42 U.S.C.
           restoration of an individual to the best possible
           functional level;’’.
 
-      HR 3590 EAS/PP
-                          1170
      (b) NCREASED  F MAP.—Section 1905(b) of the Social
 Security Act (42 U.S.C. 1396d(b)), as amended by sections
 2001(a)(3)(A) and 2004(c)(1), is amended in the first sen-
@@ -33131,8 +30795,6 @@ this section shall take effect on January 1, 2013.
      (a) R EQUIRING  C OVERAGE  OF  C OUNSELING  AND
  PHARMACOTHERAPY FOR    CESSATION OF T OBACCO U SE BY
 
-      HR 3590 EAS/PP
-                           1171
 P REGNANT   W OMEN .—Section 1905 of the Social Security
 Act (42 U.S.C. 1396d), as amended by sections
 2001(a)(3)(B) and 2303, is further amended—
@@ -33159,8 +30821,6 @@ furnished—
                ‘‘(i) is legally authorized to furnish such
           services under State law (or the State regulatory
 
-      HR 3590 EAS/PP
-                         1172
          mechanism provided by State law) of the State
          in which the services are furnished; and
               ‘‘(ii) is authorized to receive payment for
@@ -33187,8 +30847,6 @@ title.’’.
 by inserting before the period at the end the following: ‘‘,
 except, in the case of pregnant women when recommended
 
-      HR 3590 EAS/PP
-                          1173
 in accordance with the Guideline referred to in section
 1905(bb)(2)(A), agents approved by the Food and Drug Ad-
 ministration under the over-the-counter monograph process
@@ -33215,8 +30873,6 @@ bacco cessation’’.
      U.S.C. 1396o–1(b)(3)(B)(iii)) is amended by insert-
      ing ‘‘, and counseling and pharmacotherapy for ces-
 
-      HR 3590 EAS/PP
-                          1174
      sation of tobacco use by pregnant women (as defined
      in section 1905(bb))’’ after ‘‘complicate the preg-
      nancy’’.
@@ -33243,8 +30899,6 @@ section shall take effect on October 1, 2010.
           may encourage behavior modification and deter-
           mine scalable solutions.
 
-      HR 3590 EAS/PP
-                           1175
           (2) DURATION .—
                (A) I  NITIATION   OF   PROGRAM   ;   RE-
           SOURCES .—The Secretary shall awards grants to
@@ -33271,8 +30925,6 @@ section shall take effect on October 1, 2010.
                (A) IN GENERAL .—A program described in
           this paragraph is a comprehensive, evidence-
 
-      HR 3590 EAS/PP
-                           1176
           based, widely available, and easily accessible
           program, proposed by the State and approved by
           the Secretary, that is designed and uniquely
@@ -33299,8 +30951,6 @@ section shall take effect on October 1, 2010.
           shall ensure that a State makes any program de-
 
 
-      HR 3590 EAS/PP
-                          1177
           scribed in subparagraph (A) available and acces-
           sible to Medicaid beneficiaries.
               (D) F LEXIBILITY IN IMPLEMENTATION  .—A
@@ -33327,8 +30977,6 @@ section shall take effect on October 1, 2010.
      State awarded a grant to conduct an initiative under
      this section shall conduct an outreach and education
 
-      HR 3590 EAS/PP
-                            1178
       campaign to make Medicaid beneficiaries and pro-
       viders participating in Medicaid who reside in the
       State aware of the programs described in subsection
@@ -33355,8 +31003,6 @@ a system to—
       porting on quality measures for Medicaid managed
       care programs.
 
-      HR 3590 EAS/PP
-                           1179
      (d) EVALUATIONS AND   REPORTS .—
           (1) INDEPENDENT ASSESSMENT    .—The Secretary
      shall enter into a contract with an independent entity
@@ -33383,8 +31029,6 @@ a system to—
      submit reports to the Secretary, on a semi-annual
      basis, regarding the programs that are supported by
 
-      HR 3590 EAS/PP
-                            1180
       the grant funds. Such report shall include informa-
       tion, as specified by the Secretary, regarding—
                (A) the specific uses of the grant funds;
@@ -33411,8 +31055,6 @@ a system to—
       (1), together with recommendations for such legisla-
 
 
-      HR 3590 EAS/PP
-                           1181
      tion and administrative action as the Secretary deter-
      mines appropriate.
      (e) NO E FFECT ON  ELIGIBILITY FOR, OR AMOUNT OF  ,
@@ -33439,8 +31081,6 @@ expended.
      given that term for purposes of title XIX of the Social
      Security Act (42 U.S.C. 1396 et seq.).
 
-      HR 3590 EAS/PP
-                           1182
      Subtitle C—Creating Healthier
                   Communities
  SEC. 4201. COMMUNITY TRANSFORMATION GRANTS.
@@ -33467,8 +31107,6 @@ under subsection (a), an entity shall—
           tion; or
               (E) an Indian tribe; and
 
-      HR 3590 EAS/PP
-                           1183
           (2) submit to the Director an application at such
      time, in such a manner, and containing such infor-
      mation as the Director may require, including a de-
@@ -33495,8 +31133,6 @@ under subsection (a), an entity shall—
           may focus on (but not be limited to)—
 
 
-      HR 3590 EAS/PP
-                            1184
                     (i) creating healthier school environ-
                ments, including increasing healthy food
                options, physical activity opportunities,
@@ -33523,8 +31159,6 @@ under subsection (a), an entity shall—
                cial, economic, and geographic determinants
                of health; and
 
-      HR 3590 EAS/PP
-                           1185
                    (vii) addressing special populations
                needs, including all age groups and individ-
                uals with disabilities, and individuals in
@@ -33551,8 +31185,6 @@ under subsection (a), an entity shall—
           among community members participating in
           preventive health activities
 
-      HR 3590 EAS/PP
-                           1186
                (B) TYPES OF MEASURES   .—In carrying out
           subparagraph (A), the eligible entity shall, with
           respect to residents in the community, meas-
@@ -33579,8 +31211,6 @@ under subsection (a), an entity shall—
           practices, and lessons learned with respect to ac-
           tivities carried out under the grant; and
 
-      HR 3590 EAS/PP
-                           1187
                (B) develop models for the replication of
           successful programs and activities and the men-
           toring of other eligible entities.
@@ -33607,8 +31237,6 @@ rates of obesity or inactivity.
       (f) UTHORIZATION OF    APPROPRIATIONS  .—There are
 authorized to be appropriated to carry out this section, such
 
-      HR 3590 EAS/PP
-                          1188
 sums as may be necessary for each fiscal years 2010 through
 2014.
  SEC. 4202. HEALTHY AGING, LIVING WELL; EVALUATION OF
@@ -33635,8 +31263,6 @@ sums as may be necessary for each fiscal years 2010 through
           at such time, in such manner, and containing
           such information as the Secretary may require
 
-      HR 3590 EAS/PP
-                           1189
           including a description of the program to be car-
           ried out under the grant;
                (C) design a strategy for improving the
@@ -33663,8 +31289,6 @@ sums as may be necessary for each fiscal years 2010 through
                implementing such activities, a grantee
                shall collaborate with the Centers for Dis-
 
-      HR 3590 EAS/PP
-                           1190
                ease Control and Prevention and the Ad-
                ministration on Aging, and relevant local
                agencies and organizations.
@@ -33691,8 +31315,6 @@ sums as may be necessary for each fiscal years 2010 through
 
 
 
-      HR 3590 EAS/PP
-                           1191
                    (ii) T YPES  OF   SCREENING   ACTIVI -
                TIES.—Screening activities conducted under
                this subparagraph may include—
@@ -33719,8 +31341,6 @@ sums as may be necessary for each fiscal years 2010 through
                graph (C)(ii), receive clinical referral/treat-
 
 
-      HR 3590 EAS/PP
-                           1192
                ment for follow-up services to reduce such
                risk.
                    (ii) MECHANISM .—
@@ -33747,8 +31367,6 @@ sums as may be necessary for each fiscal years 2010 through
                         (III) UNINSURED INDIVIDUALS  .—
                    With respect to an individual deter-
 
-      HR 3590 EAS/PP
-                           1193
                    mined to be uninsured under subclause
                    (I), the grantee’s community-based
                    clinical partner described in para-
@@ -33775,8 +31393,6 @@ sums as may be necessary for each fiscal years 2010 through
           measure changes in the prevalence of chronic dis-
           ease risk factors among participants.
 
-      HR 3590 EAS/PP
-                         1194
          (4) P ILOT PROGRAM   EVALUATION .—The Sec-
      retary shall conduct an annual evaluation of the effec-
      tiveness of the pilot program under this subsection. In
@@ -33803,8 +31419,6 @@ sums as may be necessary for each fiscal years 2010 through
          (2) MEDICARE EVALUATION OF PREVENTION AND
      WELLNESS PROGRAMS  .—
 
-      HR 3590 EAS/PP
-                           1195
                (A) I N  GENERAL  .—The Secretary shall
           evaluate community prevention and wellness
           programs including those that are sponsored by
@@ -33831,8 +31445,6 @@ sums as may be necessary for each fiscal years 2010 through
                         (II) falls;
 
 
-      HR 3590 EAS/PP
-                           1196
                         (III) chronic disease self-manage-
                    ment; and
                         (IV) mental health.
@@ -33859,8 +31471,6 @@ sums as may be necessary for each fiscal years 2010 through
                    under the Medicare program for condi-
 
 
-      HR 3590 EAS/PP
-                           1197
                    tions that are amenable to improve-
                    ment under such programs.
           (3) R EPORT .—Not later than September 30,
@@ -33887,8 +31497,6 @@ sums as may be necessary for each fiscal years 2010 through
       Management Account. Amounts transferred under the
 
 
-      HR 3590 EAS/PP
-                            1198
       preceding sentence shall remain available until ex-
       pended.
           (5) A DMINISTRATION  .—Chapter 35 of title 44,
@@ -33915,8 +31523,6 @@ Food and Drug Administration, promulgate regulatory
 standards in accordance with the Administrative Procedure
 Act (2 U.S.C. 551 et seq.) setting forth the minimum tech-
 
-      HR 3590 EAS/PP
-                          1199
 nical criteria for medical diagnostic equipment used in (or
 in conjunction with) physician’s offices, clinics, emergency
 rooms, hospitals, and other medical settings. The standards
@@ -33943,8 +31549,6 @@ Procedure Act (2 U.S.C. 551 et seq.).’’.
      (a) STATE AUTHORITY  TO PURCHASE  R ECOMMENDED
  VACCINES FOR A DULTS.—Section 317 of the Public Health
 
-      HR 3590 EAS/PP
-                          1200
 Service Act (42 U.S.C. 247b) is amended by adding at the
 end the following:
      ‘‘(l) UTHORITY TO  PURCHASE   RECOMMENDED   V AC-
@@ -33971,8 +31575,6 @@ is further amended by adding at the end the following:
      program to award grants to States to improve the
      provision of recommended immunizations for chil-
 
-      HR 3590 EAS/PP
-                            1201
       dren, adolescents, and adults through the use of evi-
       dence-based, population-based interventions for high-
       risk populations.
@@ -33999,8 +31601,6 @@ is further amended by adding at the end the following:
           health care providers concerning immunizations
 
 
-      HR 3590 EAS/PP
-                            1202
           in combination with one or more other interven-
           tions;
                ‘‘(C) reducing out-of-pocket costs for fami-
@@ -34027,8 +31627,6 @@ is further amended by adding at the end the following:
           ‘‘(4) C ONSIDERATION  .—In awarding grants
       under this subsection, the Secretary shall consider
 
-      HR 3590 EAS/PP
-                           1203
      any reviews or recommendations of the Task Force on
      Community Preventive Services.
           ‘‘(5) VALUATION .—Not later than 3 years after
@@ -34055,8 +31653,6 @@ U.S.C. 247b(j)) is amended—
      fiscal years 1998 through 2005’’; and
 
 
-      HR 3590 EAS/PP
-                          1204
           (2) in paragraph (2), by striking ‘‘after October
      1, 1997,’’.
      (d) RULE OF  CONSTRUCTION  R EGARDING  ACCESS TO
@@ -34083,8 +31679,6 @@ tions.
               ommended vaccination that was covered
               under part D;
 
-      HR 3590 EAS/PP
-                           1205
                    (ii) the number of such beneficiaries
                who actually received a routinely rec-
                ommended vaccination that was covered
@@ -34111,8 +31705,6 @@ tions.
       ury not otherwise appropriated, there are appro-
 
 
-      HR 3590 EAS/PP
-                          1206
      priated $1,000,000 for fiscal year 2010 to carry out
      this subsection.
  SEC. 4205. NUTRITION LABELING OF STANDARD MENU
@@ -34139,8 +31731,6 @@ the Federal Food, Drug, and Cosmetic Act (21 U.S.C.
      (regardless of the type of ownership of the locations)
      and offering for sale substantially the same menu
 
-      HR 3590 EAS/PP
-                            1207
       items, the restaurant or similar retail food establish-
       ment shall disclose the information described in sub-
       clauses (ii) and (iii).
@@ -34167,8 +31757,6 @@ the Federal Food, Drug, and Cosmetic Act (21 U.S.C.
           statement adjacent to the name of the standard
           menu item, so as to be clearly associated with the
 
-      HR 3590 EAS/PP
-                            1208
           standard menu item, on the menu board, includ-
           ing a drive-through menu board, the number of
           calories contained in the standard menu item, as
@@ -34195,8 +31783,6 @@ the Federal Food, Drug, and Cosmetic Act (21 U.S.C.
       beverages or food that is on display and that is visible
       to customers, a restaurant or similar retail food es-
 
-      HR 3590 EAS/PP
-                            1209
       tablishment shall place adjacent to each food offered
       a sign that lists calories per displayed food item or
       per serving.
@@ -34223,8 +31809,6 @@ the Federal Food, Drug, and Cosmetic Act (21 U.S.C.
       ent required under subclause (ii)(III), should be dis-
       closed for the purpose of providing information to as-
 
-      HR 3590 EAS/PP
-                           1210
       sist consumers in maintaining healthy dietary prac-
       tices, the Secretary may require, by regulation, disclo-
       sure of such nutrient in the written form required
@@ -34251,8 +31835,6 @@ the Federal Food, Drug, and Cosmetic Act (21 U.S.C.
                ‘‘(I)N GENERAL  .—In the case of an article
           of food sold from a vending machine that—
 
-      HR 3590 EAS/PP
-                            1211
                     ‘‘(aa) does not permit a prospective
                purchaser to examine the Nutrition Facts
                Panel before purchasing the article or does
@@ -34279,8 +31861,6 @@ the Federal Food, Drug, and Cosmetic Act (21 U.S.C.
           retary, as specified by the Secretary by regula-
           tion.
 
-      HR 3590 EAS/PP
-                           1212
                ‘‘(II) EGISTRATION .—Within 120 days of
           enactment of this clause, the Secretary shall pub-
           lish a notice in the Federal Register specifying
@@ -34307,8 +31887,6 @@ the Federal Food, Drug, and Cosmetic Act (21 U.S.C.
                dients, and other factors, as the Secretary
                determines; and
 
-      HR 3590 EAS/PP
-                            1213
                     ‘‘(bb) specify the format and manner of
                the nutrient content disclosure requirements
                under this subclause.
@@ -34335,8 +31913,6 @@ that is not part of a chain with 20 or more locations doing
 business under the same name (regardless of the type of
 ownership of the locations) and offering for sale substan-
 
-      HR 3590 EAS/PP
-                            1214
 tially the same menu items unless such restaurant or simi-
 lar retail food establishment complies with the voluntary
 provision of nutrition information requirements under sec-
@@ -34363,8 +31939,6 @@ ments made by this section shall be construed—
       Act.
 
 
-      HR 3590 EAS/PP
-                          1215
  SEC. 4206. DEMONSTRATION PROJECT CONCERNING INDI-
              VIDUALIZED WELLNESS PLAN.
      Section 330 of the Public Health Service Act (42
@@ -34391,8 +31965,6 @@ U.S.C. 245b) is amended by adding at the end the following:
                    ‘‘(i) Nutritional counseling.
                    ‘‘(ii) A physical activity plan.
 
-      HR 3590 EAS/PP
-                           1216
                    ‘‘(iii) Alcohol and smoking cessation
                counseling and services.
                    ‘‘(iv) Stress management.
@@ -34419,8 +31991,6 @@ U.S.C. 245b) is amended by adding at the end the following:
 
 
 
-      HR 3590 EAS/PP
-                            1217
  SEC. 4207. REASONABLE BREAK TIME FOR NURSING MOTH-
               ERS.
       Section 7 of the Fair Labor Standards Act of 1938
@@ -34447,8 +32017,6 @@ ture, or structure of the employer’s business.
       ‘‘(4) Nothing in this subsection shall preempt a State
 law that provides greater protections to employees than the
 protections provided for under this subsection.’’.
-      HR 3590 EAS/PP
-                          1218
   Subtitle D—Support for Prevention
      and Public Health Innovation
  SEC. 4301. RESEARCH ON OPTIMIZING THE DELIVERY OF
@@ -34475,8 +32043,6 @@ ported under this section shall include—
      in terms of effectiveness and cost.
 
 
-      HR 3590 EAS/PP
-                         1219
      (c) EXISTING  PARTNERSHIPS .—Research supported
 under this section shall be coordinated with the Community
 Preventive Services Task Force and carried out by building
@@ -34503,8 +32069,6 @@ under this section.
      ported health care or public health program, activity
      or survey (including Current Population Surveys and
 
-      HR 3590 EAS/PP
-                            1220
       American Community Surveys conducted by the Bu-
       reau of Labor Statistics and the Bureau of the Cen-
       sus) collects and reports, to the extent practicable—
@@ -34531,8 +32095,6 @@ under this section.
           measures;
 
 
-      HR 3590 EAS/PP
-                           1221
                ‘‘(B) develop standards for the measurement
           of sex, primary language, and disability status;
                ‘‘(C) develop standards for the collection of
@@ -34559,8 +32121,6 @@ under this section.
                set forth in section 510 of the Rehabilitation
                Act of 1973; and
 
-      HR 3590 EAS/PP
-                           1222
                    ‘‘(iii) the number of employees of
                health care providers trained in disability
                awareness and patient care of individuals
@@ -34587,8 +32147,6 @@ under this section.
       or supported health care or public health program or
       activity, the Secretary shall analyze data collected
 
-      HR 3590 EAS/PP
-                           1223
      under paragraph (a) to detect and monitor trends in
      health disparities (as defined for purposes of section
      485E) at the Federal and State levels.
@@ -34615,8 +32173,6 @@ under this section.
 
 
 
-      HR 3590 EAS/PP
-                          1224
           ‘‘(2) EPORTING OF DATA  .—The Secretary shall
      report data and analyses described in (a) and (b)
      through—
@@ -34643,8 +32199,6 @@ versely affect any individual.
               ‘‘(A) all data collected pursuant to sub-
           section (a) is protected—
 
-      HR 3590 EAS/PP
-                            1225
                     ‘‘(i) under privacy protections that are
                at least as broad as those that the Secretary
                applies to other health data under the regu-
@@ -34671,8 +32225,6 @@ versely affect any individual.
       and entities within the Department of Health and
       Human Services specified in subsection (c)(1)..
 
-      HR 3590 EAS/PP
-                          1226
      ‘‘(f)ATA ON R URAL U NDERSERVED  POPULATIONS .—
 The Secretary shall ensure that any data collected in ac-
 cordance with this section regarding racial and ethnic mi-
@@ -34699,8 +32251,6 @@ agencies in carrying out this section.’’.
 
 
 
-      HR 3590 EAS/PP
-                           1227
                (A) M EDICAID.—Section 1902(a) of the So-
           cial Security Act (42 U.S.C. 1396a(a)), as
           amended by section 2001(d), is amended—
@@ -34727,8 +32277,6 @@ agencies in carrying out this section.’’.
       individuals, parents, and legal guardians.’’.
 
 
-      HR 3590 EAS/PP
-                           1228
           (2) EXTENDING MEDICARE REQUIREMENT TO AD     -
      DRESS HEALTH DISPARITIES DATA COLLECTION TO
      MEDICAID AND CHIP   .—Title XIX of the Social Secu-
@@ -34755,8 +32303,6 @@ Secretary shall consider the following objectives:
      and title XXI on race, ethnicity, sex, primary lan-
      guage, and disability status.
 
-      HR 3590 EAS/PP
-                           1229
       ‘‘(b) EPORTS TO C ONGRESS .—
           ‘‘(1) REPORT ON EVALUATION   .—Not later than
       18 months after the date of the enactment of this sec-
@@ -34783,8 +32329,6 @@ Secretary shall consider the following objectives:
       ommendations for improving the identification of
       health care disparities for beneficiaries under this
 
-      HR 3590 EAS/PP
-                          1230
      title and under title XXI based on analyses of the
      data collected under subsection (c).
      ‘‘(c) MPLEMENTING   E FFECTIVE  APPROACHES  .—Not
@@ -34811,8 +32355,6 @@ place, the Director shall—
      rector) with technical assistance, consultation, tools,
 
 
-      HR 3590 EAS/PP
-                           1231
       and other resources in evaluating such employers’ em-
       ployer-based wellness programs, including—
                ‘‘(A) measuring the participation and meth-
@@ -34839,8 +32381,6 @@ place, the Director shall—
 
 
 
-      HR 3590 EAS/PP
-                            1232
  ‘‘SEC. 399MM–1. NATIONAL WORKSITE HEALTH POLICIES
               AND PROGRAMS STUDY.
       ‘‘(a) N G ENERAL .—In order to assess, analyze, and
@@ -34867,8 +32407,6 @@ tion of privately funded programs unless an entity with a
 privately funded wellness program requests such an evalua-
 tion.
 
-      HR 3590 EAS/PP
-                          1233
  ‘‘SEC. 399MM–3. PROHIBITION OF FEDERAL WORKPLACE
              WELLNESS REQUIREMENTS.
      ‘‘Notwithstanding any other provision of this part,
@@ -34895,8 +32433,6 @@ Academic centers that assist State and eligible local and
 tribal health departments may also be eligible for funding
 under this section as the Director determines appropriate.
 Grants shall be awarded under this section to assist public
-      HR 3590 EAS/PP
-                           1234
 health agencies in improving surveillance for, and response
 to, infectious diseases and other conditions of public health
 importance by—
@@ -34923,8 +32459,6 @@ of which—
 
 
 
-      HR 3590 EAS/PP
-                           1235
           ‘‘(2) not less than $60,000,000 shall be made
      available each such fiscal year for activities under
      subsection (a)(3); and
@@ -34951,8 +32485,6 @@ of which—
           and chronic pain in the general population, and
           in identified racial, ethnic, gender, age, and
 
-      HR 3590 EAS/PP
-                          1236
           other demographic groups that may be dis-
           proportionately affected by inadequacies in the
           assessment, diagnosis, treatment, and manage-
@@ -34979,8 +32511,6 @@ of which—
      (b) P AIN R ESEARCH AT   NATIONAL  INSTITUTES OF
  H EALTH .—Part B of title IV of the Public Health Service
 
-      HR 3590 EAS/PP
-                            1237
 Act (42 U.S.C. 284 et seq.) is amended by adding at the
 end the following:
  ‘‘SEC. 409J. PAIN RESEARCH.
@@ -35007,8 +32537,6 @@ end the following:
       section.
 
 
-      HR 3590 EAS/PP
-                          1238
      ‘‘(b) NTERAGENCY   PAIN  RESEARCH   COORDINATING
  COMMITTEE .—
           ‘‘(1) STABLISHMENT  .—The Secretary shall es-
@@ -35035,8 +32563,6 @@ end the following:
 
 
 
-      HR 3590 EAS/PP
-                           1239
                    ‘‘(i) 6 non-Federal members shall be
                appointed from among scientists, physi-
                cians, and other health professionals.
@@ -35063,8 +32589,6 @@ end the following:
           vention, and treatment of pain and diseases and
           disorders associated with pain;
 
-      HR 3590 EAS/PP
-                           1240
               ‘‘(B) identify critical gaps in basic and
           clinical research on the symptoms and causes of
           pain;
@@ -35091,8 +32615,6 @@ section:
 of grants, cooperative agreements, and contracts to health
 professions schools, hospices, and other public and private
 
-      HR 3590 EAS/PP
-                            1241
 entities for the development and implementation of pro-
 grams to provide education and training to health care pro-
 fessionals in pain care.
@@ -35119,8 +32641,6 @@ information and education on—
       and
 
 
-      HR 3590 EAS/PP
-                           1242
           ‘‘(5) recent findings, developments, and improve-
      ments in the provision of pain care.
      ‘‘(c) VALUATION OF  P ROGRAMS .—The Secretary shall
@@ -35147,8 +32667,6 @@ U.S.C. 1320b–9a(e)(8)) is amended to read as follows:
      the period of fiscal years 2010 through 2014.’’.
 
 
-      HR 3590 EAS/PP
-                           1243
          Subtitle E—Miscellaneous
                     Provisions
  SEC. 4401. SENSE OF THE SENATE CONCERNING CBO SCOR-
@@ -35175,8 +32693,6 @@ goals, the Secretary of Health and Human Services shall—
      ployees, and health conditions, including workplace
 
 
-      HR 3590 EAS/PP
-                          1244
      fitness, healthy food and beverages, and incentives in
      the Federal Employee Health Benefits Program; and
          (2) submit to Congress a report concerning such
@@ -35203,8 +32719,6 @@ health disparity, and rural populations by—
      of health care services for all individuals;
 
 
-      HR 3590 EAS/PP
-                           1245
           (3) enhancing health care workforce education
       and training to improve access to and the delivery of
       health care services for all individuals; and
@@ -35231,8 +32745,6 @@ health disparity, and rural populations by—
           retary of Health and Human Services.
 
 
-      HR 3590 EAS/PP
-                           1246
           (2) HEALTH CARE CAREER PATHWAY     .—The term
      ‘‘healthcare career pathway’’ means a rigorous, en-
      gaging, and high quality set of courses and services
@@ -35259,8 +32771,6 @@ health disparity, and rural populations by—
                    (i) a secondary school diploma; and
 
 
-      HR 3590 EAS/PP
-                           1247
                    (ii) a postsecondary degree, an appren-
                ticeship or other occupational certification,
                a certificate, or a license.
@@ -35287,8 +32797,6 @@ health disparity, and rural populations by—
           under section 117 of such Act (29 U.S.C. 2832),
           respectively.
 
-      HR 3590 EAS/PP
-                           1248
           (5) P OSTSECONDARY    EDUCATION  .—The term
      ‘‘postsecondary education’’ means—
                (A) a 4-year program of instruction, or not
@@ -35315,8 +32823,6 @@ health disparity, and rural populations by—
      Apprenticeship or a State agency recognized by the
      Department of Labor.
 
-      HR 3590 EAS/PP
-                          1249
      (b) T ITLE VII  OF THE  P UBLIC  HEALTH   SERVICE
  ACT.—Section 799B of the Public Health Service Act (42
 U.S.C. 295p) is amended—
@@ -35343,8 +32849,6 @@ U.S.C. 295p) is amended—
      (a)(2) of section 751, satisfies the requirements in sec-
      tion 751(d)(1), and has as one of its principal func-
 
-      HR 3590 EAS/PP
-                            1250
       tions the operation of an area health education center.
       Appropriate organizations may include hospitals,
       health organizations with accredited primary care
@@ -35371,8 +32875,6 @@ U.S.C. 295p) is amended—
       term in section 1861(hh)(1) of the Social Security Act
       (42 U.S.C. 1395x(hh)(1)).
 
-      HR 3590 EAS/PP
-                           1251
           ‘‘(15) CULTURAL COMPETENCY    .—The term ‘cul-
       tural competency’ shall be defined by the Secretary in
       a manner consistent with section 1707(d)(3).
@@ -35399,8 +32901,6 @@ U.S.C. 295p) is amended—
       uate psychology’ means an accredited program in
       professional psychology.
 
-      HR 3590 EAS/PP
-                           1252
           ‘‘(20) H EALTH  DISPARITY  POPULATION   .—The
      term ‘health disparity population’ has the meaning
      given such term in section 903(d)(1).
@@ -35427,8 +32927,6 @@ U.S.C. 295p) is amended—
           ‘‘(24) PARAPROFESSIONAL CHILD AND ADOLES     -
      CENT MENTAL HEALTH WORKER       .—The term ‘para-
 
-      HR 3590 EAS/PP
-                           1253
      professional child and adolescent mental health work-
      er’ means an individual who is not a mental or be-
      havioral health service professional, but who works at
@@ -35455,8 +32953,6 @@ U.S.C. 296) is amended—
           6)’’; and
 
 
-      HR 3590 EAS/PP
-                           1254
                (B) by striking the period as inserting the
           following: ‘‘where graduates are—
                ‘‘(A) authorized to sit for the National
@@ -35483,8 +32979,6 @@ U.S.C. 296) is amended—
       laureate degree in nursing. Such programs may in-
       clude, Registered Nurse (RN) to Bachelor’s of Science
 
-      HR 3590 EAS/PP
-                          1255
      of Nursing (BSN) programs, RN to MSN (Master of
      Science of Nursing) programs, or BSN to Doctoral
      programs.’’.
@@ -35511,8 +33005,6 @@ that—
 
 
 
-      HR 3590 EAS/PP
-                           1256
           (5) encourages innovations to address population
      needs, constant changes in technology, and other envi-
      ronmental factors.
@@ -35539,8 +33031,6 @@ tion referred to as the ‘‘Commission’’).
               health care services; and other related fields;
               and
 
-      HR 3590 EAS/PP
-                           1257
                    (ii) who will provide a combination of
                professional perspectives, broad geographic
                representation, and a balance between
@@ -35567,8 +33057,6 @@ tion referred to as the ‘‘Commission’’).
                    secondary institutions, institutions of
                    higher education, including 2 and 4
 
-      HR 3590 EAS/PP
-                           1258
                    year institutions, or registered appren-
                    ticeship programs).
                    (ii) ADDITIONAL MEMBERS    .—The re-
@@ -35595,8 +33083,6 @@ tion referred to as the ‘‘Commission’’).
           (3) TERMS .—
 
 
-      HR 3590 EAS/PP
-                           1259
                (A) IN GENERAL .—The terms of members of
           the Commission shall be for 3 years except that
           the Comptroller General shall designate staggered
@@ -35623,8 +33109,6 @@ tion referred to as the ‘‘Commission’’).
       serving away from home and the member’s regular
       place of business, a member may be allowed travel ex-
 
-      HR 3590 EAS/PP
-                           1260
       penses, as authorized by the Chairman of the Com-
       mission. Physicians serving as personnel of the Com-
       mission may be provided a physician comparability
@@ -35651,8 +33135,6 @@ tion referred to as the ‘‘Commission’’).
       ber for the remainder of that member’s term.
 
 
-      HR 3590 EAS/PP
-                            1261
           (6) M EETINGS .—The Commission shall meet at
       the call of the chairman, but no less frequently than
       on a quarterly basis.
@@ -35679,8 +33161,6 @@ tion referred to as the ‘‘Commission’’).
 
 
 
-      HR 3590 EAS/PP
-                           1262
                (A) review current and projected health care
           workforce supply and demand, including the top-
           ics described in paragraph (3);
@@ -35707,8 +33187,6 @@ tion referred to as the ‘‘Commission’’).
                (B) health care workforce education and
           training capacity, including the number of stu-
 
-      HR 3590 EAS/PP
-                           1263
           dents who have completed education and train-
           ing, including registered apprenticeships; the
           number of qualified faculty; the education and
@@ -35735,8 +33213,6 @@ tion referred to as the ‘‘Commission’’).
           1998 (29 U.S.C. 2801 et seq.), the Carl D. Per-
           kins Career and Technical Education Act of
 
-      HR 3590 EAS/PP
-                           1264
           2006 (20 U.S.C. 2301 et seq.), the Higher Edu-
           cation Act of 1965 (20 U.S.C. 1001 et seq.), and
           any other Federal health care workforce pro-
@@ -35763,8 +33239,6 @@ tion referred to as the ‘‘Commission’’).
                planning that identifies health care profes-
                sional skills needed and maximizes the skill
 
-      HR 3590 EAS/PP
-                            1265
                sets of health care professionals across dis-
                ciplines.
                     (ii) An analysis of the nature, scopes of
@@ -35791,8 +33265,6 @@ tion referred to as the ‘‘Commission’’).
                     levels.
 
 
-      HR 3590 EAS/PP
-                           1266
                         (V) Emergency medical service
                    workforce capacity, including the re-
                    tention and recruitment of the volun-
@@ -35819,8 +33291,6 @@ tion referred to as the ‘‘Commission’’).
           cies, make recommendations to the fiscal and ad-
 
 
-      HR 3590 EAS/PP
-                           1267
           ministrative agent under section 5102(b) for
           grant recipients under section 5102;
                (C) assess the implementation of the grants
@@ -35847,8 +33317,6 @@ tion referred to as the ‘‘Commission’’).
       tion 761(b) of the Public Service Health Act (as
       amended by section 5103).
 
-      HR 3590 EAS/PP
-                          1268
      (e) C ONSULTATION   W ITH  FEDERAL , S TATE,  AND
  LOCAL  A GENCIES, C ONGRESS , AND  O THER  O RGANIZA-
  TIONS.—
@@ -35875,8 +33343,6 @@ tion referred to as the ‘‘Commission’’).
      ruption or loss of civil service status.
 
 
-      HR 3590 EAS/PP
-                           1269
       (f) DIRECTOR AND   STAFF ; EXPERTS AND   C ONSULT -
  ANTS .—Subject to such review as the Comptroller General
 of the United States determines to be necessary to ensure
@@ -35903,8 +33369,6 @@ mission may—
           (6) prescribe such rules and regulations as the
       Commission determines to be necessary with respect
 
-      HR 3590 EAS/PP
-                           1270
      to the internal organization and operation of the
      Commission.
      (g) POWERS .—
@@ -35931,8 +33395,6 @@ mission may—
      access to all deliberations, records, and data of the
      Commission, immediately upon request.
 
-      HR 3590 EAS/PP
-                           1271
           (3) PERIODIC AUDIT .—The Commission shall be
      subject to periodic audit by an independent public ac-
      countant under contract to the Commission.
@@ -35959,8 +33421,6 @@ mission may—
      tioners, primary care providers, preventive medicine
      physicians, optometrists, ophthalmologists, physician
 
-      HR 3590 EAS/PP
-                            1272
       assistants, pharmacists, dentists, dental hygienists,
       and other oral healthcare professionals, allied health
       professionals, doctors of chiropractic, community
@@ -35987,8 +33447,6 @@ mission may—
           prevention and treatment providers), social
           workers, physical and occupational therapists,
 
-      HR 3590 EAS/PP
-                            1273
           public health professionals, clinical pharmacists,
           allied health professionals, doctors of chiro-
           practic, community health workers, school
@@ -36015,8 +33473,6 @@ mission may—
 
 
 
-      HR 3590 EAS/PP
-                           1274
                (E) any other health professional the Comp-
           troller General of the United States determines
           appropriate.
@@ -36043,8 +33499,6 @@ gram, including—
           (1) administering the grants;
 
 
-      HR 3590 EAS/PP
-                           1275
           (2) providing technical assistance to grantees;
      and
           (3) reporting performance information to the
@@ -36071,8 +33525,6 @@ gram, including—
      and retain individuals in, careers in health care and
      related industries.
 
-      HR 3590 EAS/PP
-                           1276
           (3) F ISCAL AND ADMINISTRATIVE AGENT    .—The
       Governor of the State receiving a planning grant has
       the authority to appoint a fiscal and an administra-
@@ -36099,8 +33551,6 @@ gram, including—
           in order to create health care career pathways
 
 
-      HR 3590 EAS/PP
-                            1277
           for students and adults, including dislocated
           workers.
                (B) Identify current and projected high de-
@@ -36127,8 +33577,6 @@ gram, including—
           (6) PERFORMANCE AND EVALUATION     .—Before the
       State partnership receives a planning grant, such
 
-      HR 3590 EAS/PP
-                           1278
      partnership and the Administrator of the Administra-
      tion shall jointly determine the performance bench-
      marks that will be established for the purposes of the
@@ -36155,8 +33603,6 @@ gram, including—
           tration shall submit a report to Congress ana-
           lyzing the planning activities, performance, and
 
-      HR 3590 EAS/PP
-                           1279
           fund utilization of each State grant recipient,
           including an identification of promising prac-
           tices and a profile of the activities of each State
@@ -36183,8 +33629,6 @@ gram, including—
 
 
 
-      HR 3590 EAS/PP
-                           1280
                (A) received a planning grant under sub-
           section (c) and completed all requirements of
           such grant; or
@@ -36211,8 +33655,6 @@ gram, including—
                (C) a description of the activities for which
           implementation grant funds are sought, includ-
 
-      HR 3590 EAS/PP
-                           1281
           ing grants to regions by the State partnership to
           advance coherent and comprehensive regional
           health care workforce planning activities;
@@ -36239,8 +33681,6 @@ gram, including—
           not less than 60 percent of the grant funds to
           make grants to be competitively awarded by the
 
-      HR 3590 EAS/PP
-                           1282
           State partnership, consistent with State procure-
           ment rules, to encourage regional partnerships to
           address health care workforce development needs
@@ -36267,8 +33707,6 @@ gram, including—
                local barriers to a comprehensive and coher-
                ent strategy, including changes in State or
 
-      HR 3590 EAS/PP
-                           1283
                local policies to foster coherent and com-
                prehensive health care workforce develop-
                ment activities, including health care career
@@ -36295,8 +33733,6 @@ gram, including—
                ried out by regional and State partnerships;
                and
 
-      HR 3590 EAS/PP
-                           1284
                    (vii) participate in the Administra-
                tion’s evaluation and reporting activities.
           (7) PERFORMANCE AND EVALUATION    .—Before the
@@ -36323,8 +33759,6 @@ gram, including—
           the State partnership in meeting the perform-
           ance benchmarks.
 
-      HR 3590 EAS/PP
-                           1285
               (B) R EPORT TO CONGRESS   .—The Adminis-
           tration shall submit a report to Congress ana-
           lyzing implementation activities, performance,
@@ -36351,8 +33785,6 @@ Service Act (42 U.S.C. 294m) is amended—
           (2) by striking subsection (b) and inserting the
      following:
 
-      HR 3590 EAS/PP
-                          1286
      ‘‘(b) ATIONAL  CENTER FOR   H EALTH  CARE  W ORK-
  FORCE A NALYSIS.—
           ‘‘(1) STABLISHMENT  .—The Secretary shall es-
@@ -36379,8 +33811,6 @@ Service Act (42 U.S.C. 294m) is amended—
           national Internet registry of each grant awarded
           under this title and a database to collect data
 
-      HR 3590 EAS/PP
-                          1287
           from longitudinal evaluations (as described in
           subsection (d)(2)) on performance measures (as
           developed under sections 749(d)(3), 757(d)(3),
@@ -36407,8 +33837,6 @@ Service Act (42 U.S.C. 294m) is amended—
           National Center and to the public; and
 
 
-      HR 3590 EAS/PP
-                           1288
                ‘‘(B) providing technical assistance to local
           and regional entities on the collection, analysis,
           and reporting of data.
@@ -36435,8 +33863,6 @@ Service Act (42 U.S.C. 294m) is amended—
 
 
 
-      HR 3590 EAS/PP
-                           1289
                ‘‘(B) collecting and reporting data on per-
           formance measures developed under sections
           749(d)(3), 757(d)(3), and 762(a)(3).
@@ -36463,8 +33889,6 @@ Service Act (42 U.S.C. 294m) is amended—
           TIONS .—To carry out subsection (d), there are
           authorized to be appropriated such sums as may
 
-      HR 3590 EAS/PP
-                            1290
           be necessary for fiscal years 2010 through
           2014.’’; and
           (4) in paragraph (2), by striking ‘‘subsection
@@ -36491,8 +33915,6 @@ section (a).
           base (as established under section
           761(b)(2)(E)).’’.
 
-      HR 3590 EAS/PP
-                           1291
      (d) PERFORMANCE   M EASURES ; GUIDELINES FOR  LON -
  GITUDINAL E VALUATIONS .—
           (1) ADVISORY COMMITTEE ON TRAINING IN PRI    -
@@ -36519,8 +33941,6 @@ section (a).
           and inserting a semicolon; and
               (C) by adding at the end the following:
 
-      HR 3590 EAS/PP
-                           1292
           ‘‘(3) develop, publish, and implement perform-
       ance measures for programs under this part;
           ‘‘(4) develop and publish guidelines for longitu-
@@ -36547,8 +33967,6 @@ section (a).
       grams under this title, except for programs under
       part C or D.’’.
 
-      HR 3590 EAS/PP
-                          1293
   Subtitle C—Increasing the Supply
       of the Health Care Workforce
  SEC. 5201. FEDERALLY SUPPORTED STUDENT LOAN FUNDS.
@@ -36575,8 +33993,6 @@ U.S.C. 292s) is amended—
      ‘‘(d) ENSE OF CONGRESS .—It is the sense of Congress
 that funds repaid under the loan program under this sec-
 
-      HR 3590 EAS/PP
-                           1294
 tion should not be transferred to the Treasury of the United
 States or otherwise used for any other purpose other than
 to carry out this section.’’.
@@ -36603,8 +34019,6 @@ Health Service Act (42 U.S.C. 297b(a)) is amended—
      yearly loan rate and the aggregate of the loans.’’.
 
 
-      HR 3590 EAS/PP
-                           1295
      (b) L OAN P ROVISIONS.—Section 836(b) of the Public
 Health Service Act (42 U.S.C. 297b(b)) is amended—
           (1) in paragraph (1)(C), by striking ‘‘1986’’ and
@@ -36631,8 +34045,6 @@ abuse prevention and treatment services.
      ‘‘(b) PROGRAM   ADMINISTRATION .—Through the pro-
 gram established under this section, the Secretary shall
 
-      HR 3590 EAS/PP
-                            1296
 enter into contracts with qualified health professionals
 under which—
           ‘‘(1) such qualified health professionals will
@@ -36659,8 +34071,6 @@ under which—
           child and adolescent mental health professional
 
 
-      HR 3590 EAS/PP
-                           1297
           serving an area or population described in such
           paragraph.
      ‘‘(c)NIG ENERAL .—
@@ -36687,8 +34097,6 @@ under which—
           fessional who—
 
 
-      HR 3590 EAS/PP
-                            1298
                     ‘‘(i) has received specialized training
                or clinical experience in child and adoles-
                cent mental health in psychiatry, psy-
@@ -36715,8 +34123,6 @@ under which—
       The Secretary may not enter into a contract under
       this subsection with an eligible individual unless—
 
-      HR 3590 EAS/PP
-                           1299
                ‘‘(A) the individual agrees to work in, or for
           a provider serving, a health professional shortage
           area or medically underserved area, or to serve
@@ -36743,8 +34149,6 @@ authorized to be appropriated $30,000,000 for each of fiscal
 years 2010 through 2014 to carry out subsection (c)(1)(A)
 
 
-      HR 3590 EAS/PP
-                            1300
 and $20,000,000 for each of fiscal years 2010 through 2013
 to carry out subsection (c)(1)(B).’’.
  SEC. 5204. PUBLIC HEALTH WORKFORCE RECRUITMENT
@@ -36771,8 +34175,6 @@ Program, an individual shall—
       State, local, or tribal public health agency, or a re-
 
 
-      HR 3590 EAS/PP
-                            1301
       lated training fellowship, as recognized by the Sec-
       retary, to commence upon graduation;
           ‘‘(B)(i) have graduated, during the preceding 10-
@@ -36799,8 +34201,6 @@ and an individual shall contain—
       that the Secretary will repay on behalf of the indi-
       vidual loans incurred by the individual in the pur-
 
-      HR 3590 EAS/PP
-                            1302
       suit of the relevant degree or certificate in accordance
       with the terms of the contract;
           ‘‘(2) an agreement on the part of the individual
@@ -36827,8 +34227,6 @@ and an individual shall contain—
       funds being appropriated for loan repayments under
       this section;
 
-      HR 3590 EAS/PP
-                            1303
            ‘‘(5) a statement of the damages to which the
       United States is entitled, under this section for the
       individual’s breach of the contract; and
@@ -36856,8 +34254,6 @@ and an individual shall contain—
       that does not exceed 3 of the eligible loan balance for
       each year of obligated service of the individual.
 
-      HR 3590 EAS/PP
-                           1304
           ‘‘(3) TAX LIABILITY .—For the purpose of pro-
       viding reimbursements for tax liability resulting from
       payments under paragraph (2) on behalf of an indi-
@@ -36884,8 +34280,6 @@ be necessary for each of fiscal years 2011 through 2015.’’.
 
 
 
-      HR 3590 EAS/PP
-                          1305
  SEC. 5205. ALLIED HEALTH WORKFORCE RECRUITMENT
              AND RETENTION PROGRAMS.
      (a) PURPOSE .—The purpose of this section is to assure
@@ -36912,8 +34306,6 @@ cation Act of 1965 (20 U.S.C. 1078–11) is amended—
           facilities, ambulatory care facilities, personal
           residences and other settings located in health
           professional shortage areas, medically under-
-      HR 3590 EAS/PP
-                            1306
           served areas, or medically underserved popu-
           lations, as recognized by the Secretary of Health
           and Human Services.’’; and
@@ -36940,8 +34332,6 @@ cation Act of 1965 (20 U.S.C. 1078–11) is amended—
           underserved populations, as recognized by the
           Secretary of Health and Human Services.’’.
 
-      HR 3590 EAS/PP
-                          1307
  SEC. 5206. GRANTS FOR STATE AND LOCAL PROGRAMS.
      (a) N G ENERAL .—Section 765(d) of the Public Health
 Service Act (42 U.S.C. 295(d)) is amended—
@@ -36968,8 +34358,6 @@ mid-career professionals in the public health and allied
 health workforce to receive additional training in the field
 of public health and allied health.
      ‘‘(b) LIGIBILIT.—
-      HR 3590 EAS/PP
-                            1308
           ‘‘(1) ELIGIBLE ENTITY .—The term ‘eligible enti-
       ty’ indicates an accredited educational institution
       that offers a course of study, certificate program, or
@@ -36996,8 +34384,6 @@ U.S.C. 254q(a)) is amended to read as follows:
 purpose of carrying out this section, there is authorized to
 
 
-      HR 3590 EAS/PP
-                            1309
 be appropriated, out of any funds in the Treasury not oth-
 erwise appropriated, the following:
           ‘‘(1) For fiscal year 2010, $320,461,632.
@@ -37024,8 +34410,6 @@ the development and operation of nurse-managed health
 clinics.
 
 
-      HR 3590 EAS/PP
-                           1310
      (b) G RANTS.—Subpart 1 of part D of title III of the
 Public Health Service Act (42 U.S.C. 254b et seq.) is
 amended by inserting after section 330A the following:
@@ -37052,8 +34436,6 @@ section.
      ‘‘(c) PPLICATIONS .—To be eligible to receive a grant
 under this section, an entity shall—
 
-      HR 3590 EAS/PP
-                           1311
           ‘‘(1) be an NMHC; and
           ‘‘(2) submit to the Secretary an application at
      such time, in such manner, and containing—
@@ -37080,8 +34462,6 @@ mined by the Secretary, taking into account—
      ering State, local, and other operational funding pro-
      vided to the NMHC; and
 
-      HR 3590 EAS/PP
-                           1312
           ‘‘(2) other factors, as the Secretary determines
      appropriate.
      ‘‘(e) AUTHORIZATION OF   APPROPRIATIONS  .—For the
@@ -37108,8 +34488,6 @@ U.S.C. 204) is amended to read as follows:
      pointed without regard to the civil-service laws and
 
 
-      HR 3590 EAS/PP
-                          1313
      compensated without regard to the Classification Act
      of 1923, as amended.
           ‘‘(3) APPOINTMENT .—Commissioned officers of
@@ -37136,8 +34514,6 @@ viduals classified as officers in the Reserve Corps under this
 section (as such section existed on the day before the date
 
 
-      HR 3590 EAS/PP
-                           1314
 of enactment of such Act) and serving on active duty shall
 be deemed to be commissioned officers of the Regular Corps.
      ‘‘(c) URPOSE AND  U SE OF READY R ESEARCH .—
@@ -37164,8 +34540,6 @@ be deemed to be commissioned officers of the Regular Corps.
               ‘‘(D) be available for service assignment in
           isolated, hardship, and medically underserved
 
-      HR 3590 EAS/PP
-                          1315
          communities (as defined in section 799B) to im-
          prove access to health services.
      ‘‘(d) UNDING .—For the purpose of carrying out the
@@ -37192,8 +34566,6 @@ by striking section 747 and inserting the following:
      private nonprofit entity which the Secretary has de-
 
 
-      HR 3590 EAS/PP
-                            1316
       termined is capable of carrying out such grant or
       contract—
                ‘‘(A) to plan, develop, operate, or partici-
@@ -37220,8 +34592,6 @@ by striking section 747 and inserting the following:
                ‘‘(E) to provide financial assistance in the
           form of traineeships and fellowships to physi-
 
-      HR 3590 EAS/PP
-                           1317
           cians who are participants in any such pro-
           grams and who plan to teach or conduct research
           in a family medicine, general internal medicine,
@@ -37248,8 +34618,6 @@ by striking section 747 and inserting the following:
                and
 
 
-      HR 3590 EAS/PP
-                           1318
                    ‘‘(iii) providing continuing education
               to primary care physicians relevant to pa-
               tient-centered medical homes; and
@@ -37276,8 +34644,6 @@ by striking section 747 and inserting the following:
               ‘‘(B) programs that integrate academic ad-
           ministrative units in fields defined in subsection
 
-      HR 3590 EAS/PP
-                           1319
           (a)(1)(A) to enhance interdisciplinary recruit-
           ment, training, and faculty development.
           ‘‘(2) PREFERENCE IN MAKING AWARDS UNDER
@@ -37304,8 +34670,6 @@ by striking section 747 and inserting the following:
           management of chronic disease, and interprofes-
           sional integrated models of health care that in-
 
-      HR 3590 EAS/PP
-                            1320
           corporate transitions in health care settings and
           integration physical and mental health provi-
           sion;
@@ -37332,8 +34696,6 @@ by striking section 747 and inserting the following:
 
 
 
-      HR 3590 EAS/PP
-                           1321
                ‘‘(G) teach trainees the skills to provide
           interprofessional, integrated care through col-
           laboration among health professionals;
@@ -37360,8 +34722,6 @@ by striking section 747 and inserting the following:
      fiscal year 2010, and such sums as may be necessary
      for each of fiscal years 2011 through 2014.
 
-      HR 3590 EAS/PP
-                           1322
           ‘‘(2) TRAINING PROGRAMS   .—Fifteen percent of
       the amount appropriated pursuant to paragraph (1)
       in each such fiscal year shall be allocated to the phy-
@@ -37388,8 +34748,6 @@ U.S.C. 1396g(e)(1)), assisted living facilities and skilled
 nursing facilities, intermediate care facilities for individ-
 uals with mental retardation, home and community based
 
-      HR 3590 EAS/PP
-                            1323
 settings, and any other setting the Secretary determines to
 be appropriate.
       ‘‘(b) LIGIBILITY.—To be eligible to receive a grant
@@ -37416,8 +34774,6 @@ vide assistance to eligible individuals to offset the cost of
 tuition and required fees for enrollment in academic pro-
 grams provided by such entity.
 
-      HR 3590 EAS/PP
-                            1324
       ‘‘(d) LIGIBLE INDIVIDUAL .—
           ‘‘(1) ELIGIBILITY.—To be eligible for assistance
       under this section, an individual shall be enrolled in
@@ -37444,8 +34800,6 @@ $10,000,000 for the period of fiscal years 2011 through
       tion 5103 of this Act, as section 749; and
 
 
-      HR 3590 EAS/PP
-                          1325
           (2) inserting after section 747A, as added by sec-
      tion 5302, the following:
  ‘‘SEC. 748. TRAINING IN GENERAL, PEDIATRIC, AND PUBLIC
@@ -37472,8 +34826,6 @@ $10,000,000 for the period of fiscal years 2011 through
           who are participants in any such program, and
 
 
-      HR 3590 EAS/PP
-                            1326
           who plan to work in the practice of general, pe-
           diatric, public heath dentistry, or dental hygiene;
                ‘‘(C) to plan, develop, and operate a pro-
@@ -37500,8 +34852,6 @@ $10,000,000 for the period of fiscal years 2011 through
           disease management of all pediatric populations
           with an emphasis on underserved children.
 
-      HR 3590 EAS/PP
-                           1327
           ‘‘(2) ACULTY LOAN REPAYMENT    .—
                ‘‘(A) N GENERAL   .—A grant or contract
           under subsection (a)(1)(G) may be awarded to a
@@ -37528,8 +34878,6 @@ $10,000,000 for the period of fiscal years 2011 through
 section, entities eligible for such grants or contracts in gen-
 eral, pediatric, or public health dentistry shall include enti-
 
-      HR 3590 EAS/PP
-                            1328
 ties that have programs in dental or dental hygiene schools,
 or approved residency or advanced education programs in
 the practice of general, pediatric, or public health dentistry.
@@ -37556,8 +34904,6 @@ following:
       norities.
 
 
-      HR 3590 EAS/PP
-                            1329
           ‘‘(4) Qualified applicants that establish formal
       relationships with Federally qualified health centers,
       rural health centers, or accredited teaching facilities
@@ -37584,8 +34930,6 @@ following:
       education of dentists, dental health professionals, and
       dental hygienists who plan to teach oral health care
 
-      HR 3590 EAS/PP
-                            1330
       for people with developmental disabilities, cognitive
       impairment, complex medical problems, significant
       physical limitations, and vulnerable elderly.
@@ -37612,8 +34956,6 @@ to the preceding sentence for more than 3 years.’’.
 
 
 
-      HR 3590 EAS/PP
-                           1331
  SEC. 5304. ALTERNATIVE DENTAL HEALTH CARE PRO-
               VIDERS DEMONSTRATION PROJECT.
       Subpart X of part D of title III of the Public Health
@@ -37640,8 +34982,6 @@ under this section shall begin not later than 2 years after
 the date of enactment of this section, and shall conclude not
 later than 7 years after such date of enactment.
 
-      HR 3590 EAS/PP
-                           1332
       ‘‘(c) LIGIBLE E NTITIES.—To be eligible to receive a
 grant under subsection (a), an entity shall—
           ‘‘(1) be—
@@ -37668,8 +35008,6 @@ grant under subsection (a), an entity shall—
           ‘‘(1) MOUNT OF GRANT   .—Each grant under this
       section shall be in an amount that is not less than
 
-      HR 3590 EAS/PP
-                          1333
      $4,000,000 for the 5-year period during which the
      demonstration project being conducted.
           ‘‘(2) ISBURSEMENT OF FUNDS  .—
@@ -37696,8 +35034,6 @@ of the demonstration programs conducted under this section
 that shall provide analysis, based upon quantitative and
 
 
-      HR 3590 EAS/PP
-                         1334
 qualitative data, regarding access to dental health care in
 the United States.
      ‘‘(g) LARIFICATION R EGARDING  DENTAL  H EALTH
@@ -37724,8 +35060,6 @@ Section 753 of the Public Health Service Act (42 U.S.C.
      paragraph shall submit to the Secretary an applica-
 
 
-     HR 3590 EAS/PP
-                           1335
      tion at such time, in such manner, and containing
      such information as the Secretary may require.
           ‘‘(3) USE OF FUNDS  .—Amounts awarded under
@@ -37752,8 +35086,6 @@ Section 753 of the Public Health Service Act (42 U.S.C.
           appropriately credentialed volunteer faculty and
           practitioners, who do not have formal training
 
-      HR 3590 EAS/PP
-                            1336
           in geriatrics, to upgrade their knowledge and
           clinical skills for the care of older adults and
           adults with functional limitations and to en-
@@ -37780,8 +35112,6 @@ Section 753 of the Public Health Service Act (42 U.S.C.
           care settings.
 
 
-      HR 3590 EAS/PP
-                            1337
           ‘‘(5) A DDITIONAL  REQUIRED    ACTIVITIES DE  -
       SCRIBED .—Pursuant to paragraph (3), a geriatric
       education center that receives an award under this
@@ -37808,8 +35138,6 @@ Section 753 of the Public Health Service Act (42 U.S.C.
           tions for older adults.
 
 
-      HR 3590 EAS/PP
-                           1338
                ‘‘(B) INCORPORATION    OF   BEST   PRAC  -
           TICES .—A geriatric education center that re-
           ceives an award under this subsection shall de-
@@ -37836,8 +35164,6 @@ Section 753 of the Public Health Service Act (42 U.S.C.
       that funds provided to the geriatric education center
       under this subsection will be used only to supplement,
 
-      HR 3590 EAS/PP
-                           1339
      not to supplant, the amount of Federal, State, and
      local funds otherwise expended by the geriatric edu-
      cation center.
@@ -37864,8 +35190,6 @@ Section 753 of the Public Health Service Act (42 U.S.C.
 
 
 
-      HR 3590 EAS/PP
-                          1340
               ‘‘(B) submit to the Secretary an application
           at such time, in such manner, and containing
           such information as the Secretary may require.
@@ -37892,8 +35216,6 @@ amended—
      receive an Award under paragraph (1), an individual
      shall—
 
-      HR 3590 EAS/PP
-                            1341
                ‘‘(A) be board certified or board eligible in
           internal medicine, family practice, psychiatry,
           or licensed dentistry, or have completed any re-
@@ -37920,8 +35242,6 @@ amended—
           containing such information as the Secretary
 
 
-      HR 3590 EAS/PP
-                            1342
           may require, and the Secretary has approved
           such application;
                ‘‘(B) provides, in such form and manner as
@@ -37948,8 +35268,6 @@ amended—
                     (i) by inserting ‘‘for individuals who
                are physicians’’ after ‘‘this section’’; and
 
-      HR 3590 EAS/PP
-                           1343
                    (ii) by inserting after the period at the
                end the following: ‘‘The Secretary shall de-
                termine the amount of an Award under this
@@ -37976,8 +35294,6 @@ is amended—
      are preparing for advanced education nursing degrees
      in geriatric nursing, long-term care, gero-psychiatric
 
-      HR 3590 EAS/PP
-                           1344
      nursing or other nursing areas that specialize in the
      care of the elderly population.’’; and
           (2) in subsection (e), by striking ‘‘2003 through
@@ -38004,8 +35320,6 @@ clinical experience of the students in—
      for the development and implementation of inter-
      disciplinary training of psychology graduate students
 
-      HR 3590 EAS/PP
-                            1345
       for providing behavioral and mental health services,
       including substance abuse prevention and treatment
       services;
@@ -38032,8 +35346,6 @@ onstrate—
       class backgrounds, and different genders and sexual
       orientations;
 
-      HR 3590 EAS/PP
-                            1346
           ‘‘(2) knowledge and understanding of the con-
       cerns of the individuals and groups described in sub-
       section (a);
@@ -38060,8 +35372,6 @@ or other minority-serving institutions.
                ‘‘(B) have a graduation rate of not less than
           80 percent for social work students; and
 
-      HR 3590 EAS/PP
-                            1347
                ‘‘(C) exhibit an ability to recruit social
           workers from and place social workers in areas
           with a high need and high demand population.
@@ -38088,8 +35398,6 @@ or other minority-serving institutions.
                ‘‘(B) have demonstrated familiarity with
           evidence-based methods in child and adolescent
 
-      HR 3590 EAS/PP
-                           1348
           mental health services, including substance abuse
           prevention and treatment services;
                ‘‘(C) have programs designed to increase the
@@ -38116,8 +35424,6 @@ appropriated to carry out this section—
       chology in subsection (a)(2), of which not less than
 
 
-      HR 3590 EAS/PP
-                          1349
      $10,000,000 shall be allocated for doctoral,
      postdoctoral, and internship level training;
           ‘‘(3) $10,000,000 for training in professional
@@ -38144,8 +35450,6 @@ Service Act (42 U.S.C. 293e) is amended—
           purpose of’’ and all that follows through the pe-
           riod at the end and inserting ‘‘for the develop-
 
-      HR 3590 EAS/PP
-                            1350
           ment, evaluation, and dissemination of research,
           demonstration projects, and model curricula for
           cultural competency, prevention, public health
@@ -38172,8 +35476,6 @@ demonstration projects developed under section 807.
       Internet Clearinghouse under section 270 and such
 
 
-      HR 3590 EAS/PP
-                          1351
      other means as determined appropriate by the Sec-
      retary.
           ‘‘(2) VALUATION .—The Secretary shall evaluate
@@ -38200,8 +35502,6 @@ Service Act (42 U.S.C. 296e–1) is amended—
           model curricula for cultural competency, preven-
           tion, public health proficiency, reducing health
 
-      HR 3590 EAS/PP
-                            1352
            disparities, and aptitude for working with indi-
            viduals with disabilities training for use in
            health professions schools and continuing edu-
@@ -38228,8 +35528,6 @@ and
            inserting ‘‘2010 through 2015’’.
 
 
-      HR 3590 EAS/PP
-                          1353
  SEC. 5308. ADVANCED NURSING EDUCATION GRANTS.
      Section 811 of the Public Health Service Act (42
 U.S.C. 296j) is amended—
@@ -38256,8 +35554,6 @@ section are educational programs that—
 
 
 
-      HR 3590 EAS/PP
-                          1354
  SEC. 5309. NURSE EDUCATION, PRACTICE, AND RETENTION
              GRANTS.
      (a) IN G ENERAL .—Section 831 of the Public Health
@@ -38284,8 +35580,6 @@ section 831 (42 U.S.C. 296b) the following:
      ‘‘(a) RETENTION  P RIORITY  AREAS .—The Secretary
 may award grants to, and enter into contracts with, eligible
 entities to enhance the nursing workforce by initiating and
-      HR 3590 EAS/PP
-                          1355
 maintaining nurse retention programs pursuant to sub-
 section (b) or (c).
      ‘‘(b) RANTS FOR   CAREER  LADDER  P ROGRAM .—The
@@ -38312,8 +35606,6 @@ with, eligible entities for programs—
      to eligible entities to improve the retention of nurses
      and enhance patient care that is directly related to
 
-      HR 3590 EAS/PP
-                           1356
       nursing activities by enhancing collaboration and
       communication among nurses and other health care
       professionals, and by promoting nurse involvement in
@@ -38340,8 +35632,6 @@ retention, as determined by the Secretary.
 gress before the end of each fiscal year a report on the grants
 awarded and the contracts entered into under this section.
 
-      HR 3590 EAS/PP
-                          1357
 Each such report shall identify the overall number of such
 grants and contracts and provide an explanation of why
 each such grant or contract will meet the priority need of
@@ -38368,8 +35658,6 @@ Title VIII (42 U.S.C. 296 et seq.) is amended—
      basis of sex) as section 809 and moving such section
      so that it follows section 808;
 
-      HR 3590 EAS/PP
-                            1358
           (2) in sections 835, 836, 838, 840, and 842, by
       striking the term ‘‘this subpart’’ each place it appears
       and inserting ‘‘this part’’;
@@ -38396,8 +35684,6 @@ Title VIII (42 U.S.C. 296 et seq.) is amended—
                (A) by redesignating section 855, as amend-
           ed by section 5305, as section 865; and
 
-      HR 3590 EAS/PP
-                          1359
               (B) by redesignating part I as part H.
  SEC. 5311. NURSE FACULTY LOAN PROGRAM.
      (a) IN GENERAL .—Section 846A of the Public Health
@@ -38424,8 +35710,6 @@ Service Act (42 U.S.C. 297n–1) is amended—
      2007’’ and inserting ‘‘2010 through 2014’’.
 
 
-      HR 3590 EAS/PP
-                           1360
      (b) E LIGIBLE  INDIVIDUAL  S TUDENT  L OAN  REPAY -
  MENT .—Title VIII of the Public Health Service Act is
 amended by inserting after section 846A (42 U.S.C. 297n–
@@ -38452,8 +35736,6 @@ ginning on the later of—
      ‘‘(c) AGREEMENT    PROVISIONS .—Agreements entered
 into pursuant to subsection (b) shall be entered into on such
 
-      HR 3590 EAS/PP
-                           1361
 terms and conditions as the Secretary may determine, ex-
 cept that—
           ‘‘(1) not more than 10 months after the date on
@@ -38480,8 +35762,6 @@ cept that—
           calendar year; and
 
 
-      HR 3590 EAS/PP
-                           1362
                ‘‘(B) total payments may not exceed
           $80,000 during the 2010 and 2011 fiscal years
           (adjusted for subsequent fiscal years as provided
@@ -38508,8 +35788,6 @@ cept that—
      ment is entitled to recover under paragraph (1) shall
      be paid to the United States not later than the expi-
 
-      HR 3590 EAS/PP
-                           1363
       ration of the 3-year period beginning on the date the
       United States becomes so entitled.
           ‘‘(4) AVAILABILITY.—Amounts recovered under
@@ -38536,8 +35814,6 @@ port doctoral nursing students.
 are authorized to be appropriated to carry out this section
 
 
-      HR 3590 EAS/PP
-                           1364
 such sums as may be necessary for each of fiscal years 2010
 through 2014.’’.
  SEC. 5312. AUTHORIZATION OF APPROPRIATIONS FOR
@@ -38564,8 +35840,6 @@ with the Secretary, shall award grants to eligible entities
 to promote positive health behaviors and outcomes for popu-
 
 
-      HR 3590 EAS/PP
-                           1365
 lations in medically underserved communities through the
 use of community health workers.
       ‘‘(b) SE OF   FUNDS .—Grants awarded under sub-
@@ -38592,8 +35866,6 @@ ers—
       tion services regarding maternal health and prenatal
       care.
 
-      HR 3590 EAS/PP
-                           1366
      ‘‘(c) PPLICATION .—Each eligible entity that desires
 to receive a grant under subsection (a) shall submit an ap-
 plication to the Secretary, at such time, in such manner,
@@ -38620,8 +35892,6 @@ ing funds under this section to collaborate with academic
 institutions and one-stop delivery systems under section
 134(c) of the Workforce Investment Act of 1998. Nothing
 
-      HR 3590 EAS/PP
-                            1367
 in this section shall be construed to require such collabora-
 tion.
       ‘‘(f) EVIDENCE -BASED   INTERVENTIONS  .—The Sec-
@@ -38648,8 +35918,6 @@ programs identified in approved applications under this
 section with respect to planning, developing, and operating
 programs under the grant.
 
-      HR 3590 EAS/PP
-                           1368
       ‘‘(j)UTHORIZATION OF   APPROPRIATIONS  .—There are
 authorized to be appropriated, such sums as may be nec-
 essary to carry out this section for each of fiscal years 2010
@@ -38676,8 +35944,6 @@ through 2014.
                ‘‘(F) by providing referral and follow-up
           services or otherwise coordinating care; and
 
-      HR 3590 EAS/PP
-                           1369
                ‘‘(G) by proactively identifying and enroll-
           ing eligible individuals in Federal, State, local,
           private or nonprofit health and human services
@@ -38704,8 +35970,6 @@ through 2014.
           health professional shortage area as designated
           under section 332.’’.
 
-      HR 3590 EAS/PP
-                           1370
  SEC. 5314. FELLOWSHIP TRAINING IN PUBLIC HEALTH.
      Part E of title VII of the Public Health Service Act
 (42 U.S.C. 294n et seq.), as amended by section 5206, is
@@ -38732,8 +35996,6 @@ programs that meet objectives similar to the objectives of
 the programs described in subsection (b).
      ‘‘(d) WORK O BLIGATION .—Participation in fellowship
 training programs under this section shall be deemed to be
-      HR 3590 EAS/PP
-                            1371
 service for purposes of satisfying work obligations stipulated
 in contracts under section 338I(j).
       ‘‘(e) ENERAL  SUPPORT .—Amounts may be used from
@@ -38760,8 +36022,6 @@ which—
 
 
 
-      HR 3590 EAS/PP
-                          1372
  SEC. 5315. UNITED STATES PUBLIC HEALTH SCIENCES
              TRACK.
      Title II of the Public Health Service Act (42 U.S.C.
@@ -38788,8 +36048,6 @@ which—
               ‘‘(D) 100 public health students annually;
               ‘‘(E) 100 behavioral and mental health pro-
          fessional students annually;
-      HR 3590 EAS/PP
-                           1373
                ‘‘(F) 100 physician assistant or nurse prac-
           titioner students annually; and
                ‘‘(G) 50 pharmacy students annually.
@@ -38816,8 +36074,6 @@ ject to the requirements of subsection (a).
       ‘‘(d) NTEGRATED   L ONGITUDINAL   PLAN .—The Sur-
 geon General shall develop an integrated longitudinal plan
 
-      HR 3590 EAS/PP
-                           1374
 for health professions continuing education throughout the
 continuum of health-related education, training, and prac-
 tice. Training under such plan shall emphasize patient-cen-
@@ -38844,8 +36100,6 @@ shall assist the Surgeon General in an advisory capacity.
       affiliated health professions training institutions.
       Members of the faculty and staff shall be employed
 
-      HR 3590 EAS/PP
-                            1375
       under salary schedules and granted retirement and
       other related benefits prescribed by the Secretary so as
       to place the employees of the Track faculty on a com-
@@ -38872,8 +36126,6 @@ and health professions training institutions in the United
 States. Such agreements may include provisions for pay-
 ments for educational services provided students partici-
 
-      HR 3590 EAS/PP
-                          1376
 pating in Department of Health and Human Services edu-
 cational programs.
      ‘‘(d) ROGRAMS  .—The Surgeon General may establish
@@ -38900,8 +36152,6 @@ within the United States.
           enterprises in medical, dental, physician assist-
           ant, pharmacy, behavioral and mental health,
 
-      HR 3590 EAS/PP
-                            1377
           public health, and nursing research, consulta-
           tion, and education;
                ‘‘(B) to enter into contracts with entities
@@ -38928,8 +36178,6 @@ within the United States.
       vance of the enactment of budget authority for such
       outlays.
 
-      HR 3590 EAS/PP
-                           1378
           ‘‘(3) SCIENTISTS.—Scientists or other medical,
       dental, or nursing personnel utilized by the Track
       under an agreement described in paragraph (1) may
@@ -38956,8 +36204,6 @@ within the United States.
       be selected under procedures prescribed by the Sur-
       geon General. In so prescribing, the Surgeon General
 
-      HR 3590 EAS/PP
-                           1379
      shall consider the recommendations of the National
      Health Care Workforce Commission.
           ‘‘(2) RIORITY .—In developing admissions pro-
@@ -38984,8 +36230,6 @@ within the United States.
                the student is enrolled in the Track at an
                affiliated or other participating health pro-
 
-      HR 3590 EAS/PP
-                            1380
                fessions institution pursuant to an agree-
                ment between the Track and such institu-
                tion; and
@@ -39012,8 +36256,6 @@ within the United States.
                     appropriate; and
 
 
-      HR 3590 EAS/PP
-                            1381
                         ‘‘(V) to serve for a period of time
                     (referred to in this part as the ‘period
                     of obligated service’) within the Com-
@@ -39040,8 +36282,6 @@ within the United States.
           the National Health Care Workforce Commis-
           sion, shall establish Federal tuition remission
 
-      HR 3590 EAS/PP
-                            1382
           rates to be used by the Track to provide reim-
           bursement to affiliated and other participating
           health professions institutions for the cost of edu-
@@ -39068,8 +36308,6 @@ within the United States.
                ‘‘(B) in the case of a student who, upon
           completion of their residency, elects to practice
 
-      HR 3590 EAS/PP
-                          1383
           in a Federal medical facility (as defined in sec-
           tion 781(e)) that is located in a health profes-
           sional shortage area (as defined in section 332),
@@ -39096,8 +36334,6 @@ pend support. The Surgeon General shall give priority to
 health professions training institutions that train medical,
 dental, physician assistant, pharmacy, behavioral and
 
-      HR 3590 EAS/PP
-                          1384
 mental health, public health, and nursing students for some
 significant period of time together, but at a minimum have
 a discrete and shared core curriculum.
@@ -39124,8 +36360,6 @@ stipend support provided to the student.
      ‘‘Beginning with fiscal year 2010, the Secretary shall
 transfer from the Public Health and Social Services Emer-
 
-      HR 3590 EAS/PP
-                          1385
 gency Fund such sums as may be necessary to carry out
 this part.’’.
  Subtitle E—Supporting the Existing
@@ -39152,8 +36386,6 @@ serting the following:
                        ‘‘(I) 60 percent of such amount
                    for grants under subsection (a) to
 
-      HR 3590 EAS/PP
-                            1386
                     health professions schools that meet the
                     conditions described in paragraph (3)
                     or (4) of subsection (c) (including
@@ -39180,8 +36412,6 @@ serting the following:
                subsection (a) to health professions schools
 
 
-      HR 3590 EAS/PP
-                            1387
                that meet the conditions described in sub-
                section (c)(5).
                ‘‘(C) FUNDING IN EXCESS OF $30    000000.—
@@ -39208,8 +36438,6 @@ serting the following:
                ing excess amount for grants under sub-
                section (a) to health professions schools that
 
-      HR 3590 EAS/PP
-                            1388
                 meet the conditions described in paragraph
                 (2)(A), (3), (4), or (5) of subsection (c).
                 ‘‘(D) FUNDING IN EXCESS OF $40   ,00,000.—
@@ -39236,8 +36464,6 @@ serting the following:
                 health professions schools that meet the con-
 
 
-      HR 3590 EAS/PP
-                            1389
                ditions described in paragraph (2)(A), (3),
                (4), or (5) of subsection (c).
           ‘‘(2) NO LIMITATION.—Nothing in this subsection
@@ -39264,8 +36490,6 @@ serting the following:
           expending the grant, expend the Federal amounts
 
 
-      HR 3590 EAS/PP
-                         1390
          obtained from sources other than the grant, un-
          less given prior approval from the Secretary.
      ‘‘(i)UTHORIZATION OF  APPROPRIATIONS.—There are
@@ -39293,8 +36517,6 @@ fiscal years 2011 through 2014’’.
      (c) REAUTHORIZATION FOR  L OAN R EPAYMENTS AND
  FELLOWSHIPS  REGARDING  F ACULTY POSITIONS.—Section
 
-      HR 3590 EAS/PP
-                         1391
 740(b) of such Act (42 U.S.C. 293d(b)) is amended by strik-
 ing ‘‘appropriated’’ and all that follows through the period
 at the end and inserting ‘‘appropriated, $5,000,000 for each
@@ -39322,8 +36544,6 @@ with this section:
      The Secretary shall make awards to eligible entities
      to enable such entities to initiate health care work-
 
-     HR 3590 EAS/PP
-                           1392
      force educational programs or to continue to carry
      out comparable programs that are operating at the
      time the award is made by planning, developing, op-
@@ -39350,8 +36570,6 @@ with this section:
           school. With respect to a State in which no area
           health education center program is in operation,
 
-      HR 3590 EAS/PP
-                           1393
           the Secretary may award a grant or contract
           under subsection (a)(1) to a school of nursing.
                ‘‘(B) OINT OF SERVICE MAINTENANCE AND
@@ -39378,8 +36596,6 @@ with this section:
           ery system under section 134(c) of the Workforce
           Investment Act of 1998, to recruit individuals
 
-      HR 3590 EAS/PP
-                            1394
           from underrepresented minority populations or
           from disadvantaged or rural backgrounds into
           health professions, and support such individuals
@@ -39406,8 +36622,6 @@ with this section:
           ally qualified health centers, rural health clinics,
 
 
-      HR 3590 EAS/PP
-                            1395
           public health departments, or other appropriate
           facilities.
                ‘‘(D) Conduct and participate in inter-
@@ -39434,8 +36648,6 @@ with this section:
       under subsection (a)(1) or subsection (a)(2) to carry
       out any of the following activities:
 
-      HR 3590 EAS/PP
-                           1396
                ‘‘(A) Develop and implement innovative
           curricula in collaboration with community-based
           accredited primary care residency training pro-
@@ -39462,8 +36674,6 @@ with this section:
           ter program.
       ‘‘(d) EQUIREMENTS  .—
 
-      HR 3590 EAS/PP
-                            1397
           ‘‘(1) AREA HEALTH EDUCATION CENTER PRO        -
       GRAM .—In carrying out this section, the Secretary
       shall ensure the following:
@@ -39490,8 +36700,6 @@ with this section:
                ing sites in the area health education center
                program area.
 
-      HR 3590 EAS/PP
-                            1398
                ‘‘(B) An entity receiving funds under sub-
           section (a)(2) does not distribute such funding to
           a center that is eligible to receive funding under
@@ -39518,8 +36726,6 @@ with this section:
           plicate, in whole or in part, the geographic area
           or population served by any other center;
 
-      HR 3590 EAS/PP
-                            1399
                ‘‘(D) fosters networking and collaboration
           among communities and between academic
           health centers and community-based centers;
@@ -39546,8 +36752,6 @@ of not more than 75 percent of the matching fund amount
 required by the entity for each of the first 3 years the entity
 is funded through a grant under subsection (a)(1).
 
-      HR 3590 EAS/PP
-                            1400
       ‘‘(f)IMITATION .—Not less than 75 percent of the total
 amount provided to an area health education center pro-
 gram under subsection (a)(1) or (a)(2) shall be allocated
@@ -39574,8 +36778,6 @@ lished in subsection (j)(2) is maintained.
                ‘‘(B) in the case of a center within a pro-
            gram, 6 years.
 
-      HR 3590 EAS/PP
-                           1401
           ‘‘(2) E XCEPTION .—The periods described in
       paragraph (1) shall not apply to programs receiving
       point of service maintenance and enhancement
@@ -39602,8 +36804,6 @@ under this section.
                ‘‘(D) not more than 4 percent shall be used
           for grants and contracts to provide technical as-
 
-      HR 3590 EAS/PP
-                          1402
           sistance to entities receiving awards under this
           section.
           ‘‘(3) ARRYOVER FUNDS   .—An entity that re-
@@ -39630,8 +36830,6 @@ minority faculty members, enhance the practice environ-
 ment, and provide information dissemination and edu-
 cational support to reduce professional isolation through the
 
-      HR 3590 EAS/PP
-                            1403
 timely dissemination of research findings using relevant re-
 sources.
       ‘‘(b) LIGIBLE  E NTITIES.—For purposes of this sec-
@@ -39658,8 +36856,6 @@ U.S.C. 296m) is amended—
                (A) by striking ‘‘The Secretary may’’ and
            inserting the following:
 
-      HR 3590 EAS/PP
-                           1404
           ‘‘(1) UTHORITY .—The Secretary may’’;
                (B) by striking ‘‘pre-entry preparation, and
           retention activities’’ and inserting the following:
@@ -39686,8 +36882,6 @@ further amended by adding at the end the following:
  ‘‘SEC. 399W. PRIMARY CARE EXTENSION PROGRAM.
      ‘‘(a) ESTABLISHMENT  , PURPOSE AND   D EFINITION.—
 
-      HR 3590 EAS/PP
-                           1405
           ‘‘(1) IN   GENERAL  .—The Secretary, acting
      through the Director of the Agency for Healthcare Re-
      search and Quality, shall establish a Primary Care
@@ -39714,8 +36908,6 @@ further amended by adding at the end the following:
           the patient-centered medical home to provide
           high-quality, effective, efficient, and safe pri-
 
-      HR 3590 EAS/PP
-                          1406
          mary care and to provide guidance to patients
          in culturally and linguistically appropriate
          ways, and linking practices to diverse health sys-
@@ -39742,8 +36934,6 @@ further amended by adding at the end the following:
          ‘‘(2) OMPOSITION OF HUBS .—A Hub established
      by a State pursuant to paragraph (1)—
 
-      HR 3590 EAS/PP
-                           1407
                ‘‘(A) shall consist of, at a minimum, the
           State health department, the entity responsible
           for administering the State Medicaid program
@@ -39770,8 +36960,6 @@ further amended by adding at the end the following:
           scribed in subsection (b)(2)(A);
 
 
-      HR 3590 EAS/PP
-                           1408
                ‘‘(B) contract with a county- or local-level
           entity that shall serve as the Primary Care Ex-
           tension Agency to administer the services de-
@@ -39798,8 +36986,6 @@ further amended by adding at the end the following:
                care learning communities to enhance the
                dissemination of research findings for evi-
 
-      HR 3590 EAS/PP
-                           1409
                dence-based practice, assess implementation
                of practice improvement, share best prac-
                tices, and involve community clinicians in
@@ -39826,8 +37012,6 @@ further amended by adding at the end the following:
                3602 of the Patient Protection and Afford-
                able Care Act;
 
-      HR 3590 EAS/PP
-                           1410
                    ‘‘(ii) collect data and provision of pri-
                mary care provider feedback from standard-
                ized measurements of processes and out-
@@ -39854,8 +37038,6 @@ further amended by adding at the end the following:
      subsection (b) shall be—
 
 
-      HR 3590 EAS/PP
-                            1411
                ‘‘(A) program grants, that are awarded to
           State or multistate entities that submit fully-de-
           veloped plans for the implementation of a Hub,
@@ -39882,8 +37064,6 @@ further amended by adding at the end the following:
       of the State sustainability plan, as determined by the
       Secretary.
 
-      HR 3590 EAS/PP
-                            1412
           ‘‘(5) LIMITATION .—A State shall not use in ex-
       cess of 10 percent of the amount received under a
       grant to carry out administrative activities under
@@ -39910,8 +37090,6 @@ through 2014.’’.
 
 
 
-      HR 3590 EAS/PP
-                         1413
  Subtitle F—Strengthening Primary
      Care and Other Workforce Im-
      provements
@@ -39938,8 +37116,6 @@ through 2014.’’.
          vidual—
                   ‘‘(i) who—
 
-     HR 3590 EAS/PP
-                           1414
                         ‘‘(I) is a physician (as described
                    in section 1861(r)(1)) who has a pri-
                    mary specialty designation of family
@@ -39966,8 +37142,6 @@ through 2014.’’.
       The amount of the additional payment for a service
       under this subsection and subsection (m) shall be de-
 
-      HR 3590 EAS/PP
-                         1415
      termined without regard to any additional payment
      for the service under subsection (m) and this sub-
      section, respectively.
@@ -39995,8 +37169,6 @@ through 2014.’’.
  SHORTAGE A REAS.—
 
 
-     HR 3590 EAS/PP
-                           1416
           ‘‘(1) N GENERAL .—In the case of major surgical
       procedures furnished on or after January 1, 2011,
       and before January 1, 2016, by a general surgeon in
@@ -40023,8 +37195,6 @@ through 2014.’’.
           for payment under the fee schedule under section
           1848(b).
 
-      HR 3590 EAS/PP
-                           1417
           ‘‘(3) COORDINATION WITH OTHER PAYMENTS      .—
       The amount of the additional payment for a service
       under this subsection and subsection (m) shall be de-
@@ -40051,8 +37221,6 @@ new clause:
                SICIAN INCENTIVE PAYMENTS    .—Fifty per-
                cent of the additional expenditures under
 
-      HR 3590 EAS/PP
-                            1418
                this part attributable to subsections (x) and
                (y) of section 1833 for a year (as estimated
                by the Secretary) shall be taken into ac-
@@ -40079,8 +37247,6 @@ new clause:
 
 
 
-      HR 3590 EAS/PP
-                         1419
  SEC. 5502. MEDICARE FEDERALLY QUALIFIED HEALTH CEN-
             TER IMPROVEMENTS.
      (a) EXPANSION OF MEDICARE -COVERED P REVENTIVE
@@ -40108,8 +37274,6 @@ the end the following new subsection:
          velop a prospective payment system for payment
          for Federally qualified health services furnished
          by Federally qualified health centers under this
-     HR 3590 EAS/PP
-                           1420
           title. Such system shall include a process for ap-
           propriately describing the services furnished by
           Federally qualified health centers.
@@ -40136,8 +37300,6 @@ the end the following new subsection:
                payment system so that the estimated
                amount of expenditures under this title for
 
-      HR 3590 EAS/PP
-                           1421
                Federally qualified health services in the
                first year that the prospective payment sys-
                tem is implemented is equal to 103 percent
@@ -40164,8 +37326,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
       graph (7)’’ and inserting ‘‘paragraphs (7) and (8)’’;
 
 
-      HR 3590 EAS/PP
-                            1422
           (2) in paragraph (4)(H)(i), by striking ‘‘para-
       graph (7)’’ and inserting ‘‘paragraphs (7) and (8)’’;
           (3) in paragraph (7)(E), by inserting ‘‘or para-
@@ -40192,8 +37352,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
                graph shall not apply to—
 
 
-      HR 3590 EAS/PP
-                            1423
                         ‘‘(I) a hospital located in a rural
                     area (as defined in subsection
                     (d)(2)(D)(ii)) with fewer than 250
@@ -40220,8 +37378,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
                approve for portions of cost reporting peri-
                ods occurring on or after July 1, 2011. The
 
-      HR 3590 EAS/PP
-                            1424
                aggregate number of increases in the other-
                wise applicable resident limit under this
                subparagraph shall be equal to the aggregate
@@ -40248,8 +37404,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
                         ‘‘(II) not less than 75 percent of
                     the positions attributable to such in-
 
-      HR 3590 EAS/PP
-                           1425
                    crease are in a primary care or gen-
                    eral surgery residency (as determined
                    by the Secretary).
@@ -40276,8 +37430,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
                    ments of this paragraph.
 
 
-      HR 3590 EAS/PP
-                            1426
                ‘‘(C) C ONSIDERATIONS    IN  REDISTRIBU  -
           TION .—In determining for which hospitals the
           increase in the otherwise applicable resident
@@ -40304,8 +37456,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
                in the lowest quartile (as determined by the
                Secretary).
 
-      HR 3590 EAS/PP
-                            1427
                     ‘‘(ii) Whether the hospital is located in
                a State, a territory of the United States, or
                the District of Columbia that is among the
@@ -40332,8 +37482,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
                (ii), the Secretary shall reserve the positions
 
 
-      HR 3590 EAS/PP
-                            1428
                available for distribution under this para-
                graph as follows:
                         ‘‘(I) 70 percent of such positions
@@ -40360,8 +37508,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
           CARE .—With respect to additional residency po-
           sitions in a hospital attributable to the increase
 
-      HR 3590 EAS/PP
-                            1429
           provided under this paragraph, the approved
           FTE per resident amounts are deemed to be
           equal to the hospital per resident amounts for
@@ -40388,8 +37534,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
                paragraph (4) on the resident level for the
                hospital determined without regard to this
 
-      HR 3590 EAS/PP
-                           1430
                paragraph but taking into account para-
                graph (7)(A).’’.
      (b) IME.—
@@ -40416,8 +37560,6 @@ rity Act (42 U.S.C. 1395ww(h)) is amended—
      (c) CONFORMING   A MENDMENT  .—Section 422(b)(2) of
 the Medicare Prescription Drug, Improvement, and Mod-
 
-      HR 3590 EAS/PP
-                            1431
 ernization Act of 2003 (Public Law 108–173) is amended
 by striking ‘‘section 1886(h)(7)’’ and all that follows and
 inserting ‘‘paragraphs (7) and (8) of subsection (h) of sec-
@@ -40444,8 +37586,6 @@ rity Act (42 U.S.C. 1395ww(h)(4)(E)) is amended—
                which the activities are performed, if a hos-
                pital incurs the costs of the stipends and
 
-      HR 3590 EAS/PP
-                            1432
                fringe benefits of the resident during the
                time the resident spends in that setting. If
                more than one hospital incurs these costs,
@@ -40472,8 +37612,6 @@ curity Act (42 U.S.C. 1395ww(d)(5)) is amended—
           (2) by inserting after clause (I), as inserted by
       paragraph (1), the following new subparagraph:
 
-      HR 3590 EAS/PP
-                            1433
            ‘‘(II) Effective for discharges occurring on or
       after July 1, 2010, all the time spent by an intern
       or resident in patient care activities in a nonprovider
@@ -40500,8 +37638,6 @@ costs under section 1886(h) of such Act (42 U.S.C.
 
 
 
-      HR 3590 EAS/PP
-                           1434
  SEC. 5505. RULES FOR COUNTING RESIDENT TIME FOR DI-
              DACTIC AND SCHOLARLY ACTIVITIES AND
              OTHER ACTIVITIES.
@@ -40528,8 +37664,6 @@ amended—
           defined by the Secretary, shall be counted toward
           the determination of full-time equivalency.
 
-      HR 3590 EAS/PP
-                            1435
                ‘‘(K) TREATMENT OF CERTAIN OTHER AC      -
           TIVITIES.—In determining the hospital’s number
           of full-time equivalent residents for purposes of
@@ -40556,8 +37690,6 @@ such Act (42 U.S.C. 1395ww(d)(5)(B)) is amended by add-
 ing at the end the following new clause:
 
 
-      HR 3590 EAS/PP
-                            1436
                     ‘‘(x)(I) The provisions of subparagraph
                (K) of subsection (h)(4) shall apply under
                this subparagraph in the same manner as
@@ -40584,8 +37716,6 @@ ing at the end the following new clause:
                     outpatient department.
 
 
-      HR 3590 EAS/PP
-                           1437
                    ‘‘(III) In determining the hospital’s
                number of full-time equivalent residents for
                purposes of this subparagraph, all the time
@@ -40612,8 +37742,6 @@ ing at the end the following new clause:
      apply to cost reporting periods beginning on or after
      October 1, 2001. Such section, as so added, shall not
 
-      HR 3590 EAS/PP
-                           1438
       give rise to any inference as to how the law in effect
       prior to such date should be interpreted.
  SEC. 5506. PRESERVATION OF RESIDENT CAP POSITIONS
@@ -40640,8 +37768,6 @@ by adding at the end the following new clause:
                    CERTAIN AREAS   .—Subject to the suc-
                    ceeding provisions of this clause, in de-
 
-      HR 3590 EAS/PP
-                            1439
                     termining for which hospitals the in-
                     crease in the otherwise applicable resi-
                     dent limit is provided under such proc-
@@ -40668,8 +37794,6 @@ by adding at the end the following new clause:
                               ‘‘(dd) Fourth, only if the Sec-
                          retary is not able to distribute the
 
-      HR 3590 EAS/PP
-                            1440
                         increase to hospitals described in
                         item (cc), to qualifying hospitals
                         in accordance with the provisions
@@ -40696,8 +37820,6 @@ by adding at the end the following new clause:
                     35 of title 44, United States Code, shall
 
 
-      HR 3590 EAS/PP
-                            1441
                     not apply to the implementation of
                     this clause.’’.
       (b) IME.—Section 1886(d)(5)(B)(v) of the Social Se-
@@ -40724,8 +37846,6 @@ of Federal Regulations (as in effect on the date of enactment
 of this Act) in order to ensure that there is no duplication
 of FTE slots. Such amendments shall not affect the applica-
 
-      HR 3590 EAS/PP
-                        1442
 tion of section 1886(h)(4)(H)(v) of the Social Security Act
 (42 U.S.C. 1395ww(h)(4)(H)(v)).
      (e) C     ONFORMING       AMENDMENT .—Section
@@ -40754,8 +37874,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
      shall award grants to eligible entities to conduct dem-
      onstration projects that are designed to provide eligi-
 
-     HR 3590 EAS/PP
-                           1443
      ble individuals with the opportunity to obtain edu-
      cation and training for occupations in the health care
      field that pay well and are expected to either experi-
@@ -40782,8 +37900,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
           out a demonstration project under this section
           shall demonstrate in the application that the en-
 
-      HR 3590 EAS/PP
-                           1444
           tity has consulted with the State agency respon-
           sible for administering the State TANF program,
           the local workforce investment board in the area
@@ -40810,8 +37926,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
           terim reports to the Secretary on the activities
           carried out under the project and a final report
 
-      HR 3590 EAS/PP
-                            1445
           on such activities upon the conclusion of the en-
           tities’ participation in the project. Such reports
           shall include assessments of the effectiveness of
@@ -40838,8 +37952,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
           retary shall submit interim reports and, based
           on the evaluation conducted under subparagraph
 
-      HR 3590 EAS/PP
-                            1446
           (B), a final report to Congress on the demonstra-
           tion projects conducted under this subsection.
           ‘‘(4) DEFINITIONS .—In this subsection:
@@ -40866,8 +37978,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
           section 4 of the Indian Self-Determination and
           Education Assistance Act (25 U.S.C. 450b).
 
-      HR 3590 EAS/PP
-                         1447
               ‘‘(D) INSTITUTION  OF   HIGHER   EDU  -
          CATION.—The term ‘institution of higher edu-
          cation’ has the meaning given that term in sec-
@@ -40894,8 +38004,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
      section, the Secretary shall award grants to eligible
      entities that are States to conduct demonstration
 
-      HR 3590 EAS/PP
-                            1448
       projects for purposes of developing core training com-
       petencies and certification programs for personal or
       home care aides. The Secretary shall—
@@ -40922,8 +38030,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
           petencies with respect to the following areas:
 
 
-      HR 3590 EAS/PP
-                            1449
                     ‘‘(i) The role of the personal or home
                care aide (including differences between a
                personal or home care aide employed by an
@@ -40950,8 +38056,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
                ities, individuals with developmental dis-
                abilities, individuals with dementia, and
 
-      HR 3590 EAS/PP
-                           1450
                individuals with mental and behavioral
                health needs).
                    ‘‘(x) Self-Care.
@@ -40978,8 +38082,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
 
 
 
-      HR 3590 EAS/PP
-                           1451
                    ‘‘(ii) EQUIREMENTS FOR STATES     .—
                An agreement entered into under clause (i)
                shall require that a participating State—
@@ -41006,8 +38108,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
           State seeking to participate in the project
           shall—
 
-      HR 3590 EAS/PP
-                            1452
                     ‘‘(i) submit an application to the Sec-
                retary containing such information and at
                such time as the Secretary may specify;
@@ -41034,8 +38134,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
                     training competencies described in
                     paragraph (3)(A);
 
-      HR 3590 EAS/PP
-                           1453
                    ‘‘(iv) that participating States do not
                reduce the number of hours of training re-
                quired under applicable State law or regu-
@@ -41062,8 +38160,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
                sonal or home care aides within each par-
                ticipating State on job satisfaction, mastery
 
-      HR 3590 EAS/PP
-                           1454
                of job skills, beneficiary and family care-
                giver satisfaction with services, and addi-
                tional measures determined by the Secretary
@@ -41090,8 +38186,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
                ommendations for legislation or administra-
 
 
-      HR 3590 EAS/PP
-                            1455
                tive action as the Secretary determines ap-
                propriate.
                     ‘‘(ii)INAL REPORT  .—Not later than 1
@@ -41118,8 +38212,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
                under title XIX.
 
 
-      HR 3590 EAS/PP
-                           1456
                ‘‘(B) ERSONAL CARE SERVICES   .—The term
           ‘personal care services’ has the meaning given
           such term for purposes of title XIX.
@@ -41146,8 +38238,6 @@ inserting ‘‘this paragraph, paragraph (8), or paragraph
           ‘‘(2) TRAINING AND CERTIFICATION PROGRAMS
      FOR PERSONAL AND HOME CARE AIDES        .—With re-
 
-      HR 3590 EAS/PP
-                          1457
      spect to the demonstration projects under subsection
      (b), the Secretary shall use $5,000,000 of the amount
      appropriated under paragraph (1) for each of fiscal
@@ -41174,8 +38264,6 @@ years 2009 through 2012’’.
  HANCEMENT  .—Part C of title VII of the Public Health
 Service Act (42 U.S.C. 293k et. seq.), as amended by section
 
-      HR 3590 EAS/PP
-                          1458
 5303, is further amended by inserting after section 749 the
 following:
  ‘‘SEC. 749A. TEACHING HEALTH CENTERS DEVELOPMENT
@@ -41202,8 +38290,6 @@ grant under this section shall be used to cover the costs of—
           (AOA); and
 
 
-      HR 3590 EAS/PP
-                            1459
                ‘‘(D) faculty salaries during the develop-
           ment phase; and
           ‘‘(2) technical assistance provided by an eligible
@@ -41230,8 +38316,6 @@ and 799B.
       ternal medicine, pediatrics, internal medicine-pediat-
 
 
-      HR 3590 EAS/PP
-                           1460
      rics, obstetrics and gynecology, psychiatry, general
      dentistry, pediatric dentistry, and geriatrics.
           ‘‘(3) EACHING HEALTH CENTER   .—
@@ -41258,8 +38342,6 @@ and 799B.
                ganization (as defined in section 4 of the
                Indian Health Care Improvement Act).
 
-      HR 3590 EAS/PP
-                          1461
                   ‘‘(v) An entity receiving funds under
               title X of the Public Health Service Act.
      ‘‘(g) UTHORIZATION OF  APPROPRIATIONS .—There is
@@ -41286,8 +38368,6 @@ tion.’’.
      (c) PAYMENTS TO   Q UALIFIED  TEACHING  H EALTH
  CENTERS .—Part D of title III of the Public Health Service
 
-      HR 3590 EAS/PP
-                           1462
 Act (42 U.S.C. 254b et seq.) is amended by adding at the
 end the following:
       ‘‘Subpart XI—Support of Graduate Medical
@@ -41314,8 +38394,6 @@ training programs.
           proved graduate medical residency training pro-
           grams.
 
-      HR 3590 EAS/PP
-                          1463
               ‘‘(B) INDIRECT  EXPENSE   AMOUNT  .—The
           amount determined under subsection (d) for in-
           direct expenses associated with the additional
@@ -41342,8 +38420,6 @@ training programs.
      ing health centers for direct graduate expenses relat-
 
 
-      HR 3590 EAS/PP
-                          1464
      ing to approved graduate medical residency training
      programs for a fiscal year is equal to the product of—
               ‘‘(A) the updated national per resident
@@ -41370,8 +38446,6 @@ training programs.
                    ‘‘(i) by dividing the national average
               per resident amount computed under section
 
-      HR 3590 EAS/PP
-                          1465
               340E(c)(2)(D) into a wage-related portion
               and a non-wage related portion by applying
               the proportion determined under subpara-
@@ -41398,8 +38472,6 @@ training programs.
      ing health centers for indirect expenses associated
      with the additional costs of teaching residents for a
 
-      HR 3590 EAS/PP
-                            1466
       fiscal year is equal to an amount determined appro-
       priate by the Secretary.
           ‘‘(2) F ACTORS .—In determining the amount
@@ -41426,8 +38498,6 @@ training programs.
       by the Secretary.
 
 
-      HR 3590 EAS/PP
-                          1467
      ‘‘(e) LARIFICATION  REGARDING   RELATIONSHIP TO
  OTHER   P AYMENTS  FOR    GRADUATE   M EDICAL   EDU -
  CATION.—Payments under this section—
@@ -41454,8 +38524,6 @@ training programs.
      Act.
 
 
-      HR 3590 EAS/PP
-                            1468
       ‘‘(f)ECONCILIATION  .—The Secretary shall determine
 any changes to the number of residents reported by a hos-
 pital in the application of the hospital for the current fiscal
@@ -41482,8 +38550,6 @@ $230,000,000, for the period of fiscal years 2011 through
       following information for the residency academic year
       completed immediately prior to such fiscal year:
 
-      HR 3590 EAS/PP
-                            1469
                ‘‘(A) The types of primary care resident ap-
           proved training programs that the qualified
           teaching health center provided for residents.
@@ -41510,8 +38576,6 @@ $230,000,000, for the period of fiscal years 2011 through
           primary care resident positions, as determined
           by the Secretary. For purposes of this subpara-
 
-      HR 3590 EAS/PP
-                           1470
           graph, the ‘base level of primary care residents’
           for a teaching health center is the level of such
           residents as of a base period.
@@ -41538,8 +38602,6 @@ $230,000,000, for the period of fiscal years 2011 through
           (A) on the basis of a qualified teaching health
           center’s failure to provide complete and accurate
 
-      HR 3590 EAS/PP
-                            1471
           information described in subparagraph (A)(ii),
           the Secretary shall provide notice to the teaching
           health center of such failure and the Secretary’s
@@ -41566,8 +38628,6 @@ regulations to carry out this section.
       dency or other postgraduate medical training pro-
       gram—
 
-      HR 3590 EAS/PP
-                          1472
               ‘‘(A) participation in which may be counted
           toward certification in a specialty or sub-
           specialty and includes formal postgraduate
@@ -41594,8 +38654,6 @@ regulations to carry out this section.
           tion under title XVIII of the Social Security Act
           (42 U.S.C. 1395 et seq.) under which an eligible
 
-      HR 3590 EAS/PP
-                           1473
           hospital may receive payment for the hospital’s
           reasonable costs (described in paragraph (2)) for
           the provision of qualified clinical training to ad-
@@ -41622,8 +38680,6 @@ regulations to carry out this section.
           the amount reimbursed under subparagraph (A)
           may not exceed the amount of costs described in
 
-      HR 3590 EAS/PP
-                          1474
           subparagraph (A) that are attributable to an in-
           crease in the number of advanced practice reg-
           istered nurses enrolled in a program that pro-
@@ -41650,8 +38706,6 @@ regulations to carry out this section.
 eligible hospital unless such hospital has in effect a written
 
 
-      HR 3590 EAS/PP
-                            1475
 agreement with the eligible partners of the hospital. Such
 written agreement shall describe, at a minimum—
           (1) the obligations of the eligible partners with
@@ -41678,8 +38732,6 @@ lowing:
       (d) FUNDING .—
 
 
-      HR 3590 EAS/PP
-                           1476
           (1) IN GENERAL .—There is hereby appropriated
      to the Secretary, out of any funds in the Treasury not
      otherwise appropriated, $50,000,000 for each of fiscal
@@ -41706,8 +38758,6 @@ lowing:
           subsection).
 
 
-      HR 3590 EAS/PP
-                           1477
                (C) A certified registered nurse anesthetist
           (as defined in subsection (bb)(2) of such section).
                (D) A certified nurse-midwife (as defined in
@@ -41734,8 +38784,6 @@ lowing:
       tion established under subsection (a).
 
 
-      HR 3590 EAS/PP
-                           1478
           (5) E LIGIBLE  HOSPITAL  .—The term ‘‘eligible
       hospital’’ means a hospital (as defined in subsection
       (e) of section 1861 of the Social Security Act (42
@@ -41762,8 +38810,6 @@ lowing:
                individuals entitled to, or enrolled for, bene-
                fits under part A of title XVIII of the Social
 
-      HR 3590 EAS/PP
-                          1479
               Security Act, or enrolled under part B of
               such title; and
                    (ii) subject to subparagraph (B), at
@@ -41790,8 +38836,6 @@ paragraph (1) and inserting the following:
      the amounts authorized to be appropriated under sub-
 
 
-      HR 3590 EAS/PP
-                           1480
       section (d), there is authorized to be appropriated the
       following:
                ‘‘(A) For fiscal year 2010, $2,988,821,592.
@@ -41818,8 +38862,6 @@ by adding at the end the following:
                ‘‘(A) N GENERAL  .—Nothing in this section
           shall be construed to prevent a community health
 
-      HR 3590 EAS/PP
-                            1481
           center from contracting with a Federally cer-
           tified rural health clinic (as defined in section
           1861(aa)(2) of the Social Security Act), a low-
@@ -41846,8 +38888,6 @@ by adding at the end the following:
                ability of a patient to pay; and
 
 
-      HR 3590 EAS/PP
-                           1482
                    ‘‘(ii) the establishment of a sliding fee
               scale for low-income patients.’’.
  SEC. 5602. NEGOTIATED RULEMAKING FOR DEVELOPMENT
@@ -41874,8 +38914,6 @@ by adding at the end the following:
               (A) shall consult with relevant stakeholders
           who will be significantly affected by a rule (such
 
-      HR 3590 EAS/PP
-                           1483
           as national, State and regional organizations
           representing affected entities), State health of-
           fices, community organizations, health centers
@@ -41902,8 +38940,6 @@ by adding at the end the following:
 rulemaking process under this subsection, the Secretary
 shall publish the notice provided for under section 564(a)
 
-      HR 3590 EAS/PP
-                          1484
 of title 5, United States Code, by not later than 45 days
 after the date of the enactment of this Act.
      (c) TARGET  DATE FOR  P UBLICATION OF  RULE .—As
@@ -41930,8 +38966,6 @@ a consensus with regard to the rulemaking proceeding and
 whether such consensus is likely to occur before one month
 before the target date for publication of the rule. If the com-
 
-      HR 3590 EAS/PP
-                          1485
 mittee reports that the committee has failed to make signifi-
 cant progress toward such consensus or is unlikely to reach
 such consensus by the target date, the Secretary may termi-
@@ -41958,8 +38992,6 @@ such comments and republication of such rule by not later
 than 1 year after the target publication date.
 
 
-      HR 3590 EAS/PP
-                           1486
  SEC. 5603. REAUTHORIZATION OF THE WAKEFIELD EMER-
              GENCY MEDICAL SERVICES FOR CHILDREN
              PROGRAM.
@@ -41986,8 +39018,6 @@ adding at the end the following:
              CIALTY CARE IN COMMUNITY-BASED MENTAL
              HEALTH SETTINGS.
      ‘‘(a) DEFINITIONS.—In this section:
-      HR 3590 EAS/PP
-                            1487
           ‘‘(1) ELIGIBLE ENTITY .—The term ‘eligible enti-
       ty’ means a qualified community mental health pro-
       gram defined under section 1913(b)(1).
@@ -42014,8 +39044,6 @@ to provide services to special populations.
 
 
 
-      HR 3590 EAS/PP
-                            1488
            ‘‘(1) N GENERAL   .—For the benefit of special
       populations, an eligible entity shall use funds award-
       ed under this section for—
@@ -42042,8 +39070,6 @@ to provide services to special populations.
       ‘‘(e) VALUATION  .—Not later than 90 days after a
 grant or cooperative agreement awarded under this section
 
-      HR 3590 EAS/PP
-                          1489
 expires, an eligible entity shall submit to the Secretary the
 results of an evaluation to be conducted by the entity con-
 cerning the effectiveness of the activities carried out under
@@ -42070,8 +39096,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
           Commission shall be composed of 8 members, to
           be appointed equally by the majority and minor-
 
-      HR 3590 EAS/PP
-                           1490
           ity leaders of the Senate and the Speaker and
           minority leader of the House of Representatives.
                (B) PROHIBITED APPOINTMENTS   .—Members
@@ -42098,8 +39122,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
           shall be appointed by not later than 30 days
           after the date of enactment of this Act.
 
-      HR 3590 EAS/PP
-                          1491
               (F) I NITIAL  ORGANIZING  PERIOD  .—–Not
           later than 60 days after the date of enactment of
           this Act, the Commission shall develop and im-
@@ -42126,8 +39148,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
           Chairpersons of the Commission, and each subse-
           quent year thereafter, the Commission shall pre-
 
-      HR 3590 EAS/PP
-                           1492
           pare and submit to the appropriate Committees
           of Congress and the President a report that con-
           tains a detailed statement of the recommenda-
@@ -42154,8 +39174,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
                (A) IN GENERAL .—–As soon as practicable
           after the selection of the 2 Co-Chairpersons of the
 
-      HR 3590 EAS/PP
-                            1493
           Commission, the Co-Chairpersons shall enter
           into an arrangement with the National Academy
           of Sciences under which the Academy shall—
@@ -42182,8 +39200,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
                cator system and, if established, the Insti-
 
 
-      HR 3590 EAS/PP
-                           1494
                tute, and governance of the Institute’s budg-
                et and operations.
                (B) PARTICIPATION .—In executing the ar-
@@ -42210,8 +39226,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
                    tional indicator system.
 
 
-      HR 3590 EAS/PP
-                            1495
                     (ii) NSTITUTE .—If the Academy des-
                ignates an Institute under clause (i)(II),
                such Institute shall be a non-profit entity
@@ -42238,8 +39252,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
                     cators described under subclause (II).
 
 
-      HR 3590 EAS/PP
-                            1496
                         (IV) Designing, publishing, and
                     maintaining a public website that con-
                     tains a freely accessible database allow-
@@ -42266,8 +39278,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
                     mission recommendations and to the
 
 
-      HR 3590 EAS/PP
-                           1497
                    Academy regarding any inquiries by
                    the Academy.
                    (iv) G OVERNANCE  .—Upon the estab-
@@ -42294,8 +39304,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
                ignated under clause (i)(II) to receive pri-
                vate funding for activities related to the es-
 
-      HR 3590 EAS/PP
-                          1498
               tablishment of a key national indicator sys-
               tem.
               (D) A NNUAL REPORT .—As part of the ar-
@@ -42322,8 +39330,6 @@ necessary for each of fiscal years 2011 through 2014.’’.
      erally accepted government auditing standards and
 
 
-      HR 3590 EAS/PP
-                          1499
      submit a report on such audit to the Commission and
      the appropriate authorizing committees of Congress.
          (3) GAO   PROGRAMMATIC REVIEW  .—The Comp-
@@ -42350,8 +39356,6 @@ mittees of Congress a report on the activities carried out
 under the amendments made by this title, and the effective-
 ness of such activities.
 
-      HR 3590 EAS/PP
-                         1500
      (b) REPORTS BY R ECIPIENTS OF FUNDS .—The Sec-
 retary of Health and Human Services may require, as a
 condition of receiving funds under the amendments made
@@ -42378,8 +39382,6 @@ Act (42 U.S.C. 1395nn) is amended—
 
 
 
-     HR 3590 EAS/PP
-                         1501
               ‘‘(C) in the case where the entity is a hos-
          pital, the hospital meets the requirements of
          paragraph (3)(D).’’;
@@ -42406,8 +39408,6 @@ Act (42 U.S.C. 1395nn) is amended—
          had—
 
 
-      HR 3590 EAS/PP
-                            1502
                     ‘‘(i) physician ownership or investment
                on February 1, 2010; and
                     ‘‘(ii) a provider agreement under sec-
@@ -42434,8 +39434,6 @@ Act (42 U.S.C. 1395nn) is amended—
                     the hospital.
 
 
-      HR 3590 EAS/PP
-                            1503
                     ‘‘(ii) The hospital has procedures in
                place to require that any referring physi-
                cian owner or investor discloses to the pa-
@@ -42462,8 +39460,6 @@ Act (42 U.S.C. 1395nn) is amended—
                     hospital; and
 
 
-      HR 3590 EAS/PP
-                            1504
                         ‘‘(II) in any public advertising
                     for the hospital.
                ‘‘(D) ENSURING BONA FIDE INVESTMENT    .—
@@ -42490,8 +39486,6 @@ Act (42 U.S.C. 1395nn) is amended—
                indirectly guarantee a loan, make a pay-
                ment toward a loan, or otherwise subsidize
 
-      HR 3590 EAS/PP
-                            1505
                a loan, for any individual physician owner
                or investor or group of physician owners or
                investors that is related to acquiring any
@@ -42518,8 +39512,6 @@ Act (42 U.S.C. 1395nn) is amended—
                or investor in the hospital on more favor-
                able terms than the terms offered to an indi-
 
-      HR 3590 EAS/PP
-                            1506
                vidual who is not a physician owner or in-
                vestor.
                ‘‘(E) PATIENT SAFETY .—
@@ -42546,8 +39538,6 @@ Act (42 U.S.C. 1395nn) is amended—
           TAIN CONVERTED FACILITIES   .—The hospital was
           not converted from an ambulatory surgical cen-
 
-      HR 3590 EAS/PP
-                           1507
           ter to a hospital on or after the date of enact-
           ment of this subsection.
           ‘‘(2) P UBLICATION   OF    INFORMATION   RE  -
@@ -42574,8 +39564,6 @@ Act (42 U.S.C. 1395nn) is amended—
                the application.
 
 
-      HR 3590 EAS/PP
-                           1508
                    ‘‘(iii) IMING FOR IMPLEMENTATION   .—
                The Secretary shall implement the process
                under clause (i) on August 1, 2011.
@@ -42602,8 +39590,6 @@ Act (42 U.S.C. 1395nn) is amended—
                paragraph, above the number of operating
                rooms, procedure rooms, and beds for which
 
-      HR 3590 EAS/PP
-                            1509
                the hospital is licensed after the application
                of the most recent increase under such an
                exception).
@@ -42630,8 +39616,6 @@ Act (42 U.S.C. 1395nn) is amended—
                ‘‘(D) INCREASE LIMITED TO FACILITIES ON
           THE MAIN CAMPUS OF THE HOSPITAL      .—Any in-
 
-      HR 3590 EAS/PP
-                            1510
           crease in the number of operating rooms, proce-
           dure rooms, and beds for which an applicable
           hospital is licensed pursuant to this paragraph
@@ -42658,8 +39642,6 @@ Act (42 U.S.C. 1395nn) is amended—
                the hospital is located;
 
 
-      HR 3590 EAS/PP
-                           1511
                    ‘‘(iii) that does not discriminate
                against beneficiaries of Federal health care
                programs and does not permit physicians
@@ -42686,8 +39668,6 @@ Act (42 U.S.C. 1395nn) is amended—
           application under this paragraph, the Secretary
 
 
-      HR 3590 EAS/PP
-                           1512
           shall publish in the Federal Register the final de-
           cision with respect to such application.
                ‘‘(H) LIMITATION ON REVIEW  .—There shall
@@ -42714,8 +39694,6 @@ Act (42 U.S.C. 1395nn) is amended—
       (b) NFORCEMENT   .—
 
 
-      HR 3590 EAS/PP
-                          1513
           (1) ENSURING COMPLIANCE  .—The Secretary of
      Health and Human Services shall establish policies
      and procedures to ensure compliance with the require-
@@ -42742,8 +39720,6 @@ the following new section:
      VALUE .—
 
 
-      HR 3590 EAS/PP
-                            1514
                ‘‘(A) IN GENERAL  .—On March 31, 2013,
           and on the 90th day of each calendar year begin-
           ning thereafter, any applicable manufacturer
@@ -42770,8 +39746,6 @@ the following new section:
                cated (as appropriate for all that apply)
                as—
 
-      HR 3590 EAS/PP
-                            1515
                          ‘‘(I) cash or a cash equivalent;
                          ‘‘(II) in-kind items or services;
                          ‘‘(III) stock, a stock option, or
@@ -42798,8 +39772,6 @@ the following new section:
                          ‘‘(IX) research;
                          ‘‘(X) charitable contribution;
 
-      HR 3590 EAS/PP
-                            1516
                         ‘‘(XI) royalty or license;
                         ‘‘(XII) current or prospective
                     ownership or investment interest;
@@ -42826,8 +39798,6 @@ the following new section:
           vides a payment or other transfer of value to an
           entity or individual at the request of or des-
 
-      HR 3590 EAS/PP
-                            1517
           ignated on behalf of a covered recipient, the ap-
           plicable manufacturer shall disclose that pay-
           ment or other transfer of value under the name
@@ -42854,8 +39824,6 @@ the following new section:
           ership or investment interest.
 
 
-      HR 3590 EAS/PP
-                           1518
                ‘‘(C) Any payment or other transfer of
           value provided to a physician holding such an
           ownership or investment interest (or to an entity
@@ -42882,8 +39850,6 @@ the following new section:
           less than $1,000, but not more than $10,000, for
           each payment or other transfer of value or own-
 
-      HR 3590 EAS/PP
-                           1519
           ership or investment interest not reported as re-
           quired under such subsection. Such penalty shall
           be imposed and collected in the same manner as
@@ -42910,8 +39876,6 @@ the following new section:
           other transfer of value or ownership or invest-
           ment interest not reported as required under
 
-      HR 3590 EAS/PP
-                          1520
           such subsection. Such penalty shall be imposed
           and collected in the same manner as civil money
           penalties under subsection (a) of section 1128A
@@ -42938,8 +39902,6 @@ the following new section:
               to submit information to the Secretary
               under subsection (a); and
 
-      HR 3590 EAS/PP
-                            1521
                     ‘‘(ii) for the Secretary to make such in-
                formation submitted available to the public.
                ‘‘(B) DEFINITION OF TERMS    .—The proce-
@@ -42966,8 +39928,6 @@ the following new section:
                cipient, the specialty of the covered recipi-
                ent, the value of the payment or other trans-
 
-      HR 3590 EAS/PP
-                            1522
                fer of value, the date on which the payment
                or other transfer of value was provided to
                the covered recipient, the form of the pay-
@@ -42994,8 +39954,6 @@ the following new section:
                from the other information submitted under
                subsection (a) and designates such sepa-
 
-      HR 3590 EAS/PP
-                           1523
                rately listed information as funding for
                clinical research;
                    ‘‘(vii) contains any other information
@@ -43022,8 +39980,6 @@ the following new section:
           (C)(ix) prevent such information from being
           made available to the public in accordance with
 
-      HR 3590 EAS/PP
-                           1524
           the dates described in the matter preceding
           clause (i) in subparagraph (C).
                ‘‘(E) D ELAYED  PUBLICATION   FOR   PAY -
@@ -43050,8 +40006,6 @@ the following new section:
                the public on the first date described in the
 
 
-      HR 3590 EAS/PP
-                            1525
                matter preceding clause (i) in subparagraph
                (C) after the earlier of the following:
                          ‘‘(I) The date of the approval or
@@ -43078,8 +40032,6 @@ the following new section:
       ties in order to ensure that the information made
 
 
-      HR 3590 EAS/PP
-                          1526
      available to the public under such paragraph is pre-
      sented in the appropriate overall context.
      ‘‘(d) ANNUAL  R EPORTS AND   R ELATION TO   STATE
@@ -43106,8 +40058,6 @@ the following new section:
           ‘‘(2) NNUAL REPORTS TO STATES    .—Not later
      than September 30, 2013 and on June 30 of each cal-
 
-      HR 3590 EAS/PP
-                            1527
       endar year thereafter, the Secretary shall submit to
       States a report that includes a summary of the infor-
       mation submitted under subsection (a) during the
@@ -43134,8 +40084,6 @@ the following new section:
                ‘‘(B) NO PREEMPTION OF ADDITIONAL RE     -
           QUIREMENTS  .—Subparagraph (A) shall not pre-
 
-      HR 3590 EAS/PP
-                            1528
           empt any statute or regulation of a State or of
           a political subdivision of a State that requires
           the disclosure or reporting of information—
@@ -43162,8 +40110,6 @@ the following new section:
       Health and Human Services on the implementation
       of this section.
 
-      HR 3590 EAS/PP
-                            1529
       ‘‘(e) EFINITIONS.—In this section:
           ‘‘(1) APPLICABLE GROUP PURCHASING ORGANI       -
       ZATION .—The term ‘applicable group purchasing or-
@@ -43190,8 +40136,6 @@ the following new section:
       XIX or XXI (or a waiver of such a plan).
 
 
-      HR 3590 EAS/PP
-                            1530
            ‘‘(5) OVERED DRUG    , DEVICE, BIOLOGICAL  , OR
       MEDICAL SUPPLY   .—The term ‘covered drug, device,
       biological, or medical supply’ means any drug, bio-
@@ -43218,8 +40162,6 @@ the following new section:
       VICE, BIOLOGICAL , OR MEDICAL SUPPLY    .—The term
       ‘manufacturer of a covered drug, device, biological, or
 
-      HR 3590 EAS/PP
-                           1531
      medical supply’ means any entity which is engaged
      in the production, preparation, propagation,
      compounding, or conversion of a covered drug, device,
@@ -43246,8 +40188,6 @@ the following new section:
           lowing:
 
 
-      HR 3590 EAS/PP
-                            1532
                     ‘‘(i) A transfer of anything the value of
                which is less than $10, unless the aggregate
                amount transferred to, requested by, or des-
@@ -43274,8 +40214,6 @@ the following new section:
                     ‘‘(v) Items or services provided under a
                contractual warranty, including the re-
 
-      HR 3590 EAS/PP
-                            1533
                placement of a covered device, where the
                terms of the warranty are set forth in the
                purchase or lease agreement for the covered
@@ -43302,8 +40240,6 @@ the following new section:
                ered recipient if the transfer is payment
                solely for the non-medical professional serv-
 
-      HR 3590 EAS/PP
-                            1534
                ices of such licensed non-medical profes-
                sional.
                     ‘‘(xii) In the case of a covered recipient
@@ -43330,8 +40266,6 @@ clude a requirement that the referring physician inform the
 individual in writing at the time of the referral that the
 individual may obtain the services for which the individual
 
-      HR 3590 EAS/PP
-                           1535
 is being referred from a person other than a person de-
 scribed in subparagraph (A)(i) and provide such individual
 with a written list of suppliers (as defined in section
@@ -43358,8 +40292,6 @@ ceding year:
       section 503 of the Federal Food, Drug, and Cosmetic
       Act (21 U.S.C. 353), the identity and quantity of
 
-      HR 3590 EAS/PP
-                            1536
       drug samples requested and the identity and quantity
       of drug samples distributed under such subsection
       during that year, aggregated by—
@@ -43386,8 +40318,6 @@ ceding year:
           tioner; and
 
 
-      HR 3590 EAS/PP
-                           1537
                ‘‘(B) any other category of information de-
           termined appropriate by the Secretary.
       ‘‘(b) EFINITIONS.—In this section:
@@ -43414,8 +40344,6 @@ the following new section:
 
 
 
-      HR 3590 EAS/PP
-                            1538
  ‘‘SEC. 1150A. PHARMACY BENEFIT MANAGERS TRANS-
               PARENCY REQUIREMENTS.
       ‘‘(a) ROVISION OF  INFORMATION  .—A health benefits
@@ -43442,8 +40370,6 @@ contract year:
       provided through retail pharmacies compared to mail
       order pharmacies, and the percentage of prescriptions
       for which a generic drug was available and dispensed
-      HR 3590 EAS/PP
-                           1539
       (generic dispensing rate), by pharmacy type (which
       includes an independent pharmacy, chain pharmacy,
       supermarket pharmacy, or mass merchandiser phar-
@@ -43470,8 +40396,6 @@ contract year:
       macies, and mail order pharmacies, and the total
       number of prescriptions that were dispensed.
 
-      HR 3590 EAS/PP
-                             1540
       ‘‘(c) CONFIDENTIALITY  .—Information disclosed by a
 health benefits plan or PBM under this section is confiden-
 tial and shall not be disclosed by the Secretary or by a plan
@@ -43498,8 +40422,6 @@ that section.’’.
 
 
 
-      HR 3590 EAS/PP
-                         1541
         Subtitle B—Nursing Home
    Transparency and Improvement
      PART I—IMPROVING TRANSPARENCY OF
@@ -43526,8 +40448,6 @@ the following new subsection:
          in the case where the Secretary, the Inspector
 
 
-     HR 3590 EAS/PP
-                           1542
           General, the State, or the State long-term care
           ombudsman requests such information; and
                ‘‘(B) beginning on the effective date of the
@@ -43554,8 +40474,6 @@ the following new subsection:
                         ‘‘(II) each person or entity who is
                    an officer, director, member, partner,
 
-      HR 3590 EAS/PP
-                            1543
                     trustee, or managing employee of the
                     facility, including the name, title, and
                     period of service of each such person or
@@ -43582,8 +40500,6 @@ the following new subsection:
           quirements of paragraph (1).
 
 
-      HR 3590 EAS/PP
-                            1544
                ‘‘(C) SPECIAL   RULE .—In applying sub-
           paragraph (A)(i)—
                     ‘‘(i) with respect to subsections (a) and
@@ -43610,8 +40526,6 @@ the following new subsection:
           standardized format, and such other regulations
           as are necessary to carry out this subsection.
 
-      HR 3590 EAS/PP
-                           1545
           Such final regulations shall ensure that the facil-
           ity certifies, as a condition of participation and
           payment under the program under title XVIII or
@@ -43638,8 +40552,6 @@ the following new subsection:
                part thereof, or provides policies or proce-
                dures for any of the operations of the facil-
 
-      HR 3590 EAS/PP
-                            1546
                ity, or provides financial or cash manage-
                ment services to the facility;
                     ‘‘(ii) leases or subleases real property
@@ -43666,8 +40578,6 @@ the following new subsection:
 
 
 
-      HR 3590 EAS/PP
-                            1547
                ‘‘(D) O RGANIZATIONAL   STRUCTURE   .—The
           term ‘organizational structure’ means, in the
           case of—
@@ -43694,8 +40604,6 @@ the following new subsection:
                tion for the individual; and
 
 
-      HR 3590 EAS/PP
-                           1548
                    ‘‘(vii) any other person or entity, such
               information as the Secretary determines ap-
               propriate.’’.
@@ -43722,8 +40630,6 @@ lished by the Secretary.
           as subparagraph (B).
 
 
-      HR 3590 EAS/PP
-                          1549
           (2) EFFECTIVE DATE  .—The amendments made
      by paragraph (1) shall take effect on the date on
      which the Secretary makes the information described
@@ -43750,8 +40656,6 @@ term ‘facility’ means—
      is 36 months after the date of the enactment of this
      section, a facility shall, with respect to the entity that
 
-      HR 3590 EAS/PP
-                           1550
       operates the facility (in this subparagraph referred to
       as the ‘operating organization’ or ‘organization’),
       have in operation a compliance and ethics program
@@ -43778,8 +40682,6 @@ term ‘facility’ means—
           defining the standards and procedures to be fol-
           lowed by its employees. Such requirements may
 
-      HR 3590 EAS/PP
-                            1551
           specifically apply to the corporate level manage-
           ment of multi unit nursing home chains.
                ‘‘(C) EVALUATION .—Not later than 3 years
@@ -43806,8 +40708,6 @@ term ‘facility’ means—
           effective in preventing and detecting criminal,
 
 
-      HR 3590 EAS/PP
-                           1552
           civil, and administrative violations under this
           Act and in promoting quality of care; and
                ‘‘(B) includes at least the required compo-
@@ -43834,8 +40734,6 @@ term ‘facility’ means—
           knew, or should have known through the exercise
           of due diligence, had a propensity to engage in
 
-      HR 3590 EAS/PP
-                            1553
           criminal, civil, and administrative violations
           under this Act.
                ‘‘(D) The organization must have taken
@@ -43862,8 +40760,6 @@ term ‘facility’ means—
           to detect an offense.
 
 
-      HR 3590 EAS/PP
-                           1554
               ‘‘(G) After an offense has been detected, the
           organization must have taken all reasonable
           steps to respond appropriately to the offense and
@@ -43890,8 +40786,6 @@ term ‘facility’ means—
      the development of best practices in order to meet such
      standards. Not later than 1 year after the date on
 
-      HR 3590 EAS/PP
-                          1555
      which the regulations are promulgated under para-
      graph (2), a facility must submit to the Secretary a
      plan for the facility to meet such standards and im-
@@ -43918,8 +40812,6 @@ term ‘facility’ means—
           vided for comparison of nursing homes on the of-
           ficial Internet website of the Federal Government
 
-      HR 3590 EAS/PP
-                            1556
           for Medicare beneficiaries (commonly referred to
           as the ‘Nursing Home Compare’ Medicare
           website) (or a successor website), the following
@@ -43946,8 +40838,6 @@ term ‘facility’ means—
                     day’);
 
 
-      HR 3590 EAS/PP
-                            1557
                          ‘‘(II) differences in types of staff
                     (such as training associated with dif-
                     ferent categories of staff);
@@ -43974,8 +40864,6 @@ term ‘facility’ means—
                file a complaint with the State survey and
 
 
-      HR 3590 EAS/PP
-                           1558
                certification program and the State long-
                term care ombudsman program.
                    ‘‘(iv) Summary information on the
@@ -44002,8 +40890,6 @@ term ‘facility’ means—
           MATION .—
 
 
-      HR 3590 EAS/PP
-                            1559
                     ‘‘(i)N GENERAL  .—Except as provided
                in clause (ii), the Secretary shall ensure
                that the information described in subpara-
@@ -44030,8 +40916,6 @@ term ‘facility’ means—
                modify or revamp such website in accord-
 
 
-      HR 3590 EAS/PP
-                           1560
                ance with the review conducted under clause
                (i).
                ‘‘(B) CONSULTATION  .—In conducting the
@@ -44058,8 +40942,6 @@ term ‘facility’ means—
           Medicare website under subsection (i), each State
           shall submit information respecting any survey
 
-      HR 3590 EAS/PP
-                           1561
           or certification made respecting a skilled nursing
           facility (including any enforcement actions taken
           by the State) to the Secretary not later than the
@@ -44086,8 +40968,6 @@ term ‘facility’ means—
           quirement of this Act.
 
 
-      HR 3590 EAS/PP
-                          1562
               ‘‘(B) ERIODIC SURVEYS .—Under such pro-
           gram the Secretary shall conduct surveys of each
           facility in the program not less than once every
@@ -44114,8 +40994,6 @@ term ‘facility’ means—
           understandable to consumers of long-term care
           services, and searchable:
 
-      HR 3590 EAS/PP
-                            1563
                     ‘‘(i) Staffing data for each facility (in-
                cluding resident census data and data on
                the hours of care provided per resident per
@@ -44142,8 +41020,6 @@ term ‘facility’ means—
 
 
 
-      HR 3590 EAS/PP
-                            1564
                         ‘‘(IV) an explanation that appro-
                     priate staffing levels vary based on pa-
                     tient case mix.
@@ -44170,8 +41046,6 @@ term ‘facility’ means—
 
 
 
-      HR 3590 EAS/PP
-                            1565
                     ‘‘(v) The number of adjudicated in-
                stances of criminal violations by a facility
                or the employees of a facility—
@@ -44198,8 +41072,6 @@ term ‘facility’ means—
                than the date on which the requirements
                under section 1128I(g) are implemented.
 
-      HR 3590 EAS/PP
-                            1566
           ‘‘(2) REVIEW AND MODIFICATION OF WEBSITE    .—
                ‘‘(A) N GENERAL  .—The Secretary shall es-
           tablish a process—
@@ -44226,8 +41098,6 @@ term ‘facility’ means—
                grams or groups the Secretary determines
                appropriate.’’.
 
-      HR 3590 EAS/PP
-                           1567
           (2) TIMELINESS OF SUBMISSION OF SURVEY AND
      CERTIFICATION INFORMATION   .—
                (A) N GENERAL  .—Section 1919(g)(5) of the
@@ -44254,8 +41124,6 @@ term ‘facility’ means—
 
 
 
-      HR 3590 EAS/PP
-                           1568
               (B) E  FFECTIVE  DATE  .—The amendment
           made by this paragraph shall take effect 1 year
           after the date of the enactment of this Act.
@@ -44282,8 +41150,6 @@ term ‘facility’ means—
      amended by adding at the end the following new sub-
      paragraph:
 
-      HR 3590 EAS/PP
-                            1569
                 ‘‘(C) AVAILABILITY OF SURVEY    , CERTIFI -
            CATION , AND   COMPLAINT   INVESTIGATION   RE  -
            PORTS .—A skilled nursing facility must—
@@ -44310,8 +41176,6 @@ term ‘facility’ means—
                 tigations made respecting the facility dur-
 
 
-      HR 3590 EAS/PP
-                          1570
               ing the 3 preceding years available for any
               individual to review upon request; and
                    ‘‘(ii) post notice of the availability of
@@ -44338,8 +41202,6 @@ term ‘facility’ means—
      skilled nursing facilities and nursing facilities and
 
 
-      HR 3590 EAS/PP
-                            1571
       the Secretary shall, if possible, include such informa-
       tion on Nursing Home Compare.
           (2) R EQUIREMENT  .—Section 1902(a)(9) of the
@@ -44366,8 +41228,6 @@ term ‘facility’ means—
           (3) D EFINITIONS.—In this subsection:
 
 
-      HR 3590 EAS/PP
-                          1572
               (A) N URSING FACILITY.—The term ‘‘nurs-
           ing facility’’ has the meaning given such term in
           section 1919(a) of the Social Security Act (42
@@ -44394,8 +41254,6 @@ scriptions of, and information with respect to, the following:
      nursing facility that meets the needs of the indi-
      vidual.
 
-      HR 3590 EAS/PP
-                           1573
           (3) General information on consumer rights with
      respect to nursing facilities.
           (4) The nursing facility survey process (on a na-
@@ -44422,8 +41280,6 @@ subsection:
      rienced with Medicare and Medicaid nursing facility
      home cost reports, shall redesign such reports to meet
 
-      HR 3590 EAS/PP
-                            1574
       the requirement of paragraph (1) not later than 1
       year after the date of the enactment of this subsection.
           ‘‘(3) C ATEGORIZATION    BY  FUNCTIONAL    AC -
@@ -44450,8 +41306,6 @@ subsection:
           ‘‘(4) A VAILABILITY   OF   INFORMATION   SUB  -
       MITTED .—The Secretary shall establish procedures to
 
-      HR 3590 EAS/PP
-                          1575
      make information on expenditures submitted under
      this subsection readily available to interested parties
      upon request, subject to such requirements as the Sec-
@@ -44478,8 +41332,6 @@ by adding at the end the following new subsection:
               dent’s behalf.
 
 
-      HR 3590 EAS/PP
-                           1576
                ‘‘(B) COMPLAINT RESOLUTION PROCESS     .—
           The State must establish a complaint resolution
           process in order to ensure that the legal rep-
@@ -44506,8 +41358,6 @@ by adding at the end the following new subsection:
       half) from submitting a complaint in a manner or
       format other than by using the standardized com-
 
-      HR 3590 EAS/PP
-                          1577
      plaint form developed under paragraph (1) (including
      submitting a complaint orally).’’.
      (b) EFFECTIVE D ATE.—The amendment made by this
@@ -44534,8 +41384,6 @@ groups, and parties). Such specifications shall require that
 the information submitted under the preceding sentence—
 
 
-      HR 3590 EAS/PP
-                            1578
            ‘‘(1) specify the category of work a certified em-
       ployee performs (such as whether the employee is a
       registered nurse, licensed practical nurse, licensed vo-
@@ -44562,8 +41410,6 @@ States (in this section referred to as the ‘‘Comptroller Gen-
 eral’’) shall conduct a study on the Five-Star Quality Rat-
 ing System for nursing homes of the Centers for Medicare
 
-      HR 3590 EAS/PP
-                          1579
 & Medicaid Services. Such study shall include an analysis
 of—
           (1) how such system is being implemented;
@@ -44590,8 +41436,6 @@ Comptroller General determines appropriate.
           subclauses:
 
 
-      HR 3590 EAS/PP
-                            1580
                         ‘‘(II) EDUCTION OF CIVIL MONEY
                     PENALTIES     IN    CERTAIN     CIR -
                     CUMSTANCES  .—Subject to subclause
@@ -44618,8 +41462,6 @@ Comptroller General determines appropriate.
                         CIENCIES .—The Secretary may
                         not reduce the amount of a pen-
 
-      HR 3590 EAS/PP
-                            1581
                          alty under subclause (II) if the
                          penalty is imposed on the facility
                          for a deficiency that is found to
@@ -44646,8 +41488,6 @@ Comptroller General determines appropriate.
                              ‘‘(bb) in the case where the
                          penalty is imposed for each day of
 
-      HR 3590 EAS/PP
-                            1582
                         noncompliance, provide that a
                         penalty may not be imposed for
                         any day during the period begin-
@@ -44674,8 +41514,6 @@ Comptroller General determines appropriate.
                              ‘‘(ee) in the case where the
                         facility successfully appeals the
 
-      HR 3590 EAS/PP
-                            1583
                          penalty, may provide for the re-
                          turn of such amounts collected
                          (plus interest) to the facility; and
@@ -44702,8 +41540,6 @@ Comptroller General determines appropriate.
                          veyors, technical assistance for fa-
                          cilities implementing quality as-
 
-      HR 3590 EAS/PP
-                           1584
                         surance programs, the appoint-
                         ment of temporary management
                         firms, and other activities ap-
@@ -44730,8 +41566,6 @@ Comptroller General determines appropriate.
                    ciency for which a penalty was im-
                    posed under this clause not later than
 
-      HR 3590 EAS/PP
-                            1585
                     10 calendar days after the date of such
                     imposition, the Secretary may reduce
                     the amount of the penalty imposed by
@@ -44758,8 +41592,6 @@ Comptroller General determines appropriate.
                         jeopardizes the health or safety of
                         a resident or residents of the facil-
 
-      HR 3590 EAS/PP
-                            1586
                         ity, or results in the death of a
                         resident of the facility.
                         ‘‘(IV) C  OLLECTION   OF   CIVIL
@@ -44786,8 +41618,6 @@ Comptroller General determines appropriate.
                         on the day on which the informal
 
 
-      HR 3590 EAS/PP
-                            1587
                          dispute resolution process under
                          item (aa) is completed;
                              ‘‘(cc) may provide for the col-
@@ -44814,8 +41644,6 @@ Comptroller General determines appropriate.
                          such appeals are unsuccessful,
                          may provide that some portion of
 
-      HR 3590 EAS/PP
-                           1588
                         such amounts collected may be
                         used to support activities that
                         benefit residents, including assist-
@@ -44842,8 +41670,6 @@ Comptroller General determines appropriate.
           (2) C    ONFORMING       AMENDMENT   .—Section
       1919(h)(5)(8) of the Social Security Act (42 U.S.C.
 
-      HR 3590 EAS/PP
-                           1589
      1396r(h)(5)(8)) is amended by inserting ‘‘(ii)(IV),’’
      after ‘‘(i),’’.
      (c) EFFECTIVE  DATE .—The amendments made by this
@@ -44870,8 +41696,6 @@ ment of this Act.
      demonstration project under this section for a 2-year
      period.
 
-      HR 3590 EAS/PP
-                            1590
            (4) IMPLEMENTATION   .—The Secretary shall im-
       plement the demonstration project under this section
       not later than 1 year after the date of the enactment
@@ -44898,8 +41722,6 @@ shall—
            (2) conduct sustained oversight of the efforts of
       the chain, whether publicly or privately held, to
 
-      HR 3590 EAS/PP
-                           1591
       achieve compliance by facilities of the chain with
       State and Federal laws and regulations applicable to
       the facilities;
@@ -44926,8 +41748,6 @@ shall—
           plement such recommendations, and why it will
           not do so.
 
-      HR 3590 EAS/PP
-                            1592
           (2) R ECEIPT OF REPORT BY INDEPENDENT MON     -
       ITOR.—Not later than 10 days after receipt of a re-
       port submitted by a chain under paragraph (1), an
@@ -44954,8 +41774,6 @@ essary to carry out this section.
           (1) ADDITIONAL DISCLOSABLE PARTY    .—The term
       ‘‘additional disclosable party’’ has the meaning given
 
-      HR 3590 EAS/PP
-                           1593
      such term in section 1124(c)(5)(A) of the Social Secu-
      rity Act, as added by section 4201(a).
           (2) F ACILITY.—The term ‘‘facility’’ means a
@@ -44982,8 +41800,6 @@ essary to carry out this section.
      section, the Secretary shall submit to Congress a re-
      port containing the results of the evaluation con-
 
-      HR 3590 EAS/PP
-                          1594
      ducted under paragraph (1), together with rec-
      ommendations—
               (A) as to whether the independent monitor
@@ -45010,8 +41826,6 @@ by adding at the end the following new subsection:
 
 
 
-      HR 3590 EAS/PP
-                            1595
                     ‘‘(i) subject to clause (ii), not later
                than the date that is 60 days prior to the
                date of such closure; and
@@ -45038,8 +41852,6 @@ by adding at the end the following new subsection:
           facility have been successfully relocated to an-
 
 
-      HR 3590 EAS/PP
-                            1596
           other facility or an alternative home and com-
           munity-based setting.
                ‘‘(B) CONTINUATION OF PAYMENTS UNTIL
@@ -45066,8 +41878,6 @@ by adding at the end the following new subsection:
       second sentence of subsection (f)) shall apply to a civil
       money penalty or exclusion under paragraph (3) in
 
-      HR 3590 EAS/PP
-                           1597
      the same manner as such provisions apply to a pen-
      alty or proceeding under section 1128A(a).’’.
      (b) C ONFORMING  A MENDMENTS  .—Section 1819(h)(4)
@@ -45094,8 +41904,6 @@ ing in order to undertake culture change) and 1 for the de-
 velopment of best practices in skilled nursing facilities and
 
 
-      HR 3590 EAS/PP
-                           1598
 nursing facilities for the use of information technology to
 improve resident care.
      (b) CONDUCT OF  DEMONSTRATION   PROJECTS .—
@@ -45122,8 +41930,6 @@ improve resident care.
      (d) DEFINITIONS .—In this section:
 
 
-      HR 3590 EAS/PP
-                           1599
           (1) NURSING FACILITY .—The term ‘‘nursing fa-
      cility’’ has the meaning given such term in section
      1919(a) of the Social Security Act (42 U.S.C.
@@ -45150,8 +41956,6 @@ tion as the Secretary determines appropriate.
      3(f)(2)(A)(i)(I)) is amended by inserting ‘‘(including,
      in the case of initial training and, if the Secretary
 
-      HR 3590 EAS/PP
-                           1600
      determines appropriate, in the case of ongoing train-
      ing, dementia management training, and patient
      abuse prevention training’’ before ‘‘, (II)’’.
@@ -45178,8 +41982,6 @@ tion as the Secretary determines appropriate.
           such services through an agency or under a con-
           tract with the facility.’’.
 
-      HR 3590 EAS/PP
-                         1601
      (c) FFECTIVE D ATE.—The amendments made by this
 section shall take effect 1 year after the date of the enact-
 ment of this Act.
@@ -45206,8 +42008,6 @@ under section 307 of the Medicare Prescription Drug, Im-
 provement, and Modernization Act of 2003 (Public Law
 108–173; 117 Stat. 2257), including the prohibition on hir-
 
-     HR 3590 EAS/PP
-                           1602
 ing abusive workers and the authorization of the imposition
 of penalties by a participating State under subsection
 (b)(3)(A) and (b)(6), respectively, of such section 307:
@@ -45234,8 +42034,6 @@ of penalties by a participating State under subsection
               duct background checks under the program
 
 
-      HR 3590 EAS/PP
-                           1603
                established under subsection (a) of such sec-
                tion 307 on a Statewide basis;
                    (ii) that agrees to conduct background
@@ -45262,8 +42060,6 @@ of penalties by a participating State under subsection
           cluding the abuse and neglect registries of an-
           other State in the case where a prospective em-
 
-      HR 3590 EAS/PP
-                            1604
           ployee previously resided in that State, State
           criminal history records, the records of any pro-
           ceedings in the State that may contain disquali-
@@ -45290,8 +42086,6 @@ of penalties by a participating State under subsection
           the long-term care facility or provider which em-
 
 
-      HR 3590 EAS/PP
-                           1605
           ploys the direct patient access employee of such
           conviction; and
                (C) require that criminal history back-
@@ -45318,8 +42112,6 @@ of penalties by a participating State under subsection
                term care facility or provider of a direct
                patient access employee, not to exceed 60
 
-      HR 3590 EAS/PP
-                            1606
                days, pending completion of the required
                criminal history background check and, in
                the case where the employee has appealed
@@ -45346,8 +42138,6 @@ of penalties by a participating State under subsection
                fying information with respect to the cur-
                rent employment of the individual;
 
-      HR 3590 EAS/PP
-                            1607
                     (v) provide for the designation of a
                single State agency as responsible for—
                         (I) overseeing the coordination of
@@ -45374,8 +42164,6 @@ of penalties by a participating State under subsection
                     ground check the results of such review;
                     and
 
-      HR 3590 EAS/PP
-                            1608
                         (IV) in the case of an employee
                     with a conviction for a relevant crime
                     that is subject to reporting under sec-
@@ -45402,8 +42190,6 @@ of penalties by a participating State under subsection
                match the prints on file with the State law
                enforcement department—
 
-      HR 3590 EAS/PP
-                           1609
                         (I) the department will imme-
                    diately inform the State agency des-
                    ignated under clause (v) and such
@@ -45430,8 +42216,6 @@ of penalties by a participating State under subsection
                or private entities) a particular amount of
                non-Federal contributions, as a condition of
 
-      HR 3590 EAS/PP
-                           1610
                receiving the Federal match under clause
                (ii).
                    (ii) FEDERAL MATCH    .—The payment
@@ -45458,8 +42242,6 @@ of penalties by a participating State under subsection
                ters into an agreement with under para-
                graph (1)(B) shall be 3 times the amount
 
-      HR 3590 EAS/PP
-                           1611
               that the State guarantees to make available
               under clause (i), except that in no case may
               the payment amount exceed $1,500,000.
@@ -45486,8 +42268,6 @@ of penalties by a participating State under subsection
           a State agency under section 1819(g)(1)(C) or
           1919(g)(1)(C) of the Social Security Act (42
 
-      HR 3590 EAS/PP
-                           1612
           U.S.C. 1395i–3(g)(1)(C), 1396r(g)(1)(C)) or a
           Federal agency that a direct patient access em-
           ployee has committed—
@@ -45514,8 +42294,6 @@ of penalties by a participating State under subsection
           dent of the long-term care facility or provider.
 
 
-      HR 3590 EAS/PP
-                            1613
                (E) L ONG -TERM CARE FACILITY OR PRO      -
           VIDER .—The term ‘‘long-term care facility or
           provider’’ means the following facilities or pro-
@@ -45542,8 +42320,6 @@ of penalties by a participating State under subsection
                care services, including an assisted living
 
 
-      HR 3590 EAS/PP
-                           1614
                facility that provides a level of care estab-
                lished by the Secretary.
                    (ix) An intermediate care facility for
@@ -45570,8 +42346,6 @@ of penalties by a participating State under subsection
                    patient access employees under the na-
                    tionwide program and identification of
 
-      HR 3590 EAS/PP
-                           1615
                    the most appropriate, efficient, and ef-
                    fective procedures for conducting such
                    background checks.
@@ -45598,8 +42372,6 @@ of penalties by a participating State under subsection
           the Inspector General of the Department of
           Health and Human Services shall submit a re-
 
-      HR 3590 EAS/PP
-                           1616
           port to Congress containing the results of the
           evaluation conducted under subparagraph (A).
      (b) FUNDING .—
@@ -45626,8 +42398,6 @@ of penalties by a participating State under subsection
           (a)(7)(A).
 
 
-      HR 3590 EAS/PP
-                          1617
       Subtitle D—Patient-Centered
              Outcomes Research
  SEC. 6301. PATIENT-CENTERED OUTCOMES RESEARCH.
@@ -45654,8 +42424,6 @@ the following new part:
           paragraph are health care interventions, proto-
           cols for treatment, care management, and deliv-
 
-      HR 3590 EAS/PP
-                            1618
           ery, procedures, medical devices, diagnostic tools,
           pharmaceuticals (including drugs and
           biologicals), integrative health practices, and any
@@ -45682,8 +42450,6 @@ the following new part:
           companies that own or manufacture medical
           treatments, services, or items to be studied under
 
-      HR 3590 EAS/PP
-                           1619
           this section that in the aggregate exceeds $10,000
           per year. For purposes of the preceding sentence,
           a financial benefit includes honoraria, fees, stock,
@@ -45710,8 +42476,6 @@ the following new part:
      Centered Outcomes Research Trust Fund (referred to
      in this section as the ‘PCORTF’) under section 9511
 
-      HR 3590 EAS/PP
-                            1620
       of the Internal Revenue Code of 1986 shall be avail-
       able, without further appropriation, to the Institute
       to carry out this section.
@@ -45738,8 +42502,6 @@ and items described in subsection (a)(2)(B).
           tions), gaps in evidence in terms of clinical out-
           comes, practice variations and health disparities
 
-      HR 3590 EAS/PP
-                            1621
           in terms of delivery and outcomes of care, the po-
           tential for new evidence to improve patient
           health, well-being, and the quality of care, the ef-
@@ -45766,8 +42528,6 @@ and items described in subsection (a)(2)(B).
           termines appropriate.
 
 
-      HR 3590 EAS/PP
-                           1622
           ‘‘(2) ARRYING OUT RESEARCH PROJECT AGEN      -
      DA .—
                ‘‘(A) ESEARCH  .—The Institute shall carry
@@ -45794,8 +42554,6 @@ and items described in subsection (a)(2)(B).
                    with the research project agenda estab-
                    lished under paragraph (1)(B), the In-
 
-      HR 3590 EAS/PP
-                           1623
                    stitute shall enter into contracts for the
                    management of funding and conduct of
                    research in accordance with the fol-
@@ -45822,8 +42580,6 @@ and items described in subsection (a)(2)(B).
                         ‘‘(I) abide by the transparency
                    and conflicts of interest requirements
 
-      HR 3590 EAS/PP
-                            1624
                     under subsection (h) that apply to the
                     Institute with respect to the research
                     managed or conducted under such con-
@@ -45850,8 +42606,6 @@ and items described in subsection (a)(2)(B).
                     information available to the public
                     under paragraph (8); and
 
-      HR 3590 EAS/PP
-                           1625
                         ‘‘(VII) comply with other terms
                    and conditions determined necessary
                    by the Institute to carry out the re-
@@ -45878,8 +42632,6 @@ and items described in subsection (a)(2)(B).
                with the agency, instrumentality, or entity
                which managed or conducted such research
 
-      HR 3590 EAS/PP
-                           1626
                for a period determined appropriate by the
                Institute (but not less than 5 years).
                ‘‘(C) EVIEW AND UPDATE OF EVIDENCE     .—
@@ -45906,8 +42658,6 @@ and items described in subsection (a)(2)(B).
           impact of the skill of the operator of the treat-
           ment modality.
 
-      HR 3590 EAS/PP
-                           1627
           ‘‘(3) ATA COLLECTION  .—
                ‘‘(A) N GENERAL   .—The Secretary shall,
           with appropriate safeguards for privacy, make
@@ -45934,8 +42684,6 @@ and items described in subsection (a)(2)(B).
                sory panels as determined appropriate to
                assist in identifying research priorities and
 
-      HR 3590 EAS/PP
-                            1628
                establishing the research project agenda
                under paragraph (1) and for other pur-
                poses.
@@ -45962,8 +42710,6 @@ and items described in subsection (a)(2)(B).
                search study and determining the relative
 
 
-      HR 3590 EAS/PP
-                           1629
                value and feasibility of conducting the re-
                search study.
                ‘‘(B) COMPOSITION  .—An expert advisory
@@ -45990,8 +42736,6 @@ and items described in subsection (a)(2)(B).
                ‘‘(A) N GENERAL  .—The Institute shall es-
           tablish a standing methodology committee to
 
-      HR 3590 EAS/PP
-                           1630
           carry out the functions described in subpara-
           graph (C).
                ‘‘(B) APPOINTMENT   AND  COMPOSITION   .—
@@ -46018,8 +42762,6 @@ and items described in subsection (a)(2)(B).
           not later than 18 months after the establishment
           of the Institute, directly or through subcontract,
 
-      HR 3590 EAS/PP
-                            1631
           developing and periodically updating the fol-
           lowing:
                     ‘‘(i) Methodological standards for re-
@@ -46046,8 +42788,6 @@ and items described in subsection (a)(2)(B).
                and evaluated in different types of research.
                As appropriate, such standards shall build
 
-      HR 3590 EAS/PP
-                            1632
                on existing work on methodological stand-
                ards for defined categories of health inter-
                ventions and for each of the major cat-
@@ -46074,8 +42814,6 @@ and items described in subsection (a)(2)(B).
           committee’s performance of the functions de-
           scribed in subparagraph (C). Reports shall con-
 
-      HR 3590 EAS/PP
-                           1633
           tain recommendations for the Institute to adopt
           methodological standards developed and updated
           by the methodology committee as well as other
@@ -46102,8 +42840,6 @@ and items described in subsection (a)(2)(B).
           process shall be designed in a manner so as to
           avoid bias and conflicts of interest on the part
 
-      HR 3590 EAS/PP
-                           1634
           of the reviewers and shall be composed of experts
           in the scientific field relevant to the research
           under review.
@@ -46130,8 +42866,6 @@ and items described in subsection (a)(2)(B).
           tients, and the general public. The Institute shall
           ensure that the research findings—
 
-      HR 3590 EAS/PP
-                            1635
                     ‘‘(i) convey the findings of research in
                a manner that is comprehensible and useful
                to patients and providers in making health
@@ -46158,8 +42892,6 @@ and items described in subsection (a)(2)(B).
           ment.
 
 
-      HR 3590 EAS/PP
-                            1636
           ‘‘(9) ADOPTION .—Subject to subsection (h)(1),
       the Institute shall adopt the national priorities iden-
       tified under paragraph (1)(A), the research project
@@ -46186,8 +42918,6 @@ and items described in subsection (a)(2)(B).
           during the preceding year;
 
 
-      HR 3590 EAS/PP
-                           1637
                ‘‘(B) the research project agenda and budget
           of the Institute for the following year;
                ‘‘(C) any administrative activities con-
@@ -46214,8 +42944,6 @@ and items described in subsection (a)(2)(B).
 
 
 
-      HR 3590 EAS/PP
-                            1638
           ‘‘(1) N GENERAL   .—The Institute shall have a
       Board of Governors, which shall consist of the fol-
       lowing members:
@@ -46242,8 +42970,6 @@ and items described in subsection (a)(2)(B).
                who self-insure employee benefits.
 
 
-      HR 3590 EAS/PP
-                            1639
                     ‘‘(iv) 3 members representing pharma-
                ceutical, device, and diagnostic manufactur-
                ers or developers.
@@ -46270,8 +42996,6 @@ and items described in subsection (a)(2)(B).
       pation.
 
 
-      HR 3590 EAS/PP
-                            1640
           ‘‘(3) T ERMS ; VACANCIES .—A member of the
       Board shall be appointed for a term of 6 years, except
       with respect to the members first appointed, whose
@@ -46298,8 +43022,6 @@ and items described in subsection (a)(2)(B).
           ‘‘(6) DIRECTOR AND STAFF   ;EXPERTS AND CON   -
       SULTANTS .—The Board may employ and fix the com-
 
-      HR 3590 EAS/PP
-                           1641
      pensation of an Executive Director and such other
      personnel as may be necessary to carry out the duties
      of the Institute and may seek such assistance and
@@ -46326,8 +43048,6 @@ and items described in subsection (a)(2)(B).
               nual basis, the financial audits conducted
               under paragraph (1).
 
-      HR 3590 EAS/PP
-                            1642
                     ‘‘(ii) Not less frequently than every 5
                years, the processes established by the Insti-
                tute, including the research priorities and
@@ -46354,8 +43074,6 @@ and items described in subsection (a)(2)(B).
                years, the overall effectiveness of activities
                conducted under this section and the dis-
 
-      HR 3590 EAS/PP
-                            1643
                semination, training, and capacity building
                activities conducted under section 937 of the
                Public Health Service Act. Such review
@@ -46382,8 +43100,6 @@ and items described in subsection (a)(2)(B).
                ing should be continued or adjusted.
 
 
-      HR 3590 EAS/PP
-                           1644
                ‘‘(B) ANNUAL REPORTS   .—Not later than
           April 1 of each year, the Comptroller General of
           the United States shall submit to Congress a re-
@@ -46410,8 +43126,6 @@ credibility, and access are met:
       draft findings with respect to systematic reviews of
       existing research and evidence.
 
-      HR 3590 EAS/PP
-                            1645
           ‘‘(2) ADDITIONAL FORUMS   .—The Institute shall
       support forums to increase public awareness and ob-
       tain and incorporate public input and feedback
@@ -46438,8 +43152,6 @@ credibility, and access are met:
 
 
 
-      HR 3590 EAS/PP
-                           1646
                ‘‘(C) Notice of public comment periods
           under paragraph (1), including deadlines for
           public comments.
@@ -46466,8 +43178,6 @@ credibility, and access are met:
                in the case of individuals contributing to
                any such peer review process, such descrip-
 
-      HR 3590 EAS/PP
-                            1647
                tion shall be in a manner such that those
                individuals cannot be identified with a par-
                ticular research project.
@@ -46494,8 +43204,6 @@ section.
       be construed—
 
 
-      HR 3590 EAS/PP
-                          1648
               ‘‘(A) to permit the Institute to mandate cov-
           erage, reimbursement, or other policies for any
           public or private payer; or
@@ -46522,8 +43230,6 @@ amended by inserting after section 936 the following:
      of Health, shall broadly disseminate the research find-
      ings that are published by the Patient Centered Out-
 
-      HR 3590 EAS/PP
-                            1649
       comes Research Institute established under section
       1181(b) of the Social Security Act (referred to in this
       section as the ‘Institute’) and other government-fund-
@@ -46550,8 +43256,6 @@ amended by inserting after section 936 the following:
           for specific subpopulations, the research method-
           ology, and the limitations of the research, and
 
-      HR 3590 EAS/PP
-                            1650
           the names of the entities, agencies, instrumental-
           ities, and individuals who conducted any re-
           search which was published by the Institute; and
@@ -46578,8 +43282,6 @@ findings publicly available as required under section
 1181(d)(8) of the Social Security Act.
 
 
-      HR 3590 EAS/PP
-                           1651
      ‘‘(e) TRAINING OF  R ESEARCHERS  .—The Agency for
 Health Care Research and Quality, in consultation with
 the National Institutes of Health, shall build capacity for
@@ -46606,8 +43308,6 @@ accept and retain funds, for the conduct and support of re-
 search described in this part, provided that the research to
 be conducted or supported under such agreements is author-
 
-      HR 3590 EAS/PP
-                            1652
 ized under the governing statutes of such agencies and in-
 strumentalities.’’.
       (c) N G ENERAL  .—Part D of title XI of the Social Se-
@@ -46634,8 +43334,6 @@ from comparative clinical effectiveness research conducted
 under section 1181 in determining coverage, reimburse-
 ment, or incentive programs under title XVIII in a manner
 that treats extending the life of an elderly, disabled, or ter-
-      HR 3590 EAS/PP
-                             1653
 minally ill individual as of lower value than extending the
 life of an individual who is younger, nondisabled, or not
 terminally ill.
@@ -46662,8 +43360,6 @@ the length of their life and the risk of disability.
            ‘‘(ii) prevent the Secretary from using evidence
       or findings from such comparative clinical effective-
 
-      HR 3590 EAS/PP
-                            1654
       ness research in determining coverage, reimbursement,
       or incentive programs under such title based upon a
       comparison of the difference in the effectiveness of al-
@@ -46690,8 +43386,6 @@ curity Act, as added by subsection (a) and amended by sub-
 section (c), is amended by adding at the end the following
 new section:
 
-      HR 3590 EAS/PP
-                           1655
      ‘TRUST FUND TRANSFERS TO PATIENT    -CENTERED
             OUTCOMES RESEARCH TRUST FUND
      ‘‘SEC. 1183. (a) IN G ENERAL .—The Secretary shall
@@ -46718,8 +43412,6 @@ Internal Revenue Code of 1986, of the following:
 September 30, 2014, the dollar amount in effect under sub-
 section (a)(2) for such fiscal year shall be equal to the sum
 
-      HR 3590 EAS/PP
-                          1656
 of such dollar amount for the previous fiscal year (deter-
 mined after the application of this subsection), plus an
 amount equal to the product of—
@@ -46746,8 +43438,6 @@ Fund’ (hereafter in this section referred to as the
 priated or credited to such Trust Fund as provided in this
 section and section 9602(b).
 
-      HR 3590 EAS/PP
-                           1657
       ‘‘(b)RANSFERS TO   FUND .—
           ‘‘(1) APPROPRIATION .—There are hereby appro-
       priated to the Trust Fund the following:
@@ -46774,8 +43464,6 @@ section and section 9602(b).
           ferred from the general fund of the Treasury,
           from funds not otherwise appropriated.
 
-      HR 3590 EAS/PP
-                           1658
           ‘‘(2) RUST FUND TRANSFERS    .—In addition to
      the amounts appropriated under paragraph (1), there
      shall be credited to the PCORTF the amounts trans-
@@ -46802,8 +43490,6 @@ be a trustee of the PCORTF.
      paragraph (2), amounts in the PCORTF are avail-
      able, without further appropriation, to the Patient-
 
-      HR 3590 EAS/PP
-                           1659
       Centered Outcomes Research Institute established
       under section 1181(b) of the Social Security Act for
       carrying out part D of title XI of the Social Security
@@ -46830,8 +43516,6 @@ be a trustee of the PCORTF.
                by Agency for Healthcare Research and
                Quality) to carry out the activities de-
 
-      HR 3590 EAS/PP
-                            1660
                scribed in section 937 of the Public Health
                Service Act; and
                     ‘‘(ii) 20 percent to the Secretary to
@@ -46858,8 +43542,6 @@ be transferred to the general fund of the Treasury.’’.
                (A) G ENERAL RULE  .—Chapter 34 of the In-
           ternal Revenue Code of 1986 is amended by add-
           ing at the end the following new subchapter:
-      HR 3590 EAS/PP
-                           1661
     ‘‘Subchapter B—Insured and Self-Insured
                      Health Plans
     ‘‘Sec. 4375. Health insurance.
@@ -46887,8 +43569,6 @@ purposes of this section:
      clude any insurance if substantially all of its coverage
      is of excepted benefits described in section 9832(c).
 
-      HR 3590 EAS/PP
-                          1662
           ‘‘(3) TREATMENT   OF PREPAID   HEALTH  COV  -
      ERAGE ARRANGEMENTS   .—
               ‘‘(A) N GENERAL  .—In the case of any ar-
@@ -46915,8 +43595,6 @@ years ending in the previous fiscal year (determined after
 the application of this subsection), plus an amount equal
 to the product of—
 
-      HR 3590 EAS/PP
-                           1663
           ‘‘(1) such dollar amount for policy years ending
       in the previous fiscal year, multiplied by
           ‘‘(2) the percentage increase in the projected per
@@ -46943,8 +43621,6 @@ under the plan.
           of a plan established or maintained by an em-
           ployee organization,
 
-      HR 3590 EAS/PP
-                           1664
                ‘‘(C) in the case of—
                    ‘‘(i) a plan established or maintained
                by 2 or more employers or jointly by 1 or
@@ -46971,8 +43647,6 @@ health coverage if—
           ‘‘(2) such plan is established or maintained—
 
 
-      HR 3590 EAS/PP
-                           1665
                ‘‘(A) by 1 or more employers for the benefit
           of their employees or former employees,
                ‘‘(B) by 1 or more employee organizations
@@ -46999,8 +43673,6 @@ fiscal year beginning after September 30, 2014, the dollar
 amount in effect under subsection (a) for such plan year
 shall be equal to the sum of such dollar amount for plan
 
-      HR 3590 EAS/PP
-                           1666
 years ending in the previous fiscal year (determined after
 the application of this subsection), plus an amount equal
 to the product of—
@@ -47027,8 +43699,6 @@ plan years ending after September 30, 2019.
      includes any possession of the United States.
      ‘‘(b) REATMENT OF   GOVERNMENTAL   E NTITIES.—
 
-      HR 3590 EAS/PP
-                           1667
           ‘‘(1) N GENERAL  .—For purposes of this sub-
      chapter—
                ‘‘(A) the term ‘person’ includes any govern-
@@ -47055,8 +43725,6 @@ plan years ending after September 30, 2019.
           through insurance policies) to individuals (or the
           spouses and dependents thereof) by reason of
 
-      HR 3590 EAS/PP
-                            1668
           such individuals being members of the Armed
           Forces of the United States or veterans, and
                ‘‘(D) any program established by Federal
@@ -47084,8 +43752,6 @@ sion of the United States.’’.
                        Insurers’’.
                     (ii) The table of chapters for subtitle D
                of such Code is amended by striking the
-      HR 3590 EAS/PP
-                            1669
                item relating to chapter 34 and inserting
                the following new item:
             ‘HAPTER 34—TAXES ONCERTAINNSURANCEPOLICIE’’.
@@ -47115,8 +43781,6 @@ ment of this Act.
 
 
 
-      HR 3590 EAS/PP
-                          1670
  Subtitle E—Medicare, Medicaid,
      and CHIP Program Integrity
      Provisions
@@ -47143,8 +43807,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
           days after the date of enactment of this para-
           graph, the Secretary, in consultation with the
 
-      HR 3590 EAS/PP
-                            1671
           Inspector General of the Department of Health
           and Human Services, shall establish procedures
           under which screening is conducted with respect
@@ -47171,8 +43833,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
 
 
 
-      HR 3590 EAS/PP
-                           1672
                         ‘‘(III) unscheduled and unan-
                    nounced site visits, including
                    preenrollment site visits;
@@ -47199,8 +43859,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
                    urban consumers (all items; United
                    States city average) for the 12-month
 
-      HR 3590 EAS/PP
-                            1673
                     period ending with June of the pre-
                     vious year.
                     ‘‘(ii)NSTITUTIONAL PROVIDERS   .—Ex-
@@ -47227,8 +43885,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
                empt a provider of medical or other items
                or services or supplier from the imposition
 
-      HR 3590 EAS/PP
-                           1674
                of an application fee under this subpara-
                graph if the Secretary determines that the
                imposition of the application fee would re-
@@ -47255,8 +43911,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
                XXI as of the date of enactment of this
 
 
-      HR 3590 EAS/PP
-                            1675
                paragraph, on or after the date that is 1
                year after such date of enactment.
                     ‘‘(ii) URRENT PROVIDERS OF SERV     -
@@ -47283,8 +43937,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
                been screened under this paragraph be ini-
                tially enrolled or reenrolled in the program
 
-      HR 3590 EAS/PP
-                           1676
                under this title, title XIX, or title XXI on
                or after the date that is 3 years after such
                date of enactment.
@@ -47311,8 +43963,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
           wise the procedures under this paragraph.
           ‘‘(4) NCREASED DISCLOSURE REQUIREMENTS      .—
 
-      HR 3590 EAS/PP
-                           1677
                ‘‘(A) DISCLOSURE .—A provider of medical
           or other items or services or supplier who sub-
           mits an application for enrollment or revalida-
@@ -47339,8 +43989,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
           tion. Such a denial shall be subject to appeal in
           accordance with paragraph (7).
 
-      HR 3590 EAS/PP
-                           1678
           ‘‘(5) UTHORITY TO ADJUST PAYMENTS OF PRO      -
       VIDERS OF SERVICES AND SUPPLIERS WITH THE
       SAME TAX IDENTIFICATION NUMBER FOR PAST       DUE
@@ -47367,8 +44015,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
                assigned a different billing number or na-
                tional provider identification number under
 
-      HR 3590 EAS/PP
-                           1679
                the program under this title than is as-
                signed to the obligated provider of services
                or supplier.
@@ -47395,8 +44041,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
           be no judicial review under section 1869, section
 
 
-      HR 3590 EAS/PP
-                           1680
           1878, or otherwise, of a temporary moratorium
           imposed under subparagraph (A).
           ‘‘(7) OMPLIANCE PROGRAMS   .—
@@ -47423,8 +44067,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
           the establishment of the core elements under sub-
           paragraph (B) and the date of the implementa-
 
-      HR 3590 EAS/PP
-                           1681
           tion of subparagraph (A) for providers or sup-
           pliers within a particular industry or category.
           The Secretary shall, in determining such date of
@@ -47451,8 +44093,6 @@ Act (42 U.S.C. 1395cc(j)) is amended—
       porting requirements in accordance with subsection
       (ii);’’; and
 
-      HR 3590 EAS/PP
-                           1682
               (B) by adding at the end the following:
      ‘‘(ii) ROVIDER AND    SUPPLIER  SCREENING  , OVER -
  SIGHT, AND R EPORTING  REQUIREMENTS  .—For purposes of
@@ -47479,8 +44119,6 @@ the following:
           THE SECRETARY  .—
 
 
-      HR 3590 EAS/PP
-                           1683
                    ‘‘(i) N GENERAL   .—Subject to clause
                (ii), the State complies with any temporary
                moratorium on the enrollment of new pro-
@@ -47507,8 +44145,6 @@ the following:
           would not adversely impact beneficiaries’ access
           to medical assistance.
 
-      HR 3590 EAS/PP
-                            1684
           ‘‘(5) COMPLIANCE   PROGRAMS   .—The State re-
       quires providers and suppliers under the State plan
       or under a waiver of the plan to establish, in accord-
@@ -47535,8 +44171,6 @@ the following:
           sional to be specified on any claim for payment
 
 
-      HR 3590 EAS/PP
-                           1685
           that is based on an order or referral of the physi-
           cian or other professional.
           ‘‘(8) OTHER   STATE  OVERSIGHT  .—Nothing in
@@ -47563,8 +44197,6 @@ the following:
       terminated from the Medicare program on the date of
       enactment of this Act, within 90 days of such date).
 
-      HR 3590 EAS/PP
-                           1686
           (3) C    ONFORMING      AMENDMENT   .—Section
      1902(a)(23) of the Social Security Act (42 U.S.C.
      1396a), is amended by inserting before the semicolon
@@ -47591,8 +44223,6 @@ curity Act (42 U.S.C. 1301 et seq.), as amended by sections
 
 
 
-      HR 3590 EAS/PP
-                          1687
  ‘‘SEC. 1128J. MEDICARE AND MEDICAID PROGRAM INTEG-
              RITY PROVISIONS.
      ‘‘(a) ATA M ATCHING .—
@@ -47619,8 +44249,6 @@ curity Act (42 U.S.C. 1301 et seq.), as amended by sections
                        ‘‘(VI) The Indian Health Service
                    and the Contract Health Service pro-
                    gram.
-      HR 3590 EAS/PP
-                           1688
                    ‘‘(ii) PRIORITY  FOR   INCLUSION  OF
                CERTAIN DATA  .—Inclusion of the data de-
                scribed in subclause (I) of such clause in the
@@ -47647,8 +44275,6 @@ curity Act (42 U.S.C. 1301 et seq.), as amended by sections
                         ‘‘(I) The Commissioner of Social
                    Security.
 
-      HR 3590 EAS/PP
-                           1689
                         ‘‘(II) The Secretary of Veterans
                    Affairs.
                         ‘‘(III) The Secretary of Defense.
@@ -47675,8 +44301,6 @@ curity Act (42 U.S.C. 1301 et seq.), as amended by sections
       Health and Human Services and its contractors re-
       lated to titles XVIII, XIX, and XXI.
 
-      HR 3590 EAS/PP
-                           1690
      ‘‘(b) OIG AUTHORITY  TO O BTAIN INFORMATION .—
           ‘‘(1) N GENERAL .—Notwithstanding and in ad-
      dition to any other provision of law, the Inspector
@@ -47703,8 +44327,6 @@ curity Act (42 U.S.C. 1301 et seq.), as amended by sections
      or payments under title XVIII or XIX, including a
      prescribing physician’s medical records for an indi-
 
-      HR 3590 EAS/PP
-                          1691
      vidual who is prescribed an item or service which is
      covered under part B of title XVIII, a covered part
      D drug (as defined in section 1860D–2(e)) for which
@@ -47731,8 +44353,6 @@ curity Act (42 U.S.C. 1301 et seq.), as amended by sections
          part B of such title;
 
 
-      HR 3590 EAS/PP
-                           1692
               ‘‘(B) eligible for medical assistance under a
           State plan under title XIX or under a waiver of
           such plan; or
@@ -47759,8 +44379,6 @@ curity Act (42 U.S.C. 1301 et seq.), as amended by sections
           is due, if applicable.
 
 
-      HR 3590 EAS/PP
-                           1693
           ‘‘(3) E NFORCEMENT  .—Any overpayment re-
      tained by a person after the deadline for reporting
      and returning the overpayment under paragraph (2)
@@ -47787,8 +44405,6 @@ curity Act (42 U.S.C. 1301 et seq.), as amended by sections
                fined in section 1860D–41(a)(13)).
 
 
-      HR 3590 EAS/PP
-                          1694
                    ‘‘(ii)XCLUSION .—Such term does not
               include a beneficiary.
      ‘‘(e) NCLUSION OF  NATIONAL  PROVIDER  IDENTIFIER
@@ -47815,8 +44431,6 @@ ment submitted under such programs.’’.
               and enforcement under this title; and
 
 
-      HR 3590 EAS/PP
-                            1695
                ‘‘(B) by the Attorney General and the
           Comptroller General of the United States for the
           purposes of, and to the extent necessary in, car-
@@ -47843,8 +44457,6 @@ ment submitted under such programs.’’.
           ‘‘(9)(A) The Commissioner of Social Security
       shall, upon the request of the Secretary or the Inspec-
 
-      HR 3590 EAS/PP
-                         1696
      tor General of the Department of Health and Human
      Services—
              ‘‘(i) enter into an agreement with the Sec-
@@ -47871,8 +44483,6 @@ U.S.C. 1396b(i)) is amended—
          (3) by adding at the end the following new para-
      graph:.
 
-     HR 3590 EAS/PP
-                          1697
           ‘‘(25) with respect to any amounts expended for
      medical assistance for individuals for whom the State
      does not report enrollee encounter data (as defined by
@@ -47899,8 +44509,6 @@ U.S.C. 1396b(i)) is amended—
      zations under title XIX, and entities that apply to
 
 
-      HR 3590 EAS/PP
-                           1698
       participate as providers of services or suppliers in
       such managed care organizations and such plans.’’.
           (2) CIVIL MONETARY PENALTIES  .—
@@ -47927,8 +44535,6 @@ U.S.C. 1396b(i)) is amended—
           ‘‘(9) knowingly makes or causes to be made any
       false statement, omission, or misrepresentation of a
 
-      HR 3590 EAS/PP
-                            1699
       material fact in any application, bid, or contract to
       participate or enroll as a provider of services or a
       supplier under a Federal health care program (as so
@@ -47955,8 +44561,6 @@ U.S.C. 1396b(i)) is amended—
                ‘‘purpose)’’ and inserting ‘‘purpose; or in
                cases under paragraph (9), an assessment of
 
-      HR 3590 EAS/PP
-                           1700
                not more than 3 times the total amount
                claimed for each item or service for which
                payment was made based upon the applica-
@@ -47983,8 +44587,6 @@ U.S.C. 1396b(i)) is amended—
                ‘‘(F) any other remuneration which pro-
           motes access to care and poses a low risk of harm
 
-      HR 3590 EAS/PP
-                            1701
            to patients and Federal health care programs (as
            defined in section 1128B(f) and designated by
            the Secretary under regulations);
@@ -48011,8 +44613,6 @@ U.S.C. 1396b(i)) is amended—
                fered as part of any advertisement or solici-
                tation;
 
-      HR 3590 EAS/PP
-                           1702
                    ‘‘(ii) the items or services are not tied
                to the provision of other services reimbursed
                in whole or in part by the program under
@@ -48039,8 +44639,6 @@ U.S.C. 1396b(i)) is amended—
 Act (42 U.S.C. 1320a–7(f)) is amended by adding at the
 end the following new paragraph:
 
-      HR 3590 EAS/PP
-                          1703
           ‘‘(4) The provisions of subsections (d) and (e) of
      section 205 shall apply with respect to this section to
      the same extent as they are applicable with respect to
@@ -48067,8 +44665,6 @@ need not have actual knowledge of this section or specific
 intent to commit a violation of this section.’’.
      (g) SURETY B OND R EQUIREMENTS  .—
 
-      HR 3590 EAS/PP
-                          1704
           (1) D URABLE  MEDICAL   EQUIPMENT  .—Section
      1834(a)(16)(B) of the Social Security Act (42 U.S.C.
      1395m(a)(16)(B)) is amended by inserting ‘‘that the
@@ -48095,8 +44691,6 @@ intent to commit a violation of this section.’’.
      Secretary in an amount (not less than $50,000) that
      the Secretary determines is commensurate with the
 
-      HR 3590 EAS/PP
-                          1705
      volume of the billing of the provider of services or
      supplier. The Secretary may waive the requirement of
      a bond under the preceding sentence in the case of a
@@ -48123,8 +44717,6 @@ intent to commit a violation of this section.’’.
      payments to a provider of services or supplier under
      this title pending an investigation of a credible alle-
 
-      HR 3590 EAS/PP
-                           1706
       gation of fraud against the provider of services or
       supplier, unless the Secretary determines there is good
       cause not to suspend such payments.
@@ -48151,8 +44743,6 @@ intent to commit a violation of this section.’’.
           tions promulgated by the Secretary for purposes
           of section 1862(o) and this subparagraph, unless
 
-      HR 3590 EAS/PP
-                          1707
           the State determines in accordance with such
           regulations there is good cause not to suspend
           such payments; or’’.
@@ -48179,8 +44769,6 @@ intent to commit a violation of this section.’’.
           ‘‘until expended’’ after ‘‘appropriation’’.
           (2) NDEXING OF AMOUNTS APPROPRIATED   .—
 
-      HR 3590 EAS/PP
-                           1708
                (A) DEPARTMENTS OF HEALTH AND HUMAN
           SERVICES         AND        JUSTICE  .—Section
           1817(k)(3)(A)(i) of the Social Security Act (42
@@ -48207,8 +44795,6 @@ intent to commit a violation of this section.’’.
                    serting ‘‘for each fiscal year after fiscal
                    year 2007’’; and
 
-      HR 3590 EAS/PP
-                           1709
                         (II) by striking ‘‘; and’’ and in-
                    serting a period; and
                    (iii) by striking subclause (X).
@@ -48235,8 +44821,6 @@ intent to commit a violation of this section.’’.
                price index for all urban consumers (all
 
 
-      HR 3590 EAS/PP
-                          1710
               items; United States city average) over the
               previous year.’’.
      (j) MEDICARE  INTEGRITY  PROGRAM AND   M EDICAID
@@ -48263,8 +44847,6 @@ intent to commit a violation of this section.’’.
               (B) EVALUATIONS AND ANNUAL REPORT    .—
           Section 1893 of the Social Security Act (42
 
-      HR 3590 EAS/PP
-                           1711
           U.S.C. 1395ddd) is amended by adding at the
           end the following new subsection:
      ‘‘(i) VALUATIONS AND  ANNUAL  R EPORT.—
@@ -48291,8 +44873,6 @@ intent to commit a violation of this section.’’.
               (A) R EQUIREMENT TO PROVIDE PERFORM      -
           ANCE STATISTICS .—Section 1936(c)(2) of the So-
 
-      HR 3590 EAS/PP
-                           1712
           cial Security Act (42 U.S.C. 1396u–6(c)(2)) is
           amended—
                    (i) by redesignating subparagraph (D)
@@ -48319,8 +44899,6 @@ intent to commit a violation of this section.’’.
      retary contracts with under the Program not less fre-
      quently than every 3 years.’’.
 
-      HR 3590 EAS/PP
-                         1713
      (k) EXPANDED A PPLICATION OF HARDSHIP  W AIVERS
  FOR EXCLUSIONS .—Section 1128(c)(3)(B) of the Social Se-
 curity Act (42 U.S.C. 1320a–7(c)(3)(B)) is amended by
@@ -48348,8 +44926,6 @@ viders, suppliers, or practitioners as required by subsection
 nish the information collected under this section to the Na-
 tional Practitioner Data Bank established pursuant to the
 
-     HR 3590 EAS/PP
-                           1714
 Health Care Quality Improvement Act of 1986 (42 U.S.C.
 11101 et seq.).’’;
           (2) by striking subsection (d) and inserting the
@@ -48376,8 +44952,6 @@ Quality Improvement Act of 1986 (42 U.S.C. 11131 et seq.)
 and section 1921.’’; and
           (4) in subsection (g)—
 
-      HR 3590 EAS/PP
-                            1715
                (A) in paragraph (1)(A)—
                     (i) in clause (iii)—
                         (I) by striking ‘‘or State’’ each
@@ -48404,8 +44978,6 @@ and section 1921.’’; and
                as subparagraph (D); and
 
 
-      HR 3590 EAS/PP
-                          1716
               (C) in subparagraph (D) (as so redesig-
           nated), by striking ‘‘or State’’.
      (b) INFORMATION   R EPORTED BY    STATE  LAW OR
@@ -48432,8 +45004,6 @@ cial Security Act (42 U.S.C. 1396r–2) is amended—
                    and inserting ‘‘license or the right to
                    apply for, or renew, a license by’’; and
 
-      HR 3590 EAS/PP
-                           1717
                         (II) by inserting ‘‘nonrenew-
                    ability,’’ after ‘‘voluntary surrender,’’;
                    and
@@ -48460,8 +45030,6 @@ cial Security Act (42 U.S.C. 1396r–2) is amended—
       licensed health care practitioners;’’;
 
 
-      HR 3590 EAS/PP
-                           1718
                (B) in each of paragraphs (4) and (6), by
           inserting ‘‘, but only with respect to information
           provided pursuant to subsection (a)(1)(A)’’ before
@@ -48488,8 +45056,6 @@ cial Security Act (42 U.S.C. 1396r–2) is amended—
           tion, upon request, to the health care practitioner
 
 
-      HR 3590 EAS/PP
-                           1719
           who, or the entity that, is the subject of the infor-
           mation reported; and
                ‘‘(B) establish procedures for the case where
@@ -48516,8 +45082,6 @@ as required under this section, without knowledge of the fal-
 sity of the information contained in the report.
      ‘‘(g) EFERENCES  .—For purposes of this section:
 
-      HR 3590 EAS/PP
-                           1720
           ‘‘(1) TATE LICENSING OR CERTIFICATION AGEN    -
       CY.—The term ‘State licensing or certification agen-
       cy’ includes any authority of a State (or of a political
@@ -48544,8 +45108,6 @@ sity of the information contained in the report.
                to the delivery of a health care item or serv-
                ice;
 
-      HR 3590 EAS/PP
-                           1721
                    ‘‘(iii) exclusion from participation in
                State health care programs (as defined in
                section 1128(h));
@@ -48572,8 +45134,6 @@ amended—
           (1) in subparagraph (C), by adding ‘‘and’’ after
       the comma at the end;
 
-      HR 3590 EAS/PP
-                           1722
           (2) in subparagraph (D), by striking ‘‘, and’’
      and inserting a period; and
           (3) by striking subparagraph (E).
@@ -48600,8 +45160,6 @@ amended—
 
 
 
-      HR 3590 EAS/PP
-                           1723
           (2) REGULATIONS  .—The Secretary shall promul-
      gate regulations to carry out the amendments made
      by subsections (a) and (b).
@@ -48628,8 +45186,6 @@ amended—
           abuse shall be available to the extent necessary
           for operating the Healthcare Integrity and Pro-
 
-      HR 3590 EAS/PP
-                           1724
           tection Data Bank during the transition period,
           including systems testing and other activities
           necessary to ensure that information formerly re-
@@ -48656,8 +45212,6 @@ amended—
           and Protection Data Bank.
 
 
-      HR 3590 EAS/PP
-                          1725
           (5) TRANSITION PERIOD DEFINED    .—For pur-
      poses of this subsection, the term ‘‘transition period’’
      means the period that begins on the date of enactment
@@ -48684,8 +45238,6 @@ amended—
           retary may specify exceptions to the 1 calendar
           year period specified in such paragraph.’’
 
-      HR 3590 EAS/PP
-                           1726
           (2) PART B .—
                (A) Section 1842(b)(3) of such Act (42
           U.S.C. 1395u(b)(3)(B)) is amended—
@@ -48712,8 +45264,6 @@ amended—
                date of service;’’; and
 
 
-      HR 3590 EAS/PP
-                          1727
                    (ii) by adding at the end the following
               new sentence: ‘‘In applying paragraph (1),
               the Secretary may specify exceptions to the
@@ -48740,8 +45290,6 @@ section 1866(j) or an eligible professional under section
           (1) ART A .—Section 1814(a)(2) of such Act (42
      U.S.C. 1395(a)(2)) is amended in the matter pre-
 
-      HR 3590 EAS/PP
-                            1728
       ceding subparagraph (A) by inserting ‘‘in the case of
       services described in subparagraph (C), a physician
       enrolled under section 1866(j) or an eligible profes-
@@ -48768,8 +45316,6 @@ ferred by a physician enrolled under section 1866(j) of such
 Act (42 U.S.C. 1395cc(j)) or an eligible professional under
 
 
-      HR 3590 EAS/PP
-                           1729
 section 1848(k)(3)(B) of such Act (42 U.S.C. 1395w–
 4(k)(3)(B)).
      (d) EFFECTIVE  DATE .—The amendments made by this
@@ -48796,8 +45342,6 @@ such Act (42 U.S.C. 1395cc) is further amended—
           (1) in subparagraph (U), by striking at the end
      ‘‘and’’;
 
-      HR 3590 EAS/PP
-                           1730
           (2) in subparagraph (V), by striking the period
      at the end and adding ‘‘; and’’; and
           (3) by adding at the end the following new sub-
@@ -48824,8 +45368,6 @@ made on or after January 1, 2010.
 
 
 
-      HR 3590 EAS/PP
-                          1731
  SEC. 6407. FACE TO FACE ENCOUNTER WITH PATIENT RE-
              QUIRED BEFORE PHYSICIANS MAY CERTIFY
              ELIGIBILITY FOR HOME HEALTH SERVICES
@@ -48852,8 +45394,6 @@ made on or after January 1, 2010.
           (2) ART B .—Section 1835(a)(2)(A) of the Social
      Security Act is amended—
               (A) by striking ‘‘and’’ before ‘‘(iii)’’; and
-      HR 3590 EAS/PP
-                          1732
               (B) by inserting after ‘‘care of a physician’’
           the following: ‘‘, and (iv) in the case of a certifi-
           cation after January 1, 2010, prior to making
@@ -48880,8 +45420,6 @@ rity Act (42 U.S.C. 1395m(a)(11)(B)) is amended—
               ant to the physician documenting that a
               physician, a physician assistant, a nurse
 
-      HR 3590 EAS/PP
-                          1733
               practitioner, or a clinical nurse specialist
               (as those terms are defined in section
               1861(aa)(5)) has had a face-to-face encoun-
@@ -48908,8 +45446,6 @@ tent as such requirements apply in the case of physicians
 making such certifications under title XVIII of such Act.
 
 
-      HR 3590 EAS/PP
-                          1734
  SEC. 6408. ENHANCED PENALTIES.
      (a) CIVIL M ONETARY  PENALTIES FOR  F ALSE STATE -
  MENTS OR  D ELAYING INSPECTIONS .—Section 1128A(a) of
@@ -48936,8 +45472,6 @@ amended by section 5002(d)(2)(A), is amended—
           graph (7)’’ and inserting ‘‘in cases under para-
           graph (7)’’; and
 
-      HR 3590 EAS/PP
-                          1735
               (B) by striking ‘‘act)’’ and inserting ‘‘act,
           in cases under paragraph (8), $50,000 for each
           false record or statement, or in cases under para-
@@ -48964,8 +45498,6 @@ amended by section 5002(d)(2)(A), is amended—
           rolls an individual in any plan under this part
 
 
-      HR 3590 EAS/PP
-                            1736
           without the prior consent of the individual or the
           designee of the individual;
                ‘‘(I) transfers an individual enrolled under
@@ -48992,8 +45524,6 @@ amended by section 5002(d)(2)(A), is amended—
           paragraphs (A) through (K) of this paragraph.’’.
 
 
-      HR 3590 EAS/PP
-                           1737
           (3) P ROVISION OF FALSE INFORMATION    .—Sec-
      tion 1857(g)(2)(A) of the Social Security Act (42
      U.S.C. 1395w–27(g)(2)(A)) is amended by inserting
@@ -49020,8 +45550,6 @@ amended by section 5002(d)(2)(A), is amended—
      graph (2), the amendments made by this section shall
      apply to acts committed on or after January 1, 2010.
 
-      HR 3590 EAS/PP
-                          1738
           (2) EXCEPTION.—The amendments made by sub-
      section (b)(1) take effect on the date of enactment of
      this Act.
@@ -49048,8 +45576,6 @@ amended by section 5002(d)(2)(A), is amended—
           corporate compliance agreements.
 
 
-      HR 3590 EAS/PP
-                           1739
           (2) P UBLICATION  ON  INTERNET  WEBSITE  OF
      SRDP INFORMATION   .—The Secretary of Health and
      Human Services shall post information on the public
@@ -49076,8 +45602,6 @@ lowing factors:
           (4) Such other factors as the Secretary considers
      appropriate.
 
-      HR 3590 EAS/PP
-                          1740
      (c) REPORT .—Not later than 18 months after the date
 on which the SRDP protocol is established under subsection
 (a)(1), the Secretary shall submit to Congress a report on
@@ -49104,8 +45628,6 @@ Security Act (42 U.S.C. 1395w–3(a)(1)) is amended—
               (A) in subclause (I), by striking ‘‘and’’ at
           the end;
 
-      HR 3590 EAS/PP
-                          1741
               (B) by redesignating subclause (II) as sub-
           clause (III); and
               (C) by inserting after subclause (I) the fol-
@@ -49132,8 +45654,6 @@ tion 1834(a)(1)(F) of the Social Security Act (42 U.S.C.
                   ‘‘(iii) in the case of covered items fur-
               nished on or after January 1, 2016, the
 
-      HR 3590 EAS/PP
-                          1742
               Secretary shall continue to make such ad-
               justments described in clause (ii) as, under
               such competitive acquisition programs, ad-
@@ -49160,8 +45680,6 @@ tion 1834(a)(1)(F) of the Social Security Act (42 U.S.C.
               law and in the same manner as the Sec-
               retary enters into contracts with recovery
 
-      HR 3590 EAS/PP
-                           1743
                audit contractors under section 1893(h),
                subject to such exceptions or requirements as
                the Secretary may require for purposes of
@@ -49188,8 +45706,6 @@ tion 1834(a)(1)(F) of the Social Security Act (42 U.S.C.
                         for identifying underpayments;
 
 
-      HR 3590 EAS/PP
-                           1744
                         ‘‘(III) the State has an adequate
                    process for entities to appeal any ad-
                    verse determination made by such con-
@@ -49216,8 +45732,6 @@ tion 1834(a)(1)(F) of the Social Security Act (42 U.S.C.
                         other contractors or entities per-
                         forming audits of entities receiv-
 
-      HR 3590 EAS/PP
-                           1745
                         ing payments under the State
                         plan or waiver in the State, in-
                         cluding efforts with Federal and
@@ -49244,8 +45758,6 @@ tion 1834(a)(1)(F) of the Social Security Act (42 U.S.C.
           regulations to carry out this subsection and the
           amendments made by this subsection, including
 
-      HR 3590 EAS/PP
-                           1746
           with respect to conditions of Federal financial
           participation, as specified by the Secretary.
      (b) EXPANSION TO  M EDICARE  PARTS C  AND D.—Sec-
@@ -49272,8 +45784,6 @@ tion 1893(h) of the Social Security Act (42 U.S.C.
           C has an anti-fraud plan in effect and to review
           the effectiveness of each such anti-fraud plan;
 
-      HR 3590 EAS/PP
-                           1747
                ‘‘(B) ensure that each prescription drug
           plan under part D has an anti-fraud plan in ef-
           fect and to review the effectiveness of each such
@@ -49300,8 +45810,6 @@ for expanding or improving the program.
 
 
 
-      HR 3590 EAS/PP
-                          1748
     Subtitle F—Additional Medicaid
       Program Integrity Provisions
  SEC. 6501. TERMINATION OF PROVIDER PARTICIPATION
@@ -49328,8 +45836,6 @@ inserting after paragraph (77) the following:
      ty owns, controls, or manages an entity that (or if
 
 
-      HR 3590 EAS/PP
-                           1749
      such entity is owned, controlled, or managed by an
      individual or entity that)—
                ‘‘(A) has unpaid overpayments (as defined
@@ -49356,8 +45862,6 @@ section 6502(a), is amended by inserting after paragraph
      that submits claims on behalf of a health care pro-
 
 
-      HR 3590 EAS/PP
-                          1750
      vider must register with the State and the Secretary
      in a form and manner specified by the Secretary;’’.
  SEC. 6504. REQUIREMENT TO REPORT EXPANDED SET OF
@@ -49384,8 +45888,6 @@ quency as the Secretary shall determine’’.
 
 
 
-      HR 3590 EAS/PP
-                          1751
  SEC. 6505. PROHIBITION ON PAYMENTS TO INSTITUTIONS
              OR ENTITIES LOCATED OUTSIDE OF THE
              UNITED STATES.
@@ -49412,8 +45914,6 @@ serting after paragraph (79) the following new paragraph:
               (B) in subparagraph (D)—
                   (i) in inserting ‘‘(i)’’ after ‘‘(D)’’; and
                   (ii) by adding at the end the following:
-      HR 3590 EAS/PP
-                            1752
       ‘‘(ii) In any case where the State is unable to recover
 a debt which represents an overpayment (or any portion
 thereof) made to a person or other entity due to fraud with-
@@ -49440,8 +45940,6 @@ action.
 
 
 
-      HR 3590 EAS/PP
-                            1753
  SEC. 6507. MANDATORY STATE USE OF NATIONAL CORRECT
               CODING INITIATIVE.
       Section 1903(r) of the Social Security Act (42 U.S.C.
@@ -49468,8 +45966,6 @@ action.
       graph:
       ‘‘(4) For purposes of paragraph (1)(B)(iv), the Sec-
 retary shall do the following:
-      HR 3590 EAS/PP
-                            1754
           ‘‘(A) Not later than September 1, 2010:
                ‘‘(i) Identify those methodologies of the Na-
           tional Correct Coding Initiative administered by
@@ -49496,8 +45992,6 @@ retary shall do the following:
           ‘‘(B) Not later than March 1, 2011, submit a re-
       port to Congress that includes the notice to States
 
-      HR 3590 EAS/PP
-                            1755
       under clause (iii) of subparagraph (A) and an anal-
       ysis supporting the identification of the methodologies
       made under clauses (i) and (ii) of subparagraph
@@ -49524,8 +46018,6 @@ first regular session of the State legislature that begins after
 the date of the enactment of this Act. For purposes of the
 previous sentence, in the case of a State that has a 2-year
 
-      HR 3590 EAS/PP
-                           1756
 legislative session, each year of such session shall be deemed
 to be a separate regular session of the State legislature.
     Subtitle G—Additional Program
@@ -49552,8 +46044,6 @@ cerning—
      plan or arrangement;
 
 
-      HR 3590 EAS/PP
-                            1757
           ‘‘(2) the benefits provided by such plan or ar-
       rangement;
           ‘‘(3) the regulatory status of such plan or other
@@ -49580,8 +46070,6 @@ Income Security Act of 1974 is amended by adding at the
 end the following:
     ‘‘Sec. 519. Prohibition on false statement and representations.’’.
 
-      HR 3590 EAS/PP
-                           1758
  SEC. 6602. CLARIFYING DEFINITION.
       Section 24(a)(2) of title 18, United States Code, is
 amended by inserting ‘‘or section 411, 518, or 511 of the
@@ -49608,8 +46096,6 @@ form reporting standards for such referrals.’’.
 the Employee Retirement Income Security Act of 1974 (29
 U.S.C. 1131 et seq.), as amended by section 6601, is further
 amended by adding at the end the following:
-      HR 3590 EAS/PP
-                             1759
  ‘‘SEC. 520. APPLICABILITY OF STATE LAW TO COMBAT
               FRAUD AND ABUSE.
       ‘‘The Secretary may, for the purpose of identifying,
@@ -49636,8 +46122,6 @@ is further amended by adding at the end the following:
 
 
 
-      HR 3590 EAS/PP
-                          1760
  SEC. 6605. ENABLING THE DEPARTMENT OF LABOR TO
              ISSUE ADMINISTRATIVE SUMMARY CEASE
              AND DESIST ORDERS AND SUMMARY SEI-
@@ -49665,8 +46149,6 @@ lic injury.
      ‘‘(b) EARING .—A person that is adversely affected by
 the issuance of a cease and desist order under subsection
 (a) may request a hearing by the Secretary regarding such
-      HR 3590 EAS/PP
-                            1761
 order. The Secretary may require that a proceeding under
 this section, including all related information and evidence,
 be conducted in a confidential manner.
@@ -49693,8 +46175,6 @@ section 3(40)(A).’’.
 for part 5 of subtitle B of title I of the Employee Retirement
 
 
-      HR 3590 EAS/PP
-                            1762
 Income Security Act of 1974, as amended by section 6604,
 is further amended by adding at the end the following:
     ‘‘Sec. 521. Administrative summary cease and desist orders and summary seizure
@@ -49722,8 +46202,6 @@ ployees:
            ‘‘(1) A State insurance department.
            ‘‘(2) A State attorney general.
 
-      HR 3590 EAS/PP
-                            1763
           ‘‘(3) The National Association of Insurance Com-
       missioners.
           ‘‘(4) The Department of Labor.
@@ -49750,8 +46228,6 @@ of 2009’’.
 that is defined in section 2011 of the Social Security Act
 
 
-      HR 3590 EAS/PP
-                          1764
 (as added by section 6703(a)) and is used in this subtitle
 has the meaning given such term by such section.
  SEC. 6703. ELDER JUSTICE.
@@ -49778,8 +46254,6 @@ has the meaning given such term by such section.
          ‘‘(2) ADULT PROTECTIVE SERVICES  .—The term
      ‘adult protective services’ means such services pro-
 
-      HR 3590 EAS/PP
-                            1765
       vided to adults as the Secretary may specify and in-
       cludes services such as—
                ‘‘(A) receiving reports of adult abuse, ne-
@@ -49806,8 +46280,6 @@ has the meaning given such term by such section.
       vides assistance or long-term care services to a recipi-
       ent.
 
-      HR 3590 EAS/PP
-                            1766
           ‘‘(5) ELDER .—The term ‘elder’ means an indi-
       vidual age 60 or older.
           ‘‘(6) ELDER JUSTICE  .—The term ‘elder justice’
@@ -49834,8 +46306,6 @@ has the meaning given such term by such section.
       ized, or improper act or process of an individual, in-
       cluding a caregiver or fiduciary, that uses the re-
 
-      HR 3590 EAS/PP
-                            1767
       sources of an elder for monetary or personal benefit,
       profit, or gain, or that results in depriving an elder
       of rightful access to, or use of, benefits, resources, be-
@@ -49862,8 +46332,6 @@ has the meaning given such term by such section.
           and appoints another individual or entity
 
 
-      HR 3590 EAS/PP
-                           1768
           known as a guardian, as a conservator, or by a
           similar term, as a surrogate decisionmaker;
                ‘‘(B) the manner in which the court-ap-
@@ -49890,8 +46358,6 @@ has the meaning given such term by such section.
                ‘‘(D) investigators; and
                ‘‘(E) coroners.
 
-      HR 3590 EAS/PP
-                           1769
           ‘‘(14) ONG -TERM CARE .—
                ‘‘(A) IN GENERAL  .—The term ‘long-term
           care’ means supportive and health services speci-
@@ -49918,8 +46384,6 @@ has the meaning given such term by such section.
                ‘‘(B) self-neglect.
           ‘‘(17) URSING FACILITY .—
 
-      HR 3590 EAS/PP
-                            1770
                ‘‘(A) IN GENERAL  .—The term ‘nursing fa-
           cility’ has the meaning given such term under
           section 1919(a).
@@ -49946,8 +46410,6 @@ has the meaning given such term by such section.
 
 
 
-      HR 3590 EAS/PP
-                           1771
                    ‘‘(iii) involving protracted loss or im-
                pairment of the function of a bodily mem-
                ber, organ, or mental faculty; or
@@ -49974,8 +46436,6 @@ has the meaning given such term by such section.
       section 712(a)(2) of the Older Americans Act of 1965.
 
 
-      HR 3590 EAS/PP
-                            1772
  ‘‘SEC. 2012. GENERAL PROVISIONS.
       ‘‘(a) ROTECTION OF    PRIVACY .—In pursuing activi-
 ties under this subtitle, the Secretary shall ensure the pro-
@@ -50002,8 +46462,6 @@ prayer alone for healing when this choice—
 
 
 
-      HR 3590 EAS/PP
-                           1773
   ‘‘PART I—NATIONAL COORDINATION OF ELDER
         JUSTICE ACTIVITIES AND RESEARCH
  ‘‘Subpart A—Elder Justice Coordinating Council and
@@ -50030,8 +46488,6 @@ Council (in this section referred to as the ‘Council’).
      ernment.
 
 
-      HR 3590 EAS/PP
-                            1774
       ‘‘(c) ACANCIES .—Any vacancy in the Council shall
 not affect its powers, but shall be filled in the same manner
 as the original appointment was made.
@@ -50058,8 +46514,6 @@ times per year, as determined by the Chair.
           ments of, and challenges faced by—
                     ‘‘(i) the Council; and
 
-      HR 3590 EAS/PP
-                           1775
                    ‘‘(ii) the entities represented on the
                Council; and
                ‘‘(B) makes such recommendations for legis-
@@ -50086,8 +46540,6 @@ authorized for employees of agencies under subchapter I of
 chapter 57 of title 5, United States Code, while away from
 their homes or regular places of business in the performance
 
-      HR 3590 EAS/PP
-                           1776
 of services for the Council. Notwithstanding section 1342
 of title 31, United States Code, the Secretary may accept
 the voluntary and uncompensated services of the members
@@ -50114,8 +46566,6 @@ Justice Coordinating Council established under section
 2021.
 
 
-      HR 3590 EAS/PP
-                           1777
       ‘‘(b) OMPOSITION  .—The Advisory Board shall be
 composed of 27 members appointed by the Secretary from
 among members of the general public who are individuals
@@ -50142,8 +46592,6 @@ sory Board under subsection (b).
           shall be filled in the same manner as the original
           appointment was made.
 
-      HR 3590 EAS/PP
-                            1778
                ‘‘(B) FILLING UNEXPIRED TERM   .—An indi-
           vidual chosen to fill a vacancy shall be ap-
           pointed for the unexpired term of the member re-
@@ -50170,8 +46618,6 @@ Chair at its initial meeting.
           shall establish multidisciplinary panels to ad-
           dress, and develop consensus on, subjects relating
 
-      HR 3590 EAS/PP
-                            1779
           to improving the quality of long-term care. At
           least 1 such panel shall address, and develop con-
           sensus on, methods for managing resident-to-resi-
@@ -50198,8 +46644,6 @@ Chair at its initial meeting.
                ‘‘(B) recommendations (including rec-
           ommended priorities) regarding—
 
-      HR 3590 EAS/PP
-                            1780
                     ‘‘(i) elder justice programs, research,
                training, services, practice, enforcement,
                and coordination;
@@ -50226,8 +46670,6 @@ Chair at its initial meeting.
 
 
 
-      HR 3590 EAS/PP
-                          1781
               ‘‘(E) recommendations for a multidisci-
           plinary strategic plan to guide the effective and
           efficient development of the field of elder justice.
@@ -50254,8 +46696,6 @@ Chair at its initial meeting.
 sory Board shall not receive compensation for the perform-
 ance of services for the Advisory Board. The members shall
 
-      HR 3590 EAS/PP
-                          1782
 be allowed travel expenses for up to 4 meetings per year,
 including per diem in lieu of subsistence, at rates author-
 ized for employees of agencies under subchapter I of chapter
@@ -50282,8 +46722,6 @@ guidelines to assist researchers working in the area of elder
 abuse, neglect, and exploitation, with issues relating to
 human subject protections.
 
-      HR 3590 EAS/PP
-                          1783
      ‘‘(b) DEFINITION OF  L EGALLY  AUTHORIZED    REP-
  RESENTATIVE FOR   APPLICATION OF  R EGULATIONS .—For
 purposes of the application of subpart A of part 46 of title
@@ -50310,8 +46748,6 @@ tities to establish and operate stationary and mobile foren-
 sic centers, to develop forensic expertise regarding, and pro-
 
 
-      HR 3590 EAS/PP
-                           1784
 vide services relating to, elder abuse, neglect, and exploi-
 tation.
      ‘‘(b) STATIONARY   F ORENSIC  C ENTERS .—The Sec-
@@ -50338,8 +46774,6 @@ ties to establish and operate mobile forensic centers.
           a case, when and how health care, emergency
           service, social and protective services, and legal
 
-      HR 3590 EAS/PP
-                            1785
           service providers should intervene and when the
           providers should report the case to law enforce-
           ment authorities.
@@ -50366,8 +46800,6 @@ taining such information as the Secretary may require.
       ‘‘(f)UTHORIZATION OF   A PPROPRIATIONS .—There are
 authorized to be appropriated to carry out this section—
 
-      HR 3590 EAS/PP
-                           1786
           ‘‘(1) for fiscal year 2011, $4,000,000;
           ‘‘(2) for fiscal year 2012, $6,000,000; and
           ‘‘(3) for each of fiscal years 2013 and 2014,
@@ -50394,8 +46826,6 @@ authorized to be appropriated to carry out this section—
 
 
 
-      HR 3590 EAS/PP
-                            1787
                ‘‘(B) CAREER LADDERS AND WAGE OR BEN     -
           EFIT  INCREASES   TO  INCREASE   STAFFING  IN
           LONG -TERM CARE  .—
@@ -50422,8 +46852,6 @@ authorized to be appropriated to carry out this section—
                to the Secretary at such time, in such man-
                ner, and containing such information as the
 
-      HR 3590 EAS/PP
-                           1788
                Secretary may require (which may include
                evidence of consultation with the State in
                which the eligible entity is located with re-
@@ -50450,8 +46878,6 @@ authorized to be appropriated to carry out this section—
           as—
 
 
-      HR 3590 EAS/PP
-                            1789
                     ‘‘(i) the establishment of standard
                human resource policies that reward high
                performance, including policies that provide
@@ -50478,8 +46904,6 @@ authorized to be appropriated to carry out this section—
                ‘‘(C) APPLICATION .—To be eligible to re-
           ceive a grant under this paragraph, an eligible
 
-      HR 3590 EAS/PP
-                            1790
           entity shall submit an application to the Sec-
           retary at such time, in such manner, and con-
           taining such information as the Secretary may
@@ -50506,8 +46930,6 @@ authorized to be appropriated to carry out this section—
                ‘‘(B) ELIGIBLE ENTITY .—The term ‘eligible
           entity’ means the following:
 
-      HR 3590 EAS/PP
-                          1791
                    ‘‘(i) A long-term care facility.
                    ‘‘(ii) A community-based long-term
               care entity (as defined by the Secretary).
@@ -50534,8 +46956,6 @@ authorized to be appropriated to carry out this section—
           ware to enable e-prescribing.
 
 
-      HR 3590 EAS/PP
-                            1792
                ‘‘(D) Providing education and training to
           eligible long-term care facility staff on the use of
           such technology to implement the electronic
@@ -50562,8 +46982,6 @@ authorized to be appropriated to carry out this section—
       participate in activities conducted by a State or a
       qualified State-designated entity (as defined in sec-
 
-      HR 3590 EAS/PP
-                          1793
      tion 3013(f) of the Public Health Service Act) under
      a grant under section 3013 of the Public Health Serv-
      ice Act to coordinate care and for other purposes de-
@@ -50590,8 +47008,6 @@ authorized to be appropriated to carry out this section—
      ice Act, and general health information technology
      standards.
 
-      HR 3590 EAS/PP
-                           1794
           ‘‘(2) ELECTRONIC SUBMISSION OF DATA TO THE
       SECRETARY .—
                ‘‘(A) N GENERAL .—Not later than 10 years
@@ -50618,8 +47034,6 @@ tion—
           ‘‘(1) for fiscal year 2011, $20,000,000;
           ‘‘(2) for fiscal year 2012, $17,500,000; and
 
-      HR 3590 EAS/PP
-                           1795
           ‘‘(3) for each of fiscal years 2013 and 2014,
      $15,000,000.
  ‘‘SEC. 2042. ADULT PROTECTIVE SERVICES FUNCTIONS AND
@@ -50646,8 +47060,6 @@ tion—
           sion of adult protective services, including
 
 
-      HR 3590 EAS/PP
-                          1796
           through grants made under subsections (b) and
           (c).
           ‘‘(2) UTHORIZATION   OF  APPROPRIATIONS  .—
@@ -50674,8 +47086,6 @@ tion—
           State.
 
 
-      HR 3590 EAS/PP
-                           1797
               ‘‘(B) G  UARANTEED    MINIMUM   PAYMENT
           AMOUNT .—
                    ‘‘(i) 5STATES .—Subject to clause (ii),
@@ -50702,8 +47112,6 @@ tion—
           section may only be used by States and local
           units of government to provide adult protective
 
-      HR 3590 EAS/PP
-                          1798
           services and may not be used for any other pur-
           pose.
               ‘‘(B) USE BY AGENCY  .—Each State receiv-
@@ -50730,8 +47138,6 @@ tion—
           ‘‘(1) ESTABLISHMENT  .—The Secretary shall
      award grants to States for the purposes of conducting
 
-      HR 3590 EAS/PP
-                            1799
       demonstration programs in accordance with para-
       graph (2).
           ‘‘(2) DEMONSTRATION PROGRAMS    .—Funds made
@@ -50758,8 +47164,6 @@ tion—
       funds under this subsection shall submit to the Sec-
       retary a report at such time, in such manner, and
 
-      HR 3590 EAS/PP
-                          1800
      containing such information as the Secretary may re-
      quire on the results of the demonstration program
      conducted by the State using funds made available
@@ -50786,8 +47190,6 @@ tion—
               ‘‘(C) providing support for such State long-
          term care ombudsman programs and such pilot
 
-      HR 3590 EAS/PP
-                          1801
           programs (such as through the establishment of
           a national long-term care ombudsman resource
           center).
@@ -50814,8 +47216,6 @@ tion—
      ‘‘(a) PROVISION OF INFORMATION  .—To be eligible to
 receive a grant under this part, an applicant shall agree—
 
-      HR 3590 EAS/PP
-                          1802
           ‘‘(1) except as provided in paragraph (2), to pro-
      vide the eligible entity conducting an evaluation
      under subsection (b) of the activities funded through
@@ -50842,8 +47242,6 @@ receive a grant under this part, an applicant shall agree—
      section shall not apply to the certified EHR tech-
      nology grant program under section 2041(b).
 
-      HR 3590 EAS/PP
-                          1803
           ‘‘(3) UTHORIZED ACTIVITIES  .—A recipient of
      assistance described in paragraph (1)(B) shall use the
      funds made available through the assistance to con-
@@ -50870,8 +47268,6 @@ receive a grant under this part, an applicant shall agree—
  TECHNOLOGY  G RANT PROGRAM BY THE   SECRETARY .—
 
 
-      HR 3590 EAS/PP
-                            1804
           ‘‘(1) EVALUATIONS  .—The Secretary shall con-
       duct an evaluation of the activities funded under the
       certified EHR technology grant program under sec-
@@ -50898,8 +47294,6 @@ of the Senate a report—
       mines to be appropriate.
 
 
-      HR 3590 EAS/PP
-                           1805
  ‘‘SEC. 2046. RULE OF CONSTRUCTION.
      ‘‘Nothing in this subtitle shall be construed as—
           ‘‘(1) limiting any cause of action or other relief
@@ -50926,8 +47320,6 @@ of the Senate a report—
                    to elder care determined appropriate
                    by the State for which the State identi-
 
-      HR 3590 EAS/PP
-                          1806
                    fies an unmet need for service per-
                    sonnel,
               and, if so, shall include an overview of such
@@ -50954,8 +47346,6 @@ of the Senate a report—
           STITUTE.—The contract entered into under sub-
           paragraph (A) shall require the Institute estab-
 
-      HR 3590 EAS/PP
-                            1807
           lished and operated under such contract to carry
           out the following activities:
                     (i) Assess the extent to which State
@@ -50982,8 +47372,6 @@ of the Senate a report—
                tion of property.
 
 
-      HR 3590 EAS/PP
-                            1808
                     (v) Assess the performance of State
                complaint intake systems, in order to ensure
                that the intake of complaints occurs 24
@@ -51010,8 +47398,6 @@ of the Senate a report—
                     plaints.
 
 
-      HR 3590 EAS/PP
-                           1809
                    (viii) Conduct a national study of the
                cost to State agencies of conducting com-
                plaint investigations of skilled nursing fa-
@@ -51038,8 +47424,6 @@ of the Senate a report—
           purpose of designing and implementing com-
           plaint investigations systems that—
 
-      HR 3590 EAS/PP
-                            1810
                     (i) promptly prioritize complaints in
                order to ensure a rapid response to the most
                serious and urgent complaints;
@@ -51066,8 +47450,6 @@ of the Senate a report—
       ED LONG -TERM CARE FACILITIES  .—Part A of title XI
       of the Social Security Act (42 U.S.C. 1301 et seq.),
 
-      HR 3590 EAS/PP
-                            1811
       as amended by section 6005, is amended by inserting
       after section 1150A the following new section:
  ‘REPORTING TO LAW ENFORCEMENT OF CRIMES OCCUR          -
@@ -51094,8 +47476,6 @@ of the Senate a report—
       ager, agent, or contractor of a long-term care facility
       that is the subject of a determination described in
       paragraph (1).
-      HR 3590 EAS/PP
-                           1812
      ‘‘(b) EPORTING  R EQUIREMENTS  .—
           ‘‘(1) IN  GENERAL .—Each covered individual
      shall report to the Secretary and 1 or more law en-
@@ -51122,8 +47502,6 @@ of the Senate a report—
                ‘‘(B) the Secretary may make a determina-
           tion in the same proceeding to exclude the cov-
 
-      HR 3590 EAS/PP
-                           1813
           ered individual from participation in any Fed-
           eral health care program (as defined in section
           1128B(f)).
@@ -51150,8 +47528,6 @@ of the Senate a report—
           into account the financial burden on providers
 
 
-      HR 3590 EAS/PP
-                           1814
           with underserved populations in determining
           any penalty to be imposed under this subsection.
               ‘‘(B) U  NDERSERVED    POPULATION    DE  -
@@ -51178,8 +47554,6 @@ of the Senate a report—
           harass, or deny a promotion or other employ-
           ment-related benefit to an employee, or in any
 
-      HR 3590 EAS/PP
-                            1815
           other manner discriminate against an employee
           in the terms and conditions of employment be-
           cause of lawful acts done by the employee; or
@@ -51206,8 +47580,6 @@ of the Senate a report—
       Secretary against a long-term care facility that vio-
 
 
-      HR 3590 EAS/PP
-                           1816
      lates the provisions of this subsection and information
      with respect to the manner of filing such a complaint.
      ‘‘(e) PROCEDURE .—The provisions of section 1128A
@@ -51234,8 +47606,6 @@ the meanings given those terms in section 2011.’’.
 
 
 
-      HR 3590 EAS/PP
-                           1817
                (B) A REAS EVALUATED   .—The study con-
           ducted under this subsection shall include an
           evaluation of—
@@ -51262,8 +47632,6 @@ the meanings given those terms in section 2011.’’.
                    (vii) how the information included in
                State nurse aide registries developed and
 
-      HR 3590 EAS/PP
-                           1818
                maintained under sections 1819(e)(2) and
                1919(e)(2) of the Social Security Act (42
                U.S.C. 1395i–3(e)(2); 1396r(e)(2)(2)) would
@@ -51290,8 +47658,6 @@ the meanings given those terms in section 2011.’’.
                Long-Term Care Facility Compliance and
                Practices (July 2005).
 
-      HR 3590 EAS/PP
-                           1819
                    (iv) The Department of Health and
                Human Services Health Resources and
                Services Administration Report, Nursing
@@ -51318,8 +47684,6 @@ the meanings given those terms in section 2011.’’.
           1805(a), the Committee on Finance of the Sen-
           ate, and the Committee on Ways and Means and
 
-      HR 3590 EAS/PP
-                           1820
           the Committee on Energy and Commerce of the
           House of Representatives a report containing the
           findings and recommendations of the study con-
@@ -51346,8 +47710,6 @@ the meanings given those terms in section 2011.’’.
               (A) in the heading of section 2001, by strik-
           ing ‘TITLE’’ and insertingSUBTITLE ’’; and
 
-      HR 3590 EAS/PP
-                             1821
                 (B) in subtitle 1, by striking ‘‘this title’’
            each place it appears and inserting ‘‘this sub-
            title’’.
@@ -51374,8 +47736,6 @@ the meanings given those terms in section 2011.’’.
                      (ii) by striking ‘‘such title’’ and insert-
                 ing ‘‘such subtitle’’; and
 
-      HR 3590 EAS/PP
-                           1822
               (B) in section 1128A(i)(1), by inserting
           ‘‘subtitle 1 of’’ before ‘‘title XX’’.
      Subtitle I—Sense of the Senate
@@ -51402,8 +47762,6 @@ the meanings given those terms in section 2011.’’.
 
 
 
-      HR 3590 EAS/PP
-                         1823
  TITLE VII—IMPROVING ACCESS
      TO INNOVATIVE MEDICAL
      THERAPIES
@@ -51430,8 +47788,6 @@ Health Service Act (42 U.S.C. 262) is amended—
      application for licensure of a biological product under
      this subsection.
 
-     HR 3590 EAS/PP
-                           1824
           ‘‘(2) ONTENT .—
               ‘‘(A) N GENERAL  .—
                    ‘‘(i) EQUIRED INFORMATION  .—An ap-
@@ -51458,8 +47814,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                         ficient to demonstrate safety, pu-
                         rity, and potency in 1 or more
 
-      HR 3590 EAS/PP
-                            1825
                          appropriate conditions of use for
                          which the reference product is li-
                          censed and intended to be used
@@ -51486,8 +47840,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                          ‘‘(V) the facility in which the bio-
                     logical product is manufactured, proc-
 
-      HR 3590 EAS/PP
-                           1826
                    essed, packed, or held meets standards
                    designed to assure that the biological
                    product continues to be safe, pure, and
@@ -51514,8 +47866,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                ‘‘(B) INTERCHANGEABILITY  .—An applica-
           tion (or a supplement to an application) sub-
 
-      HR 3590 EAS/PP
-                           1827
           mitted under this subsection may include infor-
           mation demonstrating that the biological product
           meets the standards described in paragraph (4).
@@ -51542,8 +47892,6 @@ Health Service Act (42 U.S.C. 262) is amended—
       tion submitted under this subsection or any supple-
       ment to such application, the Secretary shall deter-
 
-      HR 3590 EAS/PP
-                            1828
       mine the biological product to be interchangeable with
       the reference product if the Secretary determines that
       the information submitted in the application (or a
@@ -51570,8 +47918,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                ‘‘(B) REVIEW .—An application submitted
           under this subsection shall be reviewed by the di-
 
-      HR 3590 EAS/PP
-                           1829
           vision within the Food and Drug Administra-
           tion that is responsible for the review and ap-
           proval of the application under which the ref-
@@ -51598,8 +47944,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           keting of the first interchangeable biosimilar bio-
 
 
-      HR 3590 EAS/PP
-                            1830
           logical product to be approved as interchangeable
           for that reference product;
                ‘‘(B) 18 months after—
@@ -51626,8 +47970,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           the applicant that submitted such application
           has not been sued under subsection (l)(6).
 
-      HR 3590 EAS/PP
-                            1831
       For purposes of this paragraph, the term ‘final court
       decision’ means a final decision of a court from which
       no appeal (other than a petition to the United States
@@ -51654,8 +47996,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                the same sponsor or manufacturer of the bi-
                ological product that is the reference prod-
 
-      HR 3590 EAS/PP
-                           1832
                uct (or a licensor, predecessor in interest, or
                other related entity) for—
                         ‘‘(I) a change (not including a
@@ -51682,8 +48022,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                provide the public an opportunity to com-
                ment on any proposed guidance issued
 
-      HR 3590 EAS/PP
-                            1833
                under subparagraph (A) before issuing final
                guidance.
                     ‘‘(ii)NPUT REGARDING MOST VALU      -
@@ -51710,8 +48048,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                biological product meets the standards de-
                scribed in paragraph (4).
 
-      HR 3590 EAS/PP
-                           1834
                ‘‘(E) ERTAIN PRODUCT CLASSES   .—
                    ‘‘(i) GUIDANCE .—The Secretary may
                indicate in a guidance document that the
@@ -51738,8 +48074,6 @@ Health Service Act (42 U.S.C. 262) is amended—
      ‘‘(l) ATENTS .—
 
 
-      HR 3590 EAS/PP
-                            1835
           ‘‘(1) CONFIDENTIAL ACCESS TO SUBSECTION     (k)
       APPLICATION .—
                ‘‘(A) APPLICATION OF PARAGRAPH   .—Unless
@@ -51766,8 +48100,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                section as the ‘confidential information’).
 
 
-      HR 3590 EAS/PP
-                           1836
                    ‘‘(ii) ECIPIENTS OF INFORMATION    .—
                The persons described in this clause are the
                following:
@@ -51794,8 +48126,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                sively licensed to a reference product spon-
                sor with respect to the reference product and
 
-      HR 3590 EAS/PP
-                            1837
                who has retained a right to assert the pat-
                ent or participate in litigation concerning
                the patent may be provided the confidential
@@ -51822,8 +48152,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           sively licensed by the reference product sponsor,
           whether a claim of patent infringement could
 
-      HR 3590 EAS/PP
-                            1838
           reasonably be asserted if the subsection (k) appli-
           cant engaged in the manufacture, use, offering
           for sale, sale, or importation into the United
@@ -51850,8 +48178,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           confidential information in accordance with the
           terms of that order. No confidential information
 
-      HR 3590 EAS/PP
-                            1839
           shall be included in any publicly-available com-
           plaint or other pleading. In the event that the
           reference product sponsor does not file an in-
@@ -51878,8 +48204,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           subsection (k) applicant to suffer irreparable
           harm for which there is no adequate legal rem-
 
-      HR 3590 EAS/PP
-                            1840
           edy and the court shall consider immediate in-
           junctive relief to be an appropriate and nec-
           essary remedy for any violation or threatened
@@ -51906,8 +48230,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           graph (2), the reference product sponsor shall
           provide to the subsection (k) applicant—
 
-      HR 3590 EAS/PP
-                            1841
                     ‘‘(i) a list of patents for which the ref-
                erence product sponsor believes a claim of
                patent infringement could reasonably be as-
@@ -51934,8 +48256,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                subsection (k) applicant believes a claim of
                patent infringement could reasonably be as-
 
-      HR 3590 EAS/PP
-                            1842
                serted by the reference product sponsor if a
                person not licensed by the reference product
                sponsor engaged in the making, using, offer-
@@ -51962,8 +48282,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                     begin commercial marketing of the bio-
 
 
-      HR 3590 EAS/PP
-                            1843
                     logical product before the date that
                     such patent expires; and
                     ‘‘(iii) shall provide to the reference
@@ -51990,8 +48308,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           subsection (k) applicant of the statement under
           paragraph (3)(C), the reference product sponsor
 
-      HR 3590 EAS/PP
-                           1844
           and the subsection (k) applicant shall engage in
           good faith negotiations to agree on which, if any,
           patents listed under paragraph (3) by the sub-
@@ -52018,8 +48334,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                    ‘‘(i) N GENERAL  .—On a date agreed
                to by the subsection (k) applicant and the
 
-      HR 3590 EAS/PP
-                           1845
                reference product sponsor, but in no case
                later than 5 days after the subsection (k)
                applicant notifies the reference product
@@ -52046,8 +48360,6 @@ Health Service Act (42 U.S.C. 262) is amended—
                    section (k) applicant under clause
                    (i)(I).
 
-      HR 3590 EAS/PP
-                           1846
                         ‘‘(II) XCEPTION .—If a subsection
                    (k) applicant does not list any patent
                    under clause (i)(I), the reference prod-
@@ -52074,8 +48386,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           COMPLAINT  .—
 
 
-      HR 3590 EAS/PP
-                           1847
                    ‘‘(i) NOTIFICATION TO SECRETARY    .—
                Not later than 30 days after a complaint is
                served to a subsection (k) applicant in an
@@ -52102,8 +48412,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           product sponsor engaged in the making, using,
           offering to sell, selling, or importing into the
 
-      HR 3590 EAS/PP
-                           1848
           United States of the biological product that is
           the subject of the subsection (k) application,
       not later than 30 days after such issuance or licens-
@@ -52130,8 +48438,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           keting of such biological product, the reference
           product sponsor may seek a preliminary injunc-
 
-      HR 3590 EAS/PP
-                           1849
           tion prohibiting the subsection (k) applicant
           from engaging in the commercial manufacture or
           sale of such biological product until the court de-
@@ -52158,8 +48464,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           ‘‘(9) LIMITATION ON DECLARATORY JUDGMENT
      ACTION .—
 
-      HR 3590 EAS/PP
-                            1850
                ‘‘(A) SUBSECTION   (k)  APPLICATION PRO  -
           VIDED .—If a subsection (k) applicant provides
           the application and information required under
@@ -52186,8 +48490,6 @@ Health Service Act (42 U.S.C. 262) is amended—
           vided under paragraph (7).
 
 
-      HR 3590 EAS/PP
-                            1851
                ‘‘(C) S UBSECTION   (k)  APPLICATION  NOT
           PROVIDED  .—If a subsection (k) applicant fails to
           provide the application and information re-
@@ -52214,8 +48516,6 @@ Service Act (42 U.S.C. 262(i)) is amended—
                ‘‘(A) that the biological product is highly
           similar to the reference product notwithstanding
 
-      HR 3590 EAS/PP
-                           1852
           minor differences in clinically inactive compo-
           nents; and
               ‘‘(B) there are no clinically meaningful dif-
@@ -52242,8 +48542,6 @@ Service Act (42 U.S.C. 262(i)) is amended—
               ‘‘or’’ at the end;
 
 
-      HR 3590 EAS/PP
-                            1853
                     (ii) in subparagraph (B), by adding
                ‘‘or’’ at the end; and
                     (iii) by inserting after subparagraph
@@ -52270,8 +48568,6 @@ Service Act (42 U.S.C. 262(i)) is amended—
                     cal product’’ and inserting ‘‘, veteri-
 
 
-      HR 3590 EAS/PP
-                            1854
                     nary biological product, or biological
                     product’’; and
                          (II) striking ‘‘and’’ at the end;
@@ -52298,8 +48594,6 @@ Service Act (42 U.S.C. 262(i)) is amended—
       such Act.’’; and
 
 
-      HR 3590 EAS/PP
-                            1855
                     (iv) in the matter following subpara-
                graph (D) (as added by clause (iii)), by
                striking ‘‘and (C)’’ and inserting ‘‘(C), and
@@ -52326,8 +48620,6 @@ graph (4), in the case of a patent—
 scribed in subparagraph (A), the sole and exclusive remedy
 that may be granted by a court, upon a finding that the
 
-      HR 3590 EAS/PP
-                          1856
 making, using, offering to sell, selling, or importation into
 the United States of the biological product that is the subject
 of the action infringed the patent, shall be a reasonable roy-
@@ -52354,8 +48646,6 @@ spect to the biological product.’’.
      for approval of a biological product under section
 
 
-      HR 3590 EAS/PP
-                          1857
      351(k) of the Public Health Service Act, any nec-
      essary clinical study or studies’’.
           (2) NEW ACTIVE INGREDIENT  .—Section 505B of
@@ -52382,8 +48672,6 @@ spect to the biological product.’’.
      for a biological product shall be submitted under sec-
 
 
-      HR 3590 EAS/PP
-                            1858
       tion 351 of the Public Health Service Act (42 U.S.C.
       262) (as amended by this Act).
           (2) E XCEPTION .—An application for a biological
@@ -52410,8 +48698,6 @@ spect to the biological product.’’.
       another biological product approved under subsection
       (a) of section 351 of the Public Health Service Act
 
-      HR 3590 EAS/PP
-                          1859
      that could be a reference product with respect to such
      application (within the meaning of such section 351)
      if such application were submitted under subsection
@@ -52438,8 +48724,6 @@ spect to the biological product.’’.
           goals, for the process for the review of biosimilar
           biological product applications submitted under
 
-      HR 3590 EAS/PP
-                           1860
           section 351(k) of the Public Health Service Act
           (as added by this Act) for the first 5 fiscal years
           after fiscal year 2012. In developing such rec-
@@ -52466,8 +48750,6 @@ spect to the biological product.’’.
 
 
 
-      HR 3590 EAS/PP
-                           1861
                    (iii) provide for a period of 30 days for
                the public to provide written comments on
                such recommendations;
@@ -52494,8 +48776,6 @@ spect to the biological product.’’.
      biosimilar biological product applications under sec-
 
 
-      HR 3590 EAS/PP
-                           1862
      tion 351(k) of the Public Health Service Act (as
      added by this Act).
           (3) TRANSITIONAL PROVISIONS FOR USER FEES
@@ -52522,8 +48802,6 @@ spect to the biological product.’’.
               product under section 351(k) of the Public
               Health Service Act (as added by this Act),
 
-      HR 3590 EAS/PP
-                            1863
                and on a biennial basis thereafter until Oc-
                tober 1, 2013, the Secretary shall perform
                an audit of the costs of reviewing such ap-
@@ -52550,8 +48828,6 @@ spect to the biological product.’’.
                user fee applicable to applications sub-
                mitted under such section 351(k) to more
 
-      HR 3590 EAS/PP
-                          1864
               appropriately account for the costs of re-
               viewing such applications.
                    (iii) ACCOUNTING  STANDARDS  .—The
@@ -52578,8 +48854,6 @@ spect to the biological product.’’.
      spect to the extension of a period under paragraphs
      (2) and (3) to the same extent and in the same man-
 
-      HR 3590 EAS/PP
-                           1865
       ner as such provisions apply with respect to the ex-
       tension of a period under subsection (b) or (c) of sec-
       tion 505A of the Federal Food, Drug, and Cosmetic
@@ -52606,8 +48880,6 @@ spect to the biological product.’’.
           and
 
 
-      HR 3590 EAS/PP
-                           1866
                ‘‘(B) if the biological product is designated
           under section 526 for a rare disease or condition,
           the period for such biological product referred to
@@ -52634,8 +48906,6 @@ spect to the biological product.’’.
           12 years and 6 months rather than 12 years;
           and
 
-      HR 3590 EAS/PP
-                           1867
                ‘‘(B) if the biological product is designated
           under section 526 for a rare disease or condition,
           the period for such biological product referred to
@@ -52662,8 +48932,6 @@ spect to the biological product.’’.
      tance of biological products for children that are being
      tested as a result of the amendments made by the Bio-
 
-      HR 3590 EAS/PP
-                            1868
       logics Price Competition and Innovation Act of 2009
       and the importance for children, health care pro-
       viders, parents, and others of labeling changes made
@@ -52690,8 +48958,6 @@ reference product of the later of—
       of the Federal Food, Drug, and Cosmetic Act (21
       U.S.C. 360cc(a)); and
 
-      HR 3590 EAS/PP
-                          1869
          (2) the 12-year period described in subsection
      (k)(7) of such section 351.
  SEC. 7003. SAVINGS.
@@ -52718,8 +48984,6 @@ adding at the end the following:
          rity Act, or a free-standing cancer hospital ex-
          cluded from the Medicare prospective payment
 
-      HR 3590 EAS/PP
-                           1870
           system pursuant to section 1886(d)(1)(B)(v) of
           the Social Security Act, that would meet the re-
           quirements of subparagraph (L), including the
@@ -52746,8 +49010,6 @@ Section 340B of the Public Health Service Act (42 U.S.C.
 
 
 
-      HR 3590 EAS/PP
-                          1871
           (1) in paragraphs (2), (5), (7), and (9) of sub-
      section (a), by striking ‘‘outpatient’’ each place it ap-
      pears; and
@@ -52774,8 +49036,6 @@ Section 340B of the Public Health Service Act (42 U.S.C.
  MENTS .—Section 340B(a) of the Public Health Service Act
 (42 U.S.C. 256b(a)) is amended—
 
-      HR 3590 EAS/PP
-                           1872
           (1) in paragraph (4)(L)—
                (A) in clause (i), by adding ‘‘and’’ at the
           end;
@@ -52802,8 +49062,6 @@ Section 340B of the Public Health Service Act (42 U.S.C.
 
 
 
-      HR 3590 EAS/PP
-                            1873
                     ‘‘(ii) NPATIENT   DRUGS .—Clause (i)
                shall not apply to drugs purchased for in-
                patient use.
@@ -52830,8 +49088,6 @@ Section 340B of the Public Health Service Act (42 U.S.C.
                     cate discount problem in violation of
 
 
-      HR 3590 EAS/PP
-                           1874
                    subparagraph (A) or a diversion prob-
                    lem in violation of subparagraph (B).
                    ‘‘(iv) P URCHASING   ARRANGEMENTS
@@ -52858,8 +49114,6 @@ tion 340B of the Public Health Service Act (42 U.S.C. 256b)
 is amended by striking subsection (c) and inserting the fol-
 lowing:
 
-      HR 3590 EAS/PP
-                           1875
      ‘‘(c) EDICAID  CREDIT .—Not later than 90 days after
 the date of filing of the hospital’s most recently filed Medi-
 care cost report, the hospital shall issue a credit as deter-
@@ -52886,8 +49140,6 @@ is amended to read as follows:
               ‘‘(A) IN GENERAL .—From amounts appro-
           priated under paragraph (4), the Secretary shall
 
-      HR 3590 EAS/PP
-                            1876
           provide for improvements in compliance by
           manufacturers with the requirements of this sec-
           tion in order to prevent overcharges and other
@@ -52914,8 +49166,6 @@ is amended to read as follows:
                     that is reported by manufacturers to
                     the Secretary.
 
-      HR 3590 EAS/PP
-                            1877
                          ‘‘(III) Performing spot checks of
                     sales transactions by covered entities.
                          ‘‘(IV) Inquiring into the cause of
@@ -52942,8 +49192,6 @@ is amended to read as follows:
                     pricing data and exceptional cir-
 
 
-      HR 3590 EAS/PP
-                            1878
                     cumstances such as erroneous or inten-
                     tional overcharging for covered drugs.
                     ‘‘(iii) The provision of access through
@@ -52970,8 +49218,6 @@ is amended to read as follows:
                     of lowering the applicable ceiling price
 
 
-      HR 3590 EAS/PP
-                            1879
                     for the relevant quarter for the drugs
                     involved.
                     ‘‘(v) Selective auditing of manufactur-
@@ -52998,8 +49244,6 @@ is amended to read as follows:
                     ceeds the maximum applicable price
                     under subsection (a)(1).
 
-      HR 3590 EAS/PP
-                           1880
           ‘‘(2) OVERED ENTITY COMPLIANCE   .—
                ‘‘(A) N GENERAL  .—From amounts appro-
           priated under paragraph (4), the Secretary shall
@@ -53026,8 +49270,6 @@ is amended to read as follows:
                tions available to covered entities for billing
                covered drugs to State Medicaid agencies in
 
-      HR 3590 EAS/PP
-                            1881
                a manner that avoids duplicate discounts
                pursuant to subsection (a)(5)(A).
                     ‘‘(iv) The establishment of a single,
@@ -53054,8 +49296,6 @@ is amended to read as follows:
                     for which the covered entity is found
                     liable under subsection (a)(5)(E), such
 
-      HR 3590 EAS/PP
-                            1882
                     interest to be compounded monthly and
                     equal to the current short term interest
                     rate as determined by the Federal Re-
@@ -53082,8 +49322,6 @@ is amended to read as follows:
                     scription Drug Marketing Act (21
                     U.S.C. 353).
 
-      HR 3590 EAS/PP
-                           1883
           ‘‘(3) A DMINISTRATIVE  DISPUTE   RESOLUTION
      PROCESS  .—
                ‘‘(A) N  GENERAL  .—Not later than 180
@@ -53110,8 +49348,6 @@ is amended to read as follows:
                Human Services to be responsible for re-
                viewing and finally resolving claims by cov-
 
-      HR 3590 EAS/PP
-                            1884
                ered entities that they have been charged
                prices for covered drugs in excess of the ceil-
                ing price described in subsection (a)(1), and
@@ -53138,8 +49374,6 @@ is amended to read as follows:
                to subsection (a)(5)(D) as a prerequisite to
 
 
-      HR 3590 EAS/PP
-                            1885
                initiating administrative dispute resolution
                proceedings against a covered entity;
                     ‘‘(v) permit the official or body des-
@@ -53166,8 +49400,6 @@ is amended to read as follows:
           claim or claims under the regulations promul-
           gated under subparagraph (A) shall be a final
 
-      HR 3590 EAS/PP
-                           1886
           agency decision and shall be binding upon the
           parties involved, unless invalidated by an order
           of a court of competent jurisdiction.
@@ -53194,8 +49426,6 @@ amended—
      as redesignated by section 7101(c), by inserting ‘‘after
 
 
-      HR 3590 EAS/PP
-                            1887
       audit as described in subparagraph (D) and’’ after
       ‘‘finds,’’.
  SEC. 7103. GAO STUDY TO MAKE RECOMMENDATIONS ON
@@ -53222,8 +49452,6 @@ services.
       being used by the covered entities under the program
       to further the program objectives.
 
-      HR 3590 EAS/PP
-                         1888
         TITLE VIII—CLASS ACT
  SEC. 8001. SHORT TITLE OF TITLE.
      This title may be cited as the ‘‘Community Living As-
@@ -53250,8 +49478,6 @@ ing assistance services and supports in order to—
      the community through a new financing strategy for
      community living assistance services and supports;
 
-     HR 3590 EAS/PP
-                            1889
           ‘‘(2) establish an infrastructure that will help
       address the Nation’s community living assistance
       services and supports needs;
@@ -53278,8 +49504,6 @@ ing assistance services and supports in order to—
           vidual’s position); and
 
 
-      HR 3590 EAS/PP
-                           1890
                ‘‘(B) is able to perform all the usual and
           customary duties of the individual’s employment
           on the individual’s regular work schedule.
@@ -53306,8 +49530,6 @@ ing assistance services and supports in order to—
           enrollee in the CLASS program and, as of the
           date described in subparagraph (B)—
 
-      HR 3590 EAS/PP
-                            1891
                     ‘‘(i) has paid premiums for enrollment
                in such program for at least 60 months;
                     ‘‘(ii) has earned, with respect to at
@@ -53334,8 +49556,6 @@ ing assistance services and supports in order to—
           scribed in section 3203(a)(1)(C) that is expected
 
 
-      HR 3590 EAS/PP
-                            1892
           to last for a continuous period of more than 90
           days.
                ‘‘(C) R EGULATIONS .—The Secretary shall
@@ -53362,8 +49582,6 @@ ing assistance services and supports in order to—
 
 
 
-      HR 3590 EAS/PP
-                           1893
           ‘‘(10) CLASS  INDEPENDENCE FUND   .—The term
      ‘CLASS Independence Fund’ or ‘Fund’ means the
      fund established under section 3206.
@@ -53390,8 +49608,6 @@ ing assistance services and supports in order to—
      developed shall be designed to provide eligible bene-
 
 
-      HR 3590 EAS/PP
-                           1894
       ficiaries with the benefits described in section 3205
       consistent with the following requirements:
                ‘‘(A) REMIUMS  .—
@@ -53418,8 +49634,6 @@ ing assistance services and supports in order to—
                         actively employed during any pe-
                         riod in which the individual is a
 
-      HR 3590 EAS/PP
-                           1895
                         full-time student (as determined
                         by the Secretary).
                         ‘‘(II) A   PPLICABLE     DOLLAR
@@ -53446,8 +49660,6 @@ ing assistance services and supports in order to—
                credited to the CLASS Independence Fund,
                the Secretary may decrease the required
 
-      HR 3590 EAS/PP
-                            1896
                amount of CLASS Independence Fund re-
                serves.
                ‘‘(B) VESTING PERIOD   .—A 5-year vesting
@@ -53474,8 +49686,6 @@ ing assistance services and supports in order to—
                functional limitation similar (as deter-
                mined under regulations prescribed by the
 
-      HR 3590 EAS/PP
-                           1897
                Secretary) to the level of functional limita-
                tion described in clause (i) or (ii).
                ‘‘(D) CASH BENEFIT .—Payment of a cash
@@ -53502,8 +49712,6 @@ ing assistance services and supports in order to—
           CHANGE  .—The benefits allow for coordination
           with any supplemental coverage purchased
 
-      HR 3590 EAS/PP
-                           1898
           through an Exchange established under section
           1311 of the Patient Protection and Affordable
           Care Act.
@@ -53530,8 +49738,6 @@ ing assistance services and supports in order to—
      a final rule that allows for a period of public com-
      ment.
 
-      HR 3590 EAS/PP
-                          1899
      ‘‘(b) DDITIONAL P REMIUM  REQUIREMENTS  .—
           ‘‘(1) DJUSTMENT OF PREMIUMS   .—
               ‘‘(A) N GENERAL  .—Except as provided in
@@ -53558,8 +49764,6 @@ ing assistance services and supports in order to—
               are projected to be insufficient with respect
               to the 20-year period that begins with that
 
-      HR 3590 EAS/PP
-                           1900
               year, the Secretary shall adjust the monthly
               premiums for individuals enrolled in the
               CLASS program as necessary (but main-
@@ -53586,8 +49790,6 @@ ing assistance services and supports in order to—
               which the individual failed to pay the
               monthly premium required to maintain the
 
-      HR 3590 EAS/PP
-                           1901
                individual’s enrollment in the CLASS pro-
                gram shall be treated as an initial enroll-
                ment for purposes of age-adjusting the pre-
@@ -53614,8 +49816,6 @@ ing assistance services and supports in order to—
           STUDENT  .—An individual subject to a nominal
           premium on the basis of being described in sub-
 
-      HR 3590 EAS/PP
-                            1902
           section (a)(1)(A)(ii)(I)(bb) who ceases to be de-
           scribed in that subsection, beginning with the
           first month following the month in which the in-
@@ -53642,8 +49842,6 @@ ing assistance services and supports in order to—
                individual failed to pay the monthly pre-
                mium required to maintain the individual’s
 
-      HR 3590 EAS/PP
-                           1903
                enrollment in the CLASS program and
                ends with the month preceding the month in
                which the reenollment is effective; or
@@ -53670,8 +49868,6 @@ ing assistance services and supports in order to—
           ‘‘(1) permit an individual who is eligible for the
      nominal premium required under subsection
 
-      HR 3590 EAS/PP
-                           1904
      (a)(1)(A)(ii), as part of their automatic enrollment in
      the CLASS program, to self-attest that their income
      does not exceed the poverty line or that their status
@@ -53698,8 +49894,6 @@ ing assistance services and supports in order to—
      ployer of such individual in the same manner as an
      employer may elect to automatically enroll employees
 
-      HR 3590 EAS/PP
-                           1905
      in a plan under section 401(k), 403(b), or 457 of the
      Internal Revenue Code of 1986.
           ‘‘(2) A  LTERNATIVE    ENROLLMENT     PROCE  -
@@ -53726,8 +49920,6 @@ ing assistance services and supports in order to—
 scribed in subsection (c) may elect to waive enrollment in
 the CLASS program at any time in such form and manner
 
-      HR 3590 EAS/PP
-                            1906
 as the Secretary and the Secretary of the Treasury shall
 prescribe.
       ‘‘(c)NDIVIDUAL  DESCRIBED  .—For purposes of enroll-
@@ -53754,8 +49946,6 @@ paragraph is an individual—
           fense or in connection with a verdict or finding
 
 
-      HR 3590 EAS/PP
-                           1907
           described in section 202(x)(1)(A)(ii) of the Social
           Security Act (42 U.S.C. 402(x)(1)(A)(ii)).
      ‘‘(d) RULE OF  CONSTRUCTION  .—Nothing in this title
@@ -53782,8 +49972,6 @@ in order to maintain enrollment in the CLASS program.
           cordance with subparagraph (A); or
 
 
-      HR 3590 EAS/PP
-                          1908
               ‘‘(B) who does not earn wages or derive self-
           employment income.
      ‘‘(f)RANSFER OF  PREMIUMS  C OLLECTED .—
@@ -53810,8 +49998,6 @@ which—
           ‘‘(1) an individual who, in the year of the indi-
      vidual’s initial eligibility to enroll in the CLASS
 
-      HR 3590 EAS/PP
-                           1909
      program, has elected to waive enrollment in the pro-
      gram, is eligible to elect to enroll in the program, in
      such form and manner as the Secretaries shall estab-
@@ -53838,8 +50024,6 @@ which—
                    ‘‘(i) establish an Eligibility Assessment
                System (other than a service with which the
 
-      HR 3590 EAS/PP
-                            1910
                Commissioner of Social Security has en-
                tered into an agreement, with respect to any
                State, to make disability determinations for
@@ -53866,8 +50050,6 @@ which—
           the program and if so, the amount of the cash
 
 
-      HR 3590 EAS/PP
-                            1911
           benefit (in accordance the sliding scale estab-
           lished under the plan).
                ‘‘(C) PRESUMPTIVE ELIGIBILITY FOR CER     -
@@ -53894,8 +50076,6 @@ which—
           benefits under the CLASS Independence Benefit
 
 
-      HR 3590 EAS/PP
-                            1912
           Plan shall be guaranteed the right to appeal an
           adverse determination.
       ‘‘(b) ENEFITS .—An eligible beneficiary shall receive
@@ -53922,8 +50102,6 @@ efit Plan:
           ‘‘(4) A DMINISTRATIVE    EXPENSES  .—Advocacy
       services and advise and assistance counseling services
 
-      HR 3590 EAS/PP
-                           1913
      under paragraphs (2) and (3) of this subsection shall
      be included as administrative expenses under section
      3203(b)(3).
@@ -53950,8 +50128,6 @@ efit Plan:
           home care aides, and nursing support. Nothing
           in the preceding sentence shall prevent an eligi-
 
-      HR 3590 EAS/PP
-                           1914
           ble beneficiary from using cash benefits paid into
           a Life Independence Account for obtaining as-
           sistance with decision making concerning med-
@@ -53978,8 +50154,6 @@ efit Plan:
           In the case of an eligible beneficiary who is en-
 
 
-      HR 3590 EAS/PP
-                            1915
           rolled in Medicaid, the following payment rules
           shall apply:
                     ‘‘(i) I  NSTITUTIONALIZED      BENE  -
@@ -54006,8 +50180,6 @@ efit Plan:
                     icaid for home and community based
                     services, the beneficiary shall retain an
 
-      HR 3590 EAS/PP
-                            1916
                     amount equal to 50 percent of the bene-
                     ficiary’s daily or weekly cash benefit
                     (as applicable), and the remainder of
@@ -54034,8 +50206,6 @@ efit Plan:
                     section 1902(a)(1) of the Social Secu-
                     rity Act (relating to statewideness) or
 
-      HR 3590 EAS/PP
-                           1917
                    of section 1902(a)(10)(B) of such Act
                    (relating to comparability) and the
                    State offers at a minimum case man-
@@ -54062,8 +50232,6 @@ efit Plan:
                    subclause (II), if a beneficiary is re-
                    ceiving medical assistance under Med-
 
-      HR 3590 EAS/PP
-                            1918
                     icaid for PACE program services
                     under section 1934 of the Social Secu-
                     rity Act (42 U.S.C. 1396u–4), the ben-
@@ -54090,8 +50258,6 @@ efit Plan:
                     eficiary shall be treated as in institu-
                     tionalized beneficiary under clause (i).
 
-      HR 3590 EAS/PP
-                            1919
           ‘‘(2) UTHORIZED REPRESENTATIVES     .—
                ‘‘(A) N GENERAL  .—The Secretary shall es-
           tablish procedures to allow access to a bene-
@@ -54118,8 +50284,6 @@ efit Plan:
                ‘‘(A) defer payment of their daily or weekly
           benefit and to rollover any such deferred benefits
 
-      HR 3590 EAS/PP
-                           1920
           from month-to-month, but not from year-to-year;
           and
                ‘‘(B) receive a lump-sum payment of such
@@ -54146,8 +50310,6 @@ efit Plan:
           ficiary before the end of a 12-month benefit pe-
           riod shall be included in the determination of the
 
-      HR 3590 EAS/PP
-                            1921
           applicable annual benefit paid to the eligible
           beneficiary.
                ‘‘(C) RECOUPMENT OF UNPAID     , ACCRUED
@@ -54174,8 +50336,6 @@ efit Plan:
           dence the beneficiary’s continued eligibility for
           receipt of benefits; and
 
-      HR 3590 EAS/PP
-                           1922
                ‘‘(B) submit records of expenditures attrib-
           utable to the aggregate cash benefit received by
           the beneficiary during the preceding year.
@@ -54202,8 +50362,6 @@ tion and Advocacy System for the State to—
 
 
 
-      HR 3590 EAS/PP
-                           1923
                ‘‘(C) such other assistance with obtaining
           services as the Secretary, by regulation, shall re-
           quire; and
@@ -54230,8 +50388,6 @@ ficiary with information regarding—
       structions recognized under State law, such as a liv-
       ing will or durable power of attorney for health care,
 
-      HR 3590 EAS/PP
-                           1924
      in the case that an injury or illness causes the indi-
      vidual to be unable to make health care decisions; and
           ‘‘(6) such other services as the Secretary, by reg-
@@ -54258,8 +50414,6 @@ assistance services and supports to an eligible beneficiary.
  ESTS.—The Secretary shall establish procedures to ensure
 that the Eligibility Assessment System, the Protection and
 
-      HR 3590 EAS/PP
-                            1925
 Advocacy System for a State, advocacy counselors for eligi-
 ble beneficiaries, and any other entities that provide services
 to active enrollees and eligible beneficiaries under the
@@ -54286,8 +50440,6 @@ CLASS program comply with the following:
       entity.
 
 
-      HR 3590 EAS/PP
-                           1926
           ‘‘(6) If the entity provides counseling or plan-
       ning services, the entity ensures that an active en-
       rollee or beneficiary is informed of any financial in-
@@ -54314,8 +50466,6 @@ shall remain available without fiscal year limitation—
       to the Fund and to investment under subsection (b);
       and
 
-      HR 3590 EAS/PP
-                           1927
           ‘‘(3) to pay cash benefits to eligible beneficiaries
      under the CLASS Independence Benefit Plan.
      ‘‘(b) NVESTMENT OF  F UND B ALANCE .—The Secretary
@@ -54342,8 +50492,6 @@ Fund may be invested and managed under subsections (c),
      vacancy occurring during a term shall be nominated
      and confirmed only for the remainder of such term.
 
-      HR 3590 EAS/PP
-                           1928
       An individual nominated and confirmed as a member
       of the public may serve in such position after the ex-
       piration of such member’s term until the earlier of the
@@ -54370,8 +50518,6 @@ Fund may be invested and managed under subsections (c),
                fiscal year and on its expected operation
 
 
-      HR 3590 EAS/PP
-                           1929
                and status during the current fiscal year
                and the next 2 fiscal years.
                    ‘‘(iii) Report immediately to the Con-
@@ -54398,8 +50544,6 @@ Fund may be invested and managed under subsections (c),
                    income to, and disbursements to be
                    made from, the CLASS Independence
 
-      HR 3590 EAS/PP
-                            1930
                     Fund during the current fiscal year
                     and each of the next 2 fiscal years;
                         ‘‘(III) a statement of the actuarial
@@ -54426,8 +50570,6 @@ Fund may be invested and managed under subsections (c),
           regards to the projection under section
           3203(b)(1)(B)(i) and are unlikely to be resolved
 
-      HR 3590 EAS/PP
-                           1931
           with reasonable premium increases or through
           other means, the Board of Trustees shall include
           in the report provided for in subparagraph
@@ -54454,8 +50596,6 @@ ence Advisory Council’.
           shall include representatives of older and young-
           er workers, individuals with disabilities, family
 
-      HR 3590 EAS/PP
-                            1932
           caregivers of individuals who require services
           and supports to maintain their independence at
           home or in another residential setting of their
@@ -54482,8 +50622,6 @@ icy in the administration of the CLASS program estab-
 lished under this title and in the formulation of regulations
 under this title including with respect to—
 
-      HR 3590 EAS/PP
-                           1933
           ‘‘(1) the development of the CLASS Independence
       Benefit Plan under section 3203;
           ‘‘(2) the determination of monthly premiums
@@ -54510,8 +50648,6 @@ sult with the Board of Trustees of the CLASS Independence
 Fund and the CLASS Independence Advisory Council, for
 purposes of ensuring that enrollees premiums are adequate
 
-      HR 3590 EAS/PP
-                          1934
 to ensure the financial solvency of the CLASS program,
 both with respect to fiscal years occurring in the near-term
 and fiscal years occurring over 20- and 75-year periods,
@@ -54538,8 +50674,6 @@ lowing:
      gram.
 
 
-      HR 3590 EAS/PP
-                            1935
           ‘‘(2) The total number of eligible beneficiaries
       during the fiscal year.
           ‘‘(3) The total amount of cash benefits provided
@@ -54566,8 +50700,6 @@ include findings in the following areas:
 
 
 
-      HR 3590 EAS/PP
-                          1936
  ‘‘SEC. 3210. TAX TREATMENT OF PROGRAM.
      ‘‘The CLASS program shall be treated for purposes of
 the Internal Revenue Code of 1986 in the same manner as
@@ -54594,8 +50726,6 @@ amended by inserting after paragraph (81) the following:
      the date of enactment of the Community Living As-
      sistance Services and Supports Act, each State
      shall—
-      HR 3590 EAS/PP
-                            1937
                ‘‘(A) assess the extent to which entities such
           as providers of home care, home health services,
           home and community service providers, public
@@ -54622,8 +50752,6 @@ amended by inserting after paragraph (81) the following:
           pede existing programs, models, methods, or ad-
           ministration of service delivery that provide for
 
-      HR 3590 EAS/PP
-                          1938
           consumer controlled or self-directed home and
           community services and further ensure that such
           entities will not impede the ability of individuals
@@ -54650,8 +50778,6 @@ amended by inserting after paragraph (81) the following:
      Panel, the Secretary shall ensure that such members
      include the following:
 
-      HR 3590 EAS/PP
-                          1939
               (A) Individuals with disabilities of all ages.
               (B) Senior individuals.
               (C) Representatives of individuals with dis-
@@ -54678,8 +50804,6 @@ tion 6021(d) of the Deficit Reduction Act of 2005 (42 U.S.C.
               the CLASS program established under title
               XXXII of the Public Health Service Act and
 
-      HR 3590 EAS/PP
-                           1940
                coverage available for purchase through a
                Exchange established under section 1311 of
                the Patient Protection and Affordable Care
@@ -54706,8 +50830,6 @@ including such benefits that are for income replacement.
 
 
 
-      HR 3590 EAS/PP
-                         1941
            TITLE IX—REVENUE
                  PROVISIONS
        Subtitle A—Revenue Offset
@@ -54734,8 +50856,6 @@ tion—
      sored coverage made available by an employer to an
      employee during any taxable period, the sum of the
 
-     HR 3590 EAS/PP
-                            1942
       excess amounts determined under paragraph (2) for
       months during the taxable period.
           ‘‘(2) M ONTHLY   EXCESS  AMOUNT   .—The excess
@@ -54762,8 +50882,6 @@ tion—
                ‘‘(C) APPLICABLE DOLLAR LIMIT    .—Except
           as provided in subparagraph (D)—
 
-      HR 3590 EAS/PP
-                            1943
                     ‘‘(i) 2013.—In the case of 2013, the
                dollar limit under this subparagraph is—
                         ‘‘(I) in the case of an employee
@@ -54790,8 +50908,6 @@ tion—
                     ‘‘(iii) UBSEQUENT    YEARS .—In the
                case of any calendar year after 2013, each
 
-      HR 3590 EAS/PP
-                           1944
                of the dollar amounts under clauses (i) and
                (ii) shall be increased to the amount equal
                to such amount as in effect for the calendar
@@ -54818,8 +50934,6 @@ tion—
                paragraph for such month with respect to
                such employee shall be an amount equal to
 
-      HR 3590 EAS/PP
-                           1945
               the applicable percentage of the annual lim-
               itation (determined without regard to this
               subparagraph or subparagraph (C)(ii)).
@@ -54846,8 +50960,6 @@ tion—
 
 
 
-      HR 3590 EAS/PP
-                           1946
           ‘‘(2) OVERAGE PROVIDER   .—For purposes of this
       subsection, the term ‘coverage provider’ means each of
       the following:
@@ -54874,8 +50986,6 @@ tion—
           sponsored coverage provided by the provider to
           the employee during such period, bears to
 
-      HR 3590 EAS/PP
-                           1947
               ‘‘(B) the aggregate cost of all applicable em-
           ployer-sponsored coverage provided to the em-
           ployee by all coverage providers during such pe-
@@ -54902,8 +51012,6 @@ tion—
      ‘‘(d) APPLICABLE E MPLOYER -SPONSORED   COVERAGE  ;
  COST .—For purposes of this section—
 
-      HR 3590 EAS/PP
-                           1948
           ‘‘(1) APPLICABLE   EMPLOYER  -SPONSORED   COV -
       ERAGE .—
                ‘‘(A) N GENERAL   .—The term ‘applicable
@@ -54930,8 +51038,6 @@ tion—
           ble employer-sponsored coverage without regard
 
 
-      HR 3590 EAS/PP
-                           1949
           to whether the employer or employee pays for the
           coverage.
                ‘‘(D) SELF-EMPLOYED INDIVIDUAL   .—In the
@@ -54958,8 +51064,6 @@ tion—
           cost, any portion of the cost of such coverage
           which is attributable to the tax imposed under
 
-      HR 3590 EAS/PP
-                            1950
           this section shall not be taken into account and
           the amount of such cost shall be calculated sepa-
           rately for self-only coverage and other coverage.
@@ -54986,8 +51090,6 @@ tion—
           sisting of coverage under an arrangement under
           which the employer makes contributions de-
 
-      HR 3590 EAS/PP
-                          1951
           scribed in subsection (b) or (d) of section 106, the
           cost of the coverage shall be equal to the amount
           of employer contributions under the arrange-
@@ -55014,8 +51116,6 @@ tion—
           pay a penalty in an amount equal to such ex-
           cess, plus interest at the underpayment rate de-
 
-      HR 3590 EAS/PP
-                           1952
           termined under section 6621 for the period be-
           ginning on the due date for the payment of tax
           imposed by subsection (a) to which the excess re-
@@ -55042,8 +51142,6 @@ tion—
                that the employer knew, or exercising rea-
 
 
-      HR 3590 EAS/PP
-                          1953
               sonable diligence would have known, that
               such failure existed.
               ‘‘(C) WAIVER BY SECRETARY  .—In the case
@@ -55070,8 +51168,6 @@ purposes of this section—
           tion 5000A(f)) to the employee and at least one
           other beneficiary, and the benefits provided
 
-      HR 3590 EAS/PP
-                            1954
           under such minimum essential coverage do not
           vary based on whether any individual covered
           under such coverage is the employee or another
@@ -55098,8 +51194,6 @@ purposes of this section—
       riculture (not including food processing), forestry,
       and fishing industries. Such term includes an em-
 
-      HR 3590 EAS/PP
-                           1955
      ployee who is retired from a high-risk profession de-
      scribed in the preceding sentence, if such employee
      satisfied the requirements of such sentence for a pe-
@@ -55126,8 +51220,6 @@ purposes of this section—
           ‘‘(7) LAN SPONSOR  .—The term ‘plan sponsor’
      has the meaning given such term in section 3(16)(B)
 
-      HR 3590 EAS/PP
-                            1956
       of the Employee Retirement Income Security Act of
       1974.
           ‘‘(8) TAXABLE PERIOD  .—The term ‘taxable pe-
@@ -55154,8 +51246,6 @@ section shall apply to taxable years beginning after Decem-
 ber 31, 2012.
 
 
-      HR 3590 EAS/PP
-                           1957
  SEC. 9002. INCLUSION OF COST OF EMPLOYER-SPONSORED
              HEALTH COVERAGE ON W–2.
      (a) IN  GENERAL  .—Section 6051(a) of the Internal
@@ -55182,8 +51272,6 @@ ber 31, 2010.
      (a) HSA S .—Subparagraph (A) of section 223(d)(2) of
 the Internal Revenue Code of 1986 is amended by adding
 at the end the following: ‘‘Such term shall include an
-      HR 3590 EAS/PP
-                         1958
 amount paid for medicine or a drug only if such medicine
 or drug is a prescribed drug (determined without regard
 to whether such drug is available without a prescription)
@@ -55211,8 +51299,6 @@ is insulin.’’.
      (d) FFECTIVE D ATES.—
 
 
-     HR 3590 EAS/PP
-                          1959
           (1) DISTRIBUTIONS FROM SAVINGS ACCOUNTS  .—
      The amendments made by subsections (a) and (b)
      shall apply to amounts paid with respect to taxable
@@ -55239,8 +51325,6 @@ section shall apply to distributions made after December 31,
 Code of 1986 is amended—
 
 
-      HR 3590 EAS/PP
-                          1960
           (1) by redesignating subsections (i) and (j) as
      subsections (j) and (k), respectively, and
           (2) by inserting after subsection (h) the following
@@ -55267,8 +51351,6 @@ the date of the enactment of this subsection, for purposes
 of this section the term ‘person’ includes any corporation
 
 
-      HR 3590 EAS/PP
-                         1961
 that is not an organization exempt from tax under section
 501(a).
      ‘‘(i) EGULATIONS .—The Secretary may prescribe
@@ -55295,8 +51377,6 @@ section shall apply to payments made after December 31,
 tion 501 of the Internal Revenue Code of 1986 (relating to
 exemption from tax on corporations, certain trusts, etc.) is
 
-      HR 3590 EAS/PP
-                           1962
 amended by redesignating subsection (r) as subsection (s)
 and by inserting after subsection (q) the following new sub-
 section:
@@ -55323,8 +51403,6 @@ section:
               facility which is required by a State to be
 
 
-      HR 3590 EAS/PP
-                           1963
                licensed, registered, or similarly recognized
                as a hospital, and
                    ‘‘(ii) any other organization which the
@@ -55351,8 +51429,6 @@ section:
                    ‘‘(i) has conducted a community health
                needs assessment which meets the require-
 
-      HR 3590 EAS/PP
-                           1964
                ments of subparagraph (B) in such taxable
                year or in either of the 2 taxable years im-
                mediately preceding such taxable year, and
@@ -55379,8 +51455,6 @@ section:
 
 
 
-      HR 3590 EAS/PP
-                            1965
                     ‘‘(i) eligibility criteria for financial as-
                sistance, and whether such assistance in-
                cludes free or discounted care,
@@ -55407,8 +51481,6 @@ section:
           assistance policy described in subparagraph (A).
 
 
-      HR 3590 EAS/PP
-                            1966
           ‘‘(5) LIMITATION ON CHARGES    .—An organiza-
       tion meets the requirements of this paragraph if the
       organization—
@@ -55435,8 +51507,6 @@ section:
       stitutes reasonable efforts to determine the eligibility
 
 
-      HR 3590 EAS/PP
-                         1967
      of a patient under a financial assistance policy for
      purposes of paragraph (6).’’.
      (b) EXCISET AX FOR FAILURES T O MEET H OSPITAL
@@ -55463,8 +51533,6 @@ the community benefit activities of each hospital organiza-
 tion to which section 501(r) of the Internal Revenue Code
 of 1986 (as added by this section) applies.
      (d) DDITIONAL REPORTING R EQUIREMENTS .—
-     HR 3590 EAS/PP
-                           1968
           (1) C OMMUNITY HEALTH NEEDS ASSESSMENTS
      AND   AUDITED    FINANCIAL  STATEMENTS   .—Section
      6033(b) of the Internal Revenue Code of 1986 (relat-
@@ -55491,8 +51559,6 @@ of 1986 (as added by this section) applies.
           nancial statement).’’.
 
 
-      HR 3590 EAS/PP
-                           1969
           (2) TAXES .—Section 6033(b)(10) of such Code is
      amended by striking ‘‘and’’ at the end of subpara-
      graph (B), by inserting ‘‘and’’ at the end of subpara-
@@ -55519,8 +51585,6 @@ of 1986 (as added by this section) applies.
                ernment programs, and
 
 
-      HR 3590 EAS/PP
-                          1970
                    (iv) unreimbursed costs for services
               provided with respect to non-means tested
               government programs.
@@ -55547,8 +51611,6 @@ of 1986 (as added by this section) applies.
           (1) N GENERAL  .—Except as provided in para-
      graphs (2) and (3), the amendments made by this sec-
 
-      HR 3590 EAS/PP
-                          1971
      tion shall apply to taxable years beginning after the
      date of the enactment of this Act.
           (2) COMMUNITY HEALTH NEEDS ASSESSMENT     .—
@@ -55575,8 +51637,6 @@ of 1986 (as added by this section) applies.
      with respect to any calendar year the date determined
 
 
-      HR 3590 EAS/PP
-                              1972
       by the Secretary, but in no event later than Sep-
       tember 30 of such calendar year.
       (b) D ETERMINATION OF    FEE  AMOUNT  .—
@@ -55610,8 +51670,6 @@ of 1986 (as added by this section) applies.
         More than $400,000,000 ................100 percent..................
 
 
-      HR 3590 EAS/PP
-                          1973
           (3) SECRETARIAL   DETERMINATION  .—The Sec-
      retary of the Treasury shall calculate the amount of
      each covered entity’s fee for any calendar year under
@@ -55638,8 +51696,6 @@ under subsection (a).
           under subsection (a) or (b) of section 52 of the
           Internal Revenue Code of 1986 or subsection (m)
 
-      HR 3590 EAS/PP
-                           1974
           or (o) of section 414 of such Code shall be treated
           as a single covered entity.
               (B) I  NCLUSION  OF   FOREIGN  CORPORA   -
@@ -55666,8 +51722,6 @@ poses of this section—
               351(a) of the Public Health Service Act (42
               U.S.C. 262(a)).
 
-      HR 3590 EAS/PP
-                           1975
                (B) PRESCRIPTION DRUG  .—For purposes of
           subparagraph (A)(i), the term ‘‘prescription
           drug’’ means any drug which is subject to section
@@ -55694,8 +51748,6 @@ poses of this section—
                (C) the Medicaid program under title XIX
           of the Social Security Act,
 
-      HR 3590 EAS/PP
-                           1976
                (D) any program under which branded pre-
           scription drugs are procured by the Department
           of Veterans Affairs,
@@ -55722,8 +51774,6 @@ Secretary of Defense shall report to the Secretary of the
 Treasury, in such manner as the Secretary of the Treasury
 prescribes, the total branded prescription drug sales for each
 
-      HR 3590 EAS/PP
-                           1977
 covered entity with respect to each specified government
 program under such Secretary’s jurisdiction using the fol-
 lowing methodology:
@@ -55750,8 +51800,6 @@ lowing methodology:
      tion drug of the covered entity covered by the Medi-
 
 
-      HR 3590 EAS/PP
-                           1978
       care Part B program under section 1862(a) of the So-
       cial Security Act, the product of—
                (A) the per-unit average sales price (as de-
@@ -55778,8 +51826,6 @@ lowing methodology:
           tion drug dispensed to Medicaid beneficiaries,
           minus any per-unit rebate paid by the covered
 
-      HR 3590 EAS/PP
-                           1979
           entity under section 1927 of the Social Security
           Act and any State supplemental rebate, and
                (B) the number of units of the branded pre-
@@ -55806,8 +51852,6 @@ lowing methodology:
                any per-unit rebate paid by the covered en-
                tity, and
 
-      HR 3590 EAS/PP
-                           1980
                    (ii) the number of units of the branded
               prescription drug dispensed under such pro-
               gram.
@@ -55834,8 +51878,6 @@ of 2009’’ after ‘‘this part’’.
      subsection (b).
 
 
-      HR 3590 EAS/PP
-                            1981
            (2) ANNUAL PAYMENT DATE      .—For purposes of
       this section, the term ‘‘annual payment date’’ means
       with respect to any calendar year the date determined
@@ -55864,8 +51906,6 @@ of 2009’’ after ‘‘this part’’.
         Not more than $5,000,000 ............0 percent.....................
         More than $5,000,000 but not more tha50 percent
          $25,000,000.
-      HR 3590 EAS/PP
-                            1982
       With respect to a covered entity’s aggrThe percentage of gross
       ceipts from medical device sales duringreceipts taken into ac-
                    year that are:                 count is:
@@ -55894,8 +51934,6 @@ of 2009’’ after ‘‘this part’’.
            as a single covered entity.
                (B) I  NCLUSION   OF  FOREIGN    CORPORA  -
            TIONS.—For purposes of subparagraph (A), in
-      HR 3590 EAS/PP
-                           1983
           applying subsections (a) and (b) of section 52 of
           such Code to this section, section 1563 of such
           Code shall be applied without regard to sub-
@@ -55922,8 +51960,6 @@ section—
      graph (1), the term ‘‘medical device’’ means any de-
      vice (as defined in section 201(h) of the Federal Food,
 
-      HR 3590 EAS/PP
-                           1984
      Drug, and Cosmetic Act (21 U.S.C. 321(h))) intended
      for humans.
      (e) TAX T REATMENT OF   FEES .—The fees imposed by
@@ -55950,8 +51986,6 @@ this section—
           sion of time for filing), unless it is shown that
           such failure is due to reasonable cause, there
 
-      HR 3590 EAS/PP
-                            1985
           shall be paid by the covered entity failing to file
           such report, an amount equal to—
                     (i) $10,000, plus
@@ -55978,8 +52012,6 @@ term ‘‘Secretary’’ means the Secretary of the Treasury or
 the Secretary’s delegate.
 
 
-      HR 3590 EAS/PP
-                          1986
      (h) GUIDANCE .—The Secretary shall publish guidance
 necessary to carry out the purposes of this section, including
 identification of medical devices described in subsection
@@ -56006,8 +52038,6 @@ apply to any medical device sales after December 31, 2008.
           (1) N GENERAL  .—With respect to each covered
      entity, the fee under this section for any calendar
 
-      HR 3590 EAS/PP
-                           1987
      year shall be equal to an amount that bears the same
      ratio to $6,700,000,000 as—
                (A) the sum of—
@@ -56034,8 +52064,6 @@ apply to any medical device sales after December 31, 2008.
                (A) N ET  PREMIUMS   WRITTEN  .—The net
           premiums written with respect to health insur-
 
-      HR 3590 EAS/PP
-                                1988
              ance for any United States health risk that are
              taken into account during any calendar year
              with respect to any covered entity shall be deter-
@@ -56072,8 +52100,6 @@ apply to any medical device sales after December 31, 2008.
        mine such covered entity’s net premiums written with
 
        respect to any United States health risk and third
-       HR 3590 EAS/PP
-                           1989
      party administration agreement fees on the basis of
      reports submitted by the covered entity under sub-
      section (g) and through the use of any other source of
@@ -56100,8 +52126,6 @@ apply to any medical device sales after December 31, 2008.
           as a single covered entity (or employer for pur-
           poses of paragraph (2)).
 
-      HR 3590 EAS/PP
-                          1990
               (B) I NCLUSION  OF  FOREIGN   CORPORA  -
           TIONS.—For purposes of subparagraph (A), in
           applying subsections (a) and (b) of section 52 of
@@ -56128,8 +52152,6 @@ ployees.
      (f) TAX TREATMENT OF   FEES .—The fees imposed by
 this section—
 
-      HR 3590 EAS/PP
-                           1991
           (1) for purposes of subtitle F of the Internal Rev-
      enue Code of 1986, shall be treated as excise taxes
      with respect to which only civil actions for refund
@@ -56156,8 +52178,6 @@ this section—
           shall be paid by the covered entity failing to file
           such report, an amount equal to—
 
-      HR 3590 EAS/PP
-                           1992
                    (i) $10,000, plus
                    (ii) the lesser of—
                         (I) an amount equal to $1,000,
@@ -56184,8 +52204,6 @@ section—
      gate.
 
 
-      HR 3590 EAS/PP
-                           1993
           (2) UNITED STATES  .—The term ‘‘United States’’
       means the several States, the District of Columbia, the
       Commonwealth of Puerto Rico, and the possessions of
@@ -56212,8 +52230,6 @@ of sections 9008, 9009, and 9010 on—
       (b) REPORT .—The Secretary of Veterans Affairs shall
 report the results of the study under subsection (a) to the
 
-      HR 3590 EAS/PP
-                          1994
 Committee on Ways and Means of the House of Representa-
 tives and to the Committee on Finance of the Senate not
 later than December 31, 2012.
@@ -56241,8 +52257,6 @@ cember 31, 2012, and ending before January 1, 2017, sub-
 section (a) shall be applied with respect to a taxpayer by
 substituting ‘7.5 percent’ for ‘10 percent’ if such taxpayer
 
-      HR 3590 EAS/PP
-                           1995
 or such taxpayer’s spouse has attained age 65 before the
 close of such taxable year.’’.
      (c) C ONFORMING  A MENDMENT  .—Section 56(b)(1)(B)
@@ -56269,8 +52283,6 @@ following new subparagraph:
               to services performed by an applicable indi-
               vidual during such taxable year, to the ex-
 
-      HR 3590 EAS/PP
-                            1996
                tent that the amount of such remuneration
                exceeds $500,000, or
                     ‘‘(ii) in the case of deferred deduction
@@ -56297,8 +52309,6 @@ following new subparagraph:
                     the matter preceding subclause (I)).
 
 
-      HR 3590 EAS/PP
-                           1997
                ‘‘(B) DISQUALIFIED TAXABLE YEAR    .—For
           purposes of this paragraph, the term ‘disquali-
           fied taxable year’ means, with respect to any em-
@@ -56325,8 +52335,6 @@ following new subparagraph:
                    not less than 25 percent of the gross
                    premiums received from providing
 
-      HR 3590 EAS/PP
-                            1998
                     health insurance coverage (as defined
                     in section 9832(b)(1)) is from min-
                     imum essential coverage (as defined in
@@ -56353,8 +52361,6 @@ following new subparagraph:
           or not during the taxable year). Such term shall
           not include any deferred deduction remuneration
 
-      HR 3590 EAS/PP
-                            1999
           with respect to services performed during the dis-
           qualified taxable year.
                ‘‘(E) D EFERRED   DEDUCTION   REMUNERA   -
@@ -56381,8 +52387,6 @@ following new subparagraph:
           (4) shall apply for purposes of this paragraph.
 
 
-      HR 3590 EAS/PP
-                           2000
                ‘‘(H) REGULATORY AUTHORITY    .—The Sec-
           retary may prescribe such guidance, rules, or
           regulations as are necessary to carry out the
@@ -56409,8 +52413,6 @@ date.
           ‘‘(2) DDITIONAL TAX  .—In addition to the tax
      imposed by paragraph (1) and the preceding sub-
 
-      HR 3590 EAS/PP
-                           2001
      section, there is hereby imposed on every taxpayer
      (other than a corporation, estate, or trust) a tax equal
      to 0.5 percent of wages which are received with re-
@@ -56437,8 +52439,6 @@ date.
           ‘‘(3) AX PAID BY RECIPIENT  .—If an employer,
      in violation of this chapter, fails to deduct and with-
 
-      HR 3590 EAS/PP
-                           2002
       hold the tax imposed by section 3101(b)(2) and there-
       after the tax is paid by the employee, the tax so re-
       quired to be deducted and withheld shall not be col-
@@ -56465,8 +52465,6 @@ date.
           is in excess of—
 
 
-      HR 3590 EAS/PP
-                           2003
                    ‘‘(i) in the case of a joint return,
                $250,000, and
                    ‘‘(ii) in any other case, $200,000.
@@ -56493,8 +52491,6 @@ and taxable years beginning, after December 31, 2012.
 
 
 
-      HR 3590 EAS/PP
-                          2004
  SEC. 9016. MODIFICATION OF SECTION 833 TREATMENT OF
              CERTAIN HEALTH ORGANIZATIONS.
      (a) N G ENERAL .—Subsection (c) of section 833 of the
@@ -56521,8 +52517,6 @@ ing at the end the following new chapter:
              MEDICAL PROCEDURES
     ‘‘Sec. 5000B. Imposition of tax on elective cosmetic medical procedures.
 
-      HR 3590 EAS/PP
-                          2005
  ‘‘SEC. 5000B. IMPOSITION OF TAX ON ELECTIVE COSMETIC
              MEDICAL PROCEDURES.
      ‘‘(a) N G ENERAL .—There is hereby imposed on any
@@ -56549,8 +52543,6 @@ dure which—
      payment for procedures on which a tax is imposed
      under subsection (a) shall collect the amount of the
      tax from the individual on whom the procedure is
-      HR 3590 EAS/PP
-                           2006
       performed and remit such tax quarterly to the Sec-
       retary at such time and in such manner as provided
       by the Secretary.
@@ -56579,8 +52571,6 @@ serting after section 139C the following new section:
 
 
 
-      HR 3590 EAS/PP
-                          2007
  ‘‘SEC. 139D. INDIAN HEALTH CARE BENEFITS.
      ‘‘(a) GENERAL  RULE .—Except as otherwise provided
 in this section, gross income does not include the value of
@@ -56607,8 +52597,6 @@ health care benefit’ means—
      a spouse or dependent of such a member, and
           ‘‘(4) any other medical care provided by an In-
      dian tribe or tribal organization that supplements, re-
-      HR 3590 EAS/PP
-                            2008
       places, or substitutes for a program or service relating
       to medical care provided by the Federal government
       to Indian tribes or members of such a tribe.
@@ -56635,8 +52623,6 @@ health care benefit which is not includible in gross income
 of the beneficiary of such benefit under any other provision
 of this chapter, or to the amount of any such benefit for
 
-      HR 3590 EAS/PP
-                           2009
 which a deduction is allowed to such beneficiary under any
 other provision of this chapter.’’.
       (b) LERICAL  A MENDMENT  .—The table of sections for
@@ -56663,8 +52649,6 @@ this Act, is amended by redesignating subsections (j) and
 (k) as subsections (k) and (l), respectively, and by inserting
 after subsection (i) the following new subsection:
 
-      HR 3590 EAS/PP
-                          2010
      ‘‘(j) IMPLE  C AFETERIA  PLANS FOR   SMALL  B USI-
  NESSES .—
           ‘‘(1) N GENERAL .—An eligible employer main-
@@ -56691,8 +52675,6 @@ after subsection (i) the following new subsection:
           each qualified employee in an amount equal to—
 
 
-      HR 3590 EAS/PP
-                            2011
                     ‘‘(i) a uniform percentage (not less
                than 2 percent) of the employee’s compensa-
                tion for the plan year, or
@@ -56719,8 +52701,6 @@ after subsection (i) the following new subsection:
           making contributions to provide qualified bene-
 
 
-      HR 3590 EAS/PP
-                           2012
           fits under the plan in addition to contributions
           required under subparagraph (A).
                ‘‘(D) DEFINITIONS .—For purposes of this
@@ -56747,8 +52727,6 @@ after subsection (i) the following new subsection:
                by section 416(i).
 
 
-      HR 3590 EAS/PP
-                           2013
           ‘‘(4) MINIMUM ELIGIBILITY AND PARTICIPATION
      REQUIREMENTS   .—
                ‘‘(A) N  GENERAL  .—The requirements of
@@ -56775,8 +52753,6 @@ after subsection (i) the following new subsection:
                be a collective bargaining agreement if there
                is evidence that the benefits covered under
 
-      HR 3590 EAS/PP
-                            2014
                the cafeteria plan were the subject of good
                faith bargaining between employee rep-
                resentatives and the employer, or
@@ -56803,8 +52779,6 @@ after subsection (i) the following new subsection:
           it is reasonably expected such employer will em-
           ploy on business days in the current year.
 
-      HR 3590 EAS/PP
-                           2015
                ‘‘(C) ROWING EMPLOYERS RETAIN TREAT     -
           MENT AS SMALL EMPLOYER   .—
                    ‘‘(i)N GENERAL  .—If—
@@ -56831,8 +52805,6 @@ after subsection (i) the following new subsection:
                ‘‘(D) PECIAL RULES .—
 
 
-      HR 3590 EAS/PP
-                           2016
                    ‘‘(i) PREDECESSORS  .—Any reference
                in this paragraph to an employer shall in-
                clude a reference to any predecessor of such
@@ -56859,8 +52831,6 @@ section shall apply to years beginning after December 31,
 A of chapter 1 of the Internal Revenue Code of 1986 is
 
 
-      HR 3590 EAS/PP
-                            2017
 amended by inserting after section 48C the following new
 section:
  ‘‘SEC. 48D. QUALIFYING THERAPEUTIC DISCOVERY
@@ -56887,8 +52857,6 @@ fying therapeutic discovery project of an eligible taxpayer.
       therapeutic discovery project shall not take into ac-
       count any cost—
 
-      HR 3590 EAS/PP
-                            2018
                ‘‘(A) for remuneration for an employee de-
           scribed in section 162(m)(3),
                ‘‘(B) for interest expenses,
@@ -56915,8 +52883,6 @@ fying therapeutic discovery project of an eligible taxpayer.
 
 
 
-      HR 3590 EAS/PP
-                           2019
           ‘‘(1) Q UALIFYING   THERAPEUTIC    DISCOVERY
       PROJECT .—The term ‘qualifying therapeutic discovery
       project’ means a project which is designed—
@@ -56943,8 +52909,6 @@ fying therapeutic discovery project of an eligible taxpayer.
                ‘‘(B) AGGREGATION    RULES .—All persons
           treated as a single employer under subsection (a)
 
-      HR 3590 EAS/PP
-                          2020
           or (b) of section 52, or subsection (m) or (o) of
           section 414, shall be so treated for purposes of
           this paragraph.
@@ -56971,8 +52935,6 @@ fying therapeutic discovery project of an eligible taxpayer.
               ‘‘(B) L IMITATION.—The total amount of
           credits that may be allocated under the program
 
-      HR 3590 EAS/PP
-                           2021
           shall not exceed $1,000,000,000 for the 2-year pe-
           riod beginning with 2009.
           ‘‘(2) ERTIFICATION .—
@@ -56999,8 +52961,6 @@ fying therapeutic discovery project of an eligible taxpayer.
                ‘‘(A) shall take into consideration only those
           projects that show reasonable potential—
 
-      HR 3590 EAS/PP
-                            2022
                     ‘‘(i) to result in new therapies—
                          ‘‘(I) to treat areas of unmet med-
                     ical need, or
@@ -57027,8 +52987,6 @@ fying therapeutic discovery project of an eligible taxpayer.
       subsection, publicly disclose the identity of the appli-
 
 
-      HR 3590 EAS/PP
-                           2023
       cant and the amount of the credit with respect to such
       applicant.
       ‘‘(e)PECIAL R ULES .—
@@ -57055,8 +53013,6 @@ fying therapeutic discovery project of an eligible taxpayer.
           not apply to expenses related to property of a
           character subject to an allowance for deprecia-
 
-      HR 3590 EAS/PP
-                          2024
           tion the basis of which is reduced under para-
           graph (1), or which are described in section
           280C(g).
@@ -57083,8 +53039,6 @@ of the Patient Protection and Affordable Care Act of 2009—
           ‘‘(1) ENIAL OF CREDIT .—No credit shall be de-
      termined under this section with respect to such in-
 
-      HR 3590 EAS/PP
-                            2025
       vestment for the taxable year in which such grant is
       made or any subsequent taxable year.
           ‘‘(2) RECAPTURE OF CREDITS FOR PROGRESS
@@ -57111,8 +53065,6 @@ of the Patient Protection and Affordable Care Act of 2009—
 
 
 
-      HR 3590 EAS/PP
-                           2026
      (b) INCLUSION AS  P ART OF  INVESTMENT  C REDIT.—
 Section 46 of the Internal Revenue Code of 1986 is amend-
 ed—
@@ -57139,8 +53091,6 @@ ed—
               peutic discovery project under such section
               48D.’’.
 
-      HR 3590 EAS/PP
-                           2027
           (2) Section 280C of such Code is amended by
      adding at the end the following new subsection:
      ‘‘(g) UALIFYING  THERAPEUTIC   DISCOVERY  PROJECT
@@ -57167,8 +53117,6 @@ ed—
      IZES RATHER THAN DEDUCTS EXPENSES        .—In the
      case of expenses described in paragraph (1)(A) taken
 
-      HR 3590 EAS/PP
-                          2028
      into account in determining the credit under section
      48D for the taxable year, if—
               ‘‘(A) the amount of the portion of the credit
@@ -57195,8 +53143,6 @@ item:
      retary of the Treasury shall, subject to the require-
      ments of this subsection, provide a grant to each per-
      son who makes a qualified investment in a qualifying
-      HR 3590 EAS/PP
-                           2029
      therapeutic discovery project in the amount of 50 per-
      cent of such investment. No grant shall be made under
      this subsection with respect to any investment unless
@@ -57223,8 +53169,6 @@ item:
                (C) INFORMATION TO BE SUBMITTED    .—An
           application for a grant under paragraph (1)
 
-      HR 3590 EAS/PP
-                           2030
           shall include such information and be in such
           form as the Secretary may require to state the
           amount of the credit allowable (but for the re-
@@ -57251,8 +53195,6 @@ item:
       means a qualified investment that is certified under
 
 
-      HR 3590 EAS/PP
-                           2031
      section 48D(d) of the Internal Revenue Code of 1986
      for purposes of the credit under such section 48D.
           (5) APPLICATION OF CERTAIN RULES  .—
@@ -57279,8 +53221,6 @@ item:
                ED AS RETURN INFORMATION   .—In no event
                shall the amount of a grant made under
 
-      HR 3590 EAS/PP
-                           2032
                paragraph (1), the identity of the person to
                whom such grant was made, or a descrip-
                tion of the investment with respect to which
@@ -57307,8 +53247,6 @@ item:
       described in subparagraph (D), partners and other
       holders of any equity or profits interest shall provide
 
-      HR 3590 EAS/PP
-                           2033
       to such partnership or entity such information as the
       Secretary of the Treasury may require to carry out
       the purposes of this paragraph.
@@ -57335,8 +53273,6 @@ item:
           (12) PROTECTING MIDDLE CLASS FAMILIES FROM
       TAX INCREASES .—It is the sense of the Senate that the
 
-      HR 3590 EAS/PP
-                        2034
      Senate should reject any procedural maneuver that
      would raise taxes on middle class families, such as a
      motion to commit the pending legislation to the Com-
@@ -57363,8 +53299,6 @@ as follows:
 
 
 
-     HR 3590 EAS/PP
-                           2035
           ‘‘(1) N GENERAL  .—A group health plan and a
       health insurance issuer offering group or individual
       health insurance coverage may not establish—
@@ -57391,8 +53325,6 @@ as follows:
 not be construed to prevent a group health plan or health
 insurance coverage from placing annual or lifetime per ben-
 
-      HR 3590 EAS/PP
-                             2036
 eficiary limits on specific covered benefits that are not es-
 sential health benefits under section 1302(b) of the Patient
 Protection and Affordable Care Act, to the extent that such
@@ -57419,8 +53351,6 @@ such information available to the public.’’.
 added by section 1001(5) of this Act, is amended to read
 as follows:
 
-      HR 3590 EAS/PP
-                          2037
  ‘‘SEC. 2716. PROHIBITION ON DISCRIMINATION IN FAVOR
              OF HIGHLY COMPENSATED INDIVIDUALS.
      ‘‘(a) N GENERAL .—A group health plan (other than
@@ -57447,8 +53377,6 @@ added by section 1001(5) of this Act, is amended—
  RIGHTS .—
           ‘‘(1) ELLNESS AND PREVENTION PROGRAMS    .—
      A wellness and health promotion activity imple-
-      HR 3590 EAS/PP
-                           2038
      mented under subsection (a)(1)(D) may not require
      the disclosure or collection of any information relat-
      ing to—
@@ -57475,8 +53403,6 @@ added by section 1001(5) of this Act, is amended—
      Care Act or an amendment made by that Act shall
      be construed to authorize or may be used to maintain
 
-      HR 3590 EAS/PP
-                           2039
       records of individual ownership or possession of a
       firearm or ammunition.
           ‘‘(4) LIMITATION ON DETERMINATION OF PRE      -
@@ -57503,8 +53429,6 @@ added by section 1001(5) of this Act, is amended—
           a firearm or ammunition; or
 
 
-      HR 3590 EAS/PP
-                            2040
                ‘‘(B) the lawful use, possession, or storage of
           a firearm or ammunition.’’.
       (f) Section 2718 of the Public Health Service Act, as
@@ -57531,8 +53455,6 @@ erage expends—
       Federal and State taxes and licensing or regulatory
       fees.
 
-      HR 3590 EAS/PP
-                          2041
 The Secretary shall make reports received under this section
 available to the public on the Internet website of the Depart-
 ment of Health and Human Services.
@@ -57559,8 +53481,6 @@ ment of Health and Human Services.
          year (except as provided in subparagraph
          (B)(ii)), is less than—
 
-      HR 3590 EAS/PP
-                           2042
                    ‘‘(i) with respect to a health insurance
                issuer offering coverage in the large group
                market, 85 percent, or such higher percent-
@@ -57587,8 +53507,6 @@ ment of Health and Human Services.
                    scribed in such subparagraph; and
 
 
-      HR 3590 EAS/PP
-                            2043
                         ‘‘(II) the total amount of pre-
                     mium revenue (excluding Federal and
                     State taxes and licensing or regulatory
@@ -57615,8 +53533,6 @@ ment of Health and Human Services.
       services and quality improvements.
 
 
-      HR 3590 EAS/PP
-                            2044
            ‘‘(3) ENFORCEMENT  .—The Secretary shall pro-
       mulgate regulations for enforcing the provisions of
       this section and may provide for appropriate pen-
@@ -57643,8 +53559,6 @@ guidelines developed by the Secretary) a list of the hospital’s
 standard charges for items and services provided by the hos-
 
 
-      HR 3590 EAS/PP
-                           2045
 pital, including for diagnosis-related groups established
 under section 1886(d)(4) of the Social Security Act.’’.
      (g) Section 2719 of the Public Health Service Act, as
@@ -57671,8 +53585,6 @@ as follows:
                ‘‘(C) allow an enrollee to review their file,
           to present evidence and testimony as part of the
 
-      HR 3590 EAS/PP
-                           2046
           appeals process, and to receive continued cov-
           erage pending the outcome of the appeals process.
           ‘‘(2) E STABLISHED   PROCESSES  .—To comply
@@ -57699,8 +53611,6 @@ as follows:
           standards established by the Secretary of Health
           and Human Services for such issuers.
 
-      HR 3590 EAS/PP
-                           2047
       ‘‘(b) XTERNAL   REVIEW .—A group health plan and
 a health insurance issuer offering group or individual
 health insurance coverage—
@@ -57727,8 +53637,6 @@ health insurance issuer, in operation as of the date of enact-
 ment of this section, to be in compliance with the applicable
 
 
-      HR 3590 EAS/PP
-                          2048
 process established under subsection (b), as determined ap-
 propriate by the Secretary.’’.
      (h) Subpart II of part A of title XVIII of the Public
@@ -57755,8 +53663,6 @@ provider who is available to accept such individual.
           ization determination;
 
 
-      HR 3590 EAS/PP
-                            2049
                ‘‘(B) whether the health care provider fur-
           nishing such services is a participating provider
           with respect to such services;
@@ -57783,8 +53689,6 @@ provider who is available to accept such individual.
                surance rate) is the same requirement that
 
 
-      HR 3590 EAS/PP
-                           2050
                would apply if such services were provided
                in-network;
                ‘‘(D) without regard to any other term or
@@ -57811,8 +53715,6 @@ provider who is available to accept such individual.
           emergency medical condition—
 
 
-      HR 3590 EAS/PP
-                           2051
                    ‘‘(i) a medical screening examination
                (as required under section 1867 of the So-
                cial Security Act) that is within the capa-
@@ -57839,8 +53741,6 @@ provider who is available to accept such individual.
       the group or individual market, if the plan or issuer
       requires or provides for the designation of a partici-
 
-      HR 3590 EAS/PP
-                           2052
      pating primary care provider for the child, the plan
      or issuer shall permit such person to designate a phy-
      sician (allopathic or osteopathic) who specializes in
@@ -57867,8 +53767,6 @@ provider who is available to accept such individual.
           care provided by a participating health care pro-
           fessional who specializes in obstetrics or gyne-
 
-      HR 3590 EAS/PP
-                           2053
           cology. Such professional shall agree to otherwise
           adhere to such plan’s or issuer’s policies and
           procedures, including procedures regarding refer-
@@ -57895,8 +53793,6 @@ provider who is available to accept such individual.
 
 
 
-      HR 3590 EAS/PP
-                            2054
                ‘‘(B) requires the designation by a partici-
           pant, beneficiary, or enrollee of a participating
           primary care provider.
@@ -57923,8 +53819,6 @@ added by section 1003 of this Act, is amended—
           subsection (d)) at academic or other nonprofit
           institutions to collect medical reimbursement in-
 
-      HR 3590 EAS/PP
-                           2055
           formation from health insurance issuers, to ana-
           lyze and organize such information, and to make
           such information available to such issuers, health
@@ -57951,8 +53845,6 @@ added by section 1003 of this Act, is amended—
           area charge for particular medical services; and
 
 
-      HR 3590 EAS/PP
-                            2056
                ‘‘(E) regularly publish information con-
           cerning the statistical methodologies used by the
           center to analyze health charge data and make
@@ -57979,8 +53871,6 @@ added by section 1003 of this Act, is amended—
       ‘‘group benefits plan providing health benefits’’; and
 
 
-      HR 3590 EAS/PP
-                            2057
           (2) in clause (i)(I), by inserting ‘‘or any agency
       or instrumentality of any of the foregoing’’ before the
       closed parenthetical.
@@ -58007,8 +53897,6 @@ added by section 1003 of this Act, is amended—
                ‘‘(C) Coverage under title XXI of the Social
           Security Act.
 
-      HR 3590 EAS/PP
-                            2058
                ‘‘(D) A State health benefits high risk pool,
            to the extent that such high risk pool is offered
            in such State; and
@@ -58035,8 +53923,6 @@ Health Service Act, as added by section 1201(4) of this Act,
 is amended by inserting after section 2708, the following:
 
 
-      HR 3590 EAS/PP
-                           2059
  ‘‘SEC. 2709. COVERAGE FOR INDIVIDUALS PARTICIPATING
               IN APPROVED CLINICAL TRIALS.
       ‘‘(a)OVERAGE  .—
@@ -58063,8 +53949,6 @@ is amended by inserting after section 2708, the following:
           (or coverage) that is typically covered for a
           qualified individual who is not enrolled in a
           clinical trial.
-      HR 3590 EAS/PP
-                            2060
                ‘‘(B) E XCLUSION .—For purposes of para-
           graph (1)(B), routine patient costs does not in-
           clude—
@@ -58091,8 +53975,6 @@ is amended by inserting after section 2708, the following:
       a qualified individual participating in an approved
 
 
-      HR 3590 EAS/PP
-                            2061
       clinical trial that is conducted outside the State in
       which the qualified individual resides.
       ‘‘(b) UALIFIED INDIVIDUAL  D EFINED .—For purposes
@@ -58119,8 +54001,6 @@ who meets the following conditions:
           (1).
 
 
-      HR 3590 EAS/PP
-                           2062
      ‘‘(c) IMITATIONS ON  C OVERAGE .—This section shall
 not be construed to require a group health plan, or a health
 insurance issuer offering group or individual health insur-
@@ -58147,8 +54027,6 @@ otherwise provided under the plan (or coverage).
               search and Quality.
 
 
-      HR 3590 EAS/PP
-                            2063
                     ‘‘(iv) The Centers for Medicare & Med-
                icaid Services.
                     ‘‘(v) cooperative group or center of any
@@ -58175,8 +54053,6 @@ otherwise provided under the plan (or coverage).
           ‘‘(2) CONDITIONS FOR DEPARTMENTS    .—The con-
       ditions described in this paragraph, for a study or in-
 
-      HR 3590 EAS/PP
-                            2064
       vestigation conducted by a Department, are that the
       study or investigation has been reviewed and ap-
       proved through a system of peer review that the Sec-
@@ -58203,8 +54079,6 @@ gram under such chapter.
 sion of this Act, nothing in this section shall preempt State
 laws that require a clinical trials policy for State regulated
 
-      HR 3590 EAS/PP
-                            2065
 health insurance plans that is in addition to the policy re-
 quired under this section.’’.
       (d) Section 1251(a) of this Act is amended—
@@ -58231,8 +54105,6 @@ the period the following: ‘‘, except that—
       (f) Subtitle C of title I of this Act is amended—
 
 
-      HR 3590 EAS/PP
-                            2066
           (1) by redesignating section 1253 as section
       1255; and
           (2) by inserting after section 1252, the following:
@@ -58259,8 +54131,6 @@ and self-insured group health plan markets to—
       benefits, financial solvency, capital reserve levels, and
       the risks of becoming insolvent; and
 
-      HR 3590 EAS/PP
-                            2067
           ‘‘(2) determine the extent to which new insur-
       ance market reforms are likely to cause adverse selec-
       tion in the large group market or to encourage small
@@ -58287,8 +54157,6 @@ and analyze—
 of enactment of this Act, the Secretary shall submit to the
 
 
-      HR 3590 EAS/PP
-                            2068
 appropriate committees of Congress a report concerning the
 results of the study conducted under subsection (a).’’.
  SEC. 10104. AMENDMENTS TO SUBTITLE D.
@@ -58315,8 +54183,6 @@ paragraph (2) and inserting the following:
       qualified health plan, including a multi-State quali-
       fied health plan, may as appropriate vary premiums
 
-      HR 3590 EAS/PP
-                           2069
      by rating area (as defined in section 2701(a)(2) of the
      Public Health Service Act).’’.
      (b) Section 1302 of this Act is amended—
@@ -58343,8 +54209,6 @@ lows:
      enacts a law to provide for such prohibition.
 
 
-      HR 3590 EAS/PP
-                          2070
           ‘‘(2) ERMINATION OF OPT OUT  .—A State may
      repeal a law described in paragraph (1) and provide
      for the offering of such services through the Exchange.
@@ -58371,8 +54235,6 @@ lows:
               ‘‘(B) BORTION SERVICES .—
 
 
-      HR 3590 EAS/PP
-                           2071
                    ‘‘(i) ABORTIONS FOR WHICH PUBLIC
                FUNDING IS PROHIBITED  .—The services de-
                scribed in this clause are abortions for
@@ -58399,8 +54261,6 @@ lows:
           not use any amount attributable to any of the
 
 
-      HR 3590 EAS/PP
-                            2072
           following for purposes of paying for such serv-
           ices:
                     ‘‘(i) The credit under section 36B of
@@ -58427,8 +54287,6 @@ lows:
                     by the enrollee for coverage under the
                     plan of services other than services de-
 
-      HR 3590 EAS/PP
-                           2073
                    scribed in paragraph (1)(B)(i) (after
                    reduction for credits and cost-sharing
                    reductions described in subparagraph
@@ -58455,8 +54313,6 @@ lows:
                applies shall deposit—
 
 
-      HR 3590 EAS/PP
-                            2074
                         ‘‘(I) all payments described in
                     subparagraph (B)(i)(I) into a separate
                     account that consists solely of such
@@ -58483,8 +54339,6 @@ lows:
                     impact on overall costs of the inclusion
                     of such coverage, but may not take into
 
-      HR 3590 EAS/PP
-                           2075
                    account any cost reduction estimated
                    to result from such services, including
                    prenatal care, delivery, or postnatal
@@ -58511,8 +54365,6 @@ lows:
                    ‘‘(ii) C LARIFICATION .—Nothing in
                clause (i) shall prohibit the right of an indi-
 
-      HR 3590 EAS/PP
-                            2076
                vidual or health plan to appeal such action
                in courts of competent jurisdiction.
           ‘‘(3) RULES RELATING TO NOTICE  .—
@@ -58539,8 +54391,6 @@ lows:
       vide coverage of, or refer for abortions
 
 
-      HR 3590 EAS/PP
-                          2077
      ‘‘(c) PPLICATION OF STATE AND  FEDERAL  LAWS  RE-
  GARDING A BORTION.—
           ‘‘(1) O PREEMPTION OF STATE LAWS REGARD    -
@@ -58567,8 +54417,6 @@ lows:
           ‘‘(3) O EFFECT ON FEDERAL CIVIL RIGHTS
      LAW .—Nothing in this subsection shall alter the rights
 
-      HR 3590 EAS/PP
-                          2078
      and obligations of employees and employers under
      title VII of the Civil Rights Act of 1964.
      ‘‘(d) PPLICATION OF EMERGENCY  S ERVICES LAWS .—
@@ -58595,8 +54443,6 @@ garding health, medical, and scientific matters.’’.
                   described in subclause (I) directly to
 
 
-      HR 3590 EAS/PP
-                            2079
                     the qualified health plan in which such
                     individual is enrolled;
                to defray the cost of any additional benefits
@@ -58623,8 +54469,6 @@ garding health, medical, and scientific matters.’’.
                that are denied.
                     ‘‘(vi) Data on rating practices.
 
-      HR 3590 EAS/PP
-                           2080
                    ‘‘(vii) Information on cost-sharing and
                payments with respect to any out-of-net-
                work coverage.
@@ -58651,8 +54495,6 @@ garding health, medical, and scientific matters.’’.
           (including deductibles, copayments, and coinsur-
           ance) under the individual’s plan or coverage
 
-      HR 3590 EAS/PP
-                           2081
           that the individual would be responsible for pay-
           ing with respect to the furnishing of a specific
           item or service by a participating provider in a
@@ -58679,8 +54521,6 @@ garding health, medical, and scientific matters.’’.
           duce health and health care disparities, includ-
           ing through the use of language services, commu-
 
-      HR 3590 EAS/PP
-                            2082
           nity outreach, and cultural competency
           trainings.’’.
       (h) Section 1311(i)(2)((B) of this Act is amended by
@@ -58707,8 +54547,6 @@ lowing:
       transactions as alleged in the action or claim were
       publicly disclosed—
 
-      HR 3590 EAS/PP
-                            2083
                ‘‘(i) in a Federal criminal, civil, or admin-
           istrative hearing in which the Government or its
           agent is a party;
@@ -58735,8 +54573,6 @@ lowing:
           (2) by redesignating paragraph (4) as para-
       graph (5); and
 
-      HR 3590 EAS/PP
-                           2084
           (3) by inserting after paragraph (3) the fol-
       lowing:
           ‘‘(4) a survey of the cost and affordability of
@@ -58763,8 +54599,6 @@ lowing:
       such grants shall be repaid within 15 years, taking
       into consideration any appropriate State reserve re-
 
-      HR 3590 EAS/PP
-                            2085
       quirements, solvency regulations, and requisite sur-
       plus note arrangements that must be constructed in a
       State to provide for such repayment prior to award-
@@ -58791,8 +54625,6 @@ subsection (b).
       (q) Part IV of subtitle D of title I of this Act is amend-
 ed by adding at the end the following:
 
-      HR 3590 EAS/PP
-                           2086
  ‘‘SEC. 1334. MULTI-STATE PLANS.
      ‘‘(a) VERSIGHT BY THE  O FFICE OF PERSONNEL  M AN -
  AGEMENT .—
@@ -58819,8 +54651,6 @@ ed by adding at the end the following:
      coverage provided for under section 2701(a)(1)(A)(i)
      of the Public Health Service Act.
 
-      HR 3590 EAS/PP
-                            2087
           ‘‘(3) NON -PROFIT ENTITIES .—In entering into
       contracts under paragraph (1), the Director shall en-
       sure that at least one contract is entered into with a
@@ -58847,8 +54677,6 @@ ed by adding at the end the following:
           ‘‘(6) ASSURED AVAILABILITY OF VARIED COV      -
       ERAGE .—In entering into contracts under this sub-
 
-      HR 3590 EAS/PP
-                            2088
       section, the Director shall ensure that with respect to
       multi-State qualified health plans offered in an Ex-
       change, there is at least one such plan that does not
@@ -58875,8 +54703,6 @@ such issuer—
       this title;
 
 
-      HR 3590 EAS/PP
-                          2089
           ‘‘(3) otherwise complies with the minimum
      standards prescribed for carriers offering health bene-
      fits plans under section 8902(e) of title 5, United
@@ -58903,8 +54729,6 @@ such issuer—
           miums for coverage under the plan on the basis
 
 
-      HR 3590 EAS/PP
-                           2090
           of the rating requirements of part A of title
           XXVII of the Public Health Service Act; and
                ‘‘(D) the issuer offers the plan in all geo-
@@ -58931,8 +54755,6 @@ such issuer—
           benefits required under paragraph (1)(A) be pro-
           vided to enrollees of a multi-State qualified
 
-      HR 3590 EAS/PP
-                          2091
           health plan shall not affect the amount of a pre-
           mium tax credit provided under section 36B of
           the Internal Revenue Code of 1986 with respect
@@ -58959,8 +54781,6 @@ such issuer—
      ‘‘(d) PLANS D EEMED  T O BE  CERTIFIED .—A multi-
 State qualified health plan that is offered under a contract
 
-      HR 3590 EAS/PP
-                            2092
 under subsection (a) shall be deemed to be certified by an
 Exchange for purposes of section 1311(d)(4)(A).
       ‘‘(e) HASE -IN.—Notwithstanding paragraphs (1) and
@@ -58987,8 +54807,6 @@ sion of this title.
       ‘‘(g) ONTINUED  S UPPORT FOR   FEHBP.—
 
 
-      HR 3590 EAS/PP
-                            2093
           ‘‘(1) M AINTENANCE   OF  EFFORT  .—Nothing in
       this section shall be construed to permit the Director
       to allocate fewer financial or personnel resources to
@@ -59015,8 +54833,6 @@ sion of this title.
       essary to enable the Director to carry out activities
       under this section.
 
-      HR 3590 EAS/PP
-                           2094
           ‘‘(5) ASSURANCE OF SEPARATE PROGRAM      .—In
       carrying out this section, the Director shall ensure
       that the program under this section is separate from
@@ -59043,8 +54859,6 @@ essary to carry out this section.’’.
       (r) Section 1341 of this Act is amended—
 
 
-      HR 3590 EAS/PP
-                            2095
           (1) in the section heading, by striking ‘‘ AND
       SMALL GROUP MARKETS         ’’ and inserting ‘MAR  -
       KET ’’;
@@ -59071,8 +54885,6 @@ at the end the following:
       after ‘36A,’.’’.
 
 
-      HR 3590 EAS/PP
-                            2096
       (e)(1) Subparagraph (B) of section 45R(d)(3) of the
 Internal Revenue Code of 1986, as added by section 1421(a)
 of this Act, is amended to read as follows:
@@ -59099,8 +54911,6 @@ inserting ‘‘2010, 2011’’.
 1986, as added by section 1421(d)(1) of this Act, is amended
 by striking ‘‘2011’’ and inserting ‘‘2010, 2011’’.
 
-      HR 3590 EAS/PP
-                            2097
       (4) Section 1421(f) of this Act is amended by striking
 ‘‘2010’’ both places it appears and inserting ‘‘2009’’.
       (5) The amendments made by this subsection shall take
@@ -59127,8 +54937,6 @@ determines appropriate.
       that the study under subsection (a) covers the terri-
       tories of the United States and that special attention
 
-      HR 3590 EAS/PP
-                            2098
       is paid to the disparity that exists among poverty lev-
       els and the cost of living in such territories and to the
       impact of such disparity on efforts to expand health
@@ -59155,8 +54963,6 @@ as follows:
           coverage and attempt to self-insure, which in-
 
 
-      HR 3590 EAS/PP
-                            2099
           creases financial risks to households and medical
           providers.
                ‘‘(B) Health insurance and health care serv-
@@ -59183,8 +54989,6 @@ as follows:
           ening the private employer-based health insur-
           ance system, which covers 176,000,000 Ameri-
 
-      HR 3590 EAS/PP
-                            2100
           cans nationwide. In Massachusetts, a similar re-
           quirement has strengthened private employer-
           based coverage: despite the economic downturn,
@@ -59211,8 +55015,6 @@ as follows:
           are caused in part by medical expenses. By sig-
           nificantly increasing health insurance coverage,
 
-      HR 3590 EAS/PP
-                            2101
           the requirement, together with the other provi-
           sions of this Act, will improve financial security
           for families.
@@ -59239,8 +55041,6 @@ as follows:
           surance premiums. The requirement is essential
           to creating effective health insurance markets in
 
-      HR 3590 EAS/PP
-                            2102
           which improved health insurance products that
           are guaranteed issue and do not exclude coverage
           of pre-existing conditions can be sold.
@@ -59267,8 +55067,6 @@ amended to read as follows:
       or more months, then, except as provided in sub-
       section (e), there is hereby imposed on the taxpayer
 
-      HR 3590 EAS/PP
-                            2103
       a penalty with respect to such failures in the amount
       determined under subsection (c).’’.
           (2) Paragraphs (1) and (2) of section 5000A(c)
@@ -59295,8 +55093,6 @@ amended to read as follows:
       during which any failure described in subsection
 
 
-      HR 3590 EAS/PP
-                            2104
       (b)(1) occurred is an amount equal to     112 of the
       greater of the following amounts:
                ‘‘(A) FLAT DOLLAR AMOUNT     .—An amount
@@ -59323,8 +55119,6 @@ of 1986, as added by section 1501(b) of this Act, is amended
 by striking ‘‘$350’’ and inserting ‘‘$495’’.
 
 
-      HR 3590 EAS/PP
-                            2105
       (c) Section 5000A(d)(2)(A) of the Internal Revenue
 Code of 1986, as added by section 1501(b) of this Act, is
 amended to read as follows:
@@ -59351,8 +55145,6 @@ amended to read as follows:
           employee, the determination under subparagraph
 
 
-      HR 3590 EAS/PP
-                          2106
           (A) shall be made by reference to required con-
           tribution of the employee.’’.
      (e) Section 4980H(b) of the Internal Revenue Code of
@@ -59379,8 +55171,6 @@ month,’’ after ‘‘means’’.
 
 
 
-      HR 3590 EAS/PP
-                            2107
       (2) Section 4980H(d)(2) of the Internal Revenue Code
 of 1986, as added by section 1513(a) of this Act, is amended
 by adding at the end the following:
@@ -59407,8 +55197,6 @@ apply to months beginning after December 31, 2013.
 by adding at the end the following new flush sentence:
 
 
-      HR 3590 EAS/PP
-                           2108
 ‘‘The Secretary shall have the authority to review the accu-
 racy of the information provided under this subsection, in-
 cluding the applicable large employer’s share under para-
@@ -59435,8 +55223,6 @@ issuers.
       ‘‘(b) ATA.—
 
 
-      HR 3590 EAS/PP
-                           2109
           ‘‘(1) N GENERAL  .—In conducting the study de-
       scribed in subsection (a), the Comptroller General
       shall consider samples of data concerning the fol-
@@ -59463,8 +55249,6 @@ issuers.
           issuer, where such group health plan or health
 
 
-      HR 3590 EAS/PP
-                            2110
           insurance issuer later approves such coverage or
           application.
                ‘‘(B) A LL  HEALTH    PLANS .—The study
@@ -59491,8 +55275,6 @@ defined in section 3 of the Small Business Act (15 U.S.C.
 632)) may not be waived with respect to any contract
 
 
-      HR 3590 EAS/PP
-                          2111
 awarded under any program or other authority under this
 Act or an amendment made by this Act.’’.
  SEC. 10108. FREE CHOICE VOUCHERS.
@@ -59519,8 +55301,6 @@ tion—
               household income for the taxable year de-
 
 
-      HR 3590 EAS/PP
-                           2112
               scribed in section 1412(b)(1)(B) which ends
               with or within in the plan year; and
                    (ii) does not exceed 9.8 percent of such
@@ -59547,8 +55327,6 @@ tion—
           would have been paid by the employer if the em-
           ployee were covered under the plan with respect
 
-      HR 3590 EAS/PP
-                           2113
           to which the employer pays the largest portion of
           the cost of the plan. Such amount shall be equal
           to the amount the employer would pay for an
@@ -59575,8 +55353,6 @@ tion—
      of the premium of the qualified health plan in which
 
 
-      HR 3590 EAS/PP
-                           2114
      the qualified employee is enrolled for such month,
      such excess shall be paid to the employee.
      (e) OTHER  D EFINITIONS.—Any term used in this sec-
@@ -59603,8 +55379,6 @@ section 1301 of such Act) by the taxpayer.’’.
           (3) E FFECTIVE DATE  .—The amendments made
      by this subsection shall apply to vouchers provided
      after December 31, 2013.
-      HR 3590 EAS/PP
-                          2115
      (g) DEDUCTION A LLOWED TO E MPLOYER .—
           (1) N GENERAL .—Section 162(a) of the Internal
      Revenue Code of 1986 is amended by adding at the
@@ -59631,8 +55405,6 @@ section 1301 of such Act) by the taxpayer.’’.
           tection and Affordable Care Act.’’.
 
 
-      HR 3590 EAS/PP
-                          2116
           (2) EFFECTIVE DATE .—The amendment made by
      this subsection shall apply to taxable years beginning
      after December 31, 2013.
@@ -59659,8 +55431,6 @@ section 1301 of such Act) by the taxpayer.’’.
 
 
 
-      HR 3590 EAS/PP
-                           2117
                (A) by inserting ‘‘and the employer does not
           offer a free choice voucher’’ after ‘‘Exchange’’;
           and
@@ -59687,8 +55457,6 @@ section 1301 of such Act) by the taxpayer.’’.
           ployer.
 
 
-      HR 3590 EAS/PP
-                            2118
                ‘‘(B) INDEXING .—In the case of any cal-
           endar year beginning after 2014, the 8 percent
           under subparagraph (A) shall be adjusted for the
@@ -59715,8 +55483,6 @@ section 1301 of such Act) by the taxpayer.’’.
                ployer’’ in clause (iv) and inserting ‘‘em-
                ployer’’;
 
-      HR 3590 EAS/PP
-                            2119
                     (iv) by inserting ‘‘and’’ at the end of
                clause (iv); and
                     (v) by inserting at the end the fol-
@@ -59743,8 +55509,6 @@ section 1301 of such Act) by the taxpayer.’’.
           part III of subchapter A of chapter 1 of such
           Code, as amended by section 1514, is amended
 
-      HR 3590 EAS/PP
-                          2120
           by striking ‘‘Large employers’’ in the item relat-
           ing to section 6056 and inserting ‘‘Certain em-
           ployers’’.
@@ -59771,8 +55535,6 @@ section 1301 of such Act) by the taxpayer.’’.
           rying out paragraph (1)(B), the Secretary shall
           solicit, not later than January 1, 2012, and not
 
-      HR 3590 EAS/PP
-                           2121
           less than every 3 years thereafter, input from en-
           tities described in subparagraph (B) on—
                    ‘‘(i) whether there could be greater uni-
@@ -59799,8 +55561,6 @@ section 1301 of such Act) by the taxpayer.’’.
                by the Secretary.’’.
 
 
-      HR 3590 EAS/PP
-                            2122
       (b) ACTIVITIES AND   TEMS FOR    INITIAL C ONSIDER -
  ATION .—For purposes of section 1173(a)(5) of the Social
 Security Act, as added by subsection (a), the Secretary of
@@ -59827,8 +55587,6 @@ areas:
       entities as determined appropriate by the Secretary.
 
 
-      HR 3590 EAS/PP
-                           2123
           (4) Whether there could be greater transparency
      and consistency of methodologies and processes used to
      establish claim edits used by health plans (as de-
@@ -59855,8 +55613,6 @@ areas:
      such revised crosswalk on the website of the Centers
      for Medicare & Medicaid Services.
 
-      HR 3590 EAS/PP
-                           2124
           (3) USE OF REVISED CROSSWALK   .—For purposes
      of paragraph (2), any revised crosswalk shall be treat-
      ed as a code set for which a standard has been adopt-
@@ -59883,8 +55639,6 @@ areas:
 curity Act (42 U.S.C. 1396a(a)(10)(A)(i)(IX)), as added by
 section 2004(a), is amended to read as follows:
 
-      HR 3590 EAS/PP
-                            2125
                          ‘‘(IX) who—
                              ‘‘(aa) are under 26 years of
                          age;
@@ -59911,8 +55665,6 @@ section 2004(a), is amended to read as follows:
 U.S.C. 1396a(a)(10), as amended by section 2001(a)(5)(A),
 is amended in the matter following subparagraph (G), by
 
-      HR 3590 EAS/PP
-                             2126
 striking ‘‘and (XV)’’ and inserting ‘‘(XV)’’, and by insert-
 ing ‘‘and (XVI) if an individual is described in subclause
 (IX) of subparagraph (A)(i) and is also described in sub-
@@ -59939,8 +55691,6 @@ amended by striking ‘‘January 1, 2011’’ and inserting
            sentence, by inserting ‘‘includes inpatient hos-
 
 
-      HR 3590 EAS/PP
-                           2127
           pital services,’’ after ‘‘100 percent of the poverty
           line, that’’; and
                (B) in paragraph (2)(A), by striking ‘‘on
@@ -59967,8 +55717,6 @@ amended by striking ‘‘January 1, 2011’’ and inserting
           section (y)(1)(B)(ii)(II);
 
 
-      HR 3590 EAS/PP
-                            2128
                 ‘‘(ii) the Secretary determines will not re-
            ceive any payments under this title on the basis
            of an increased Federal medical assistance per-
@@ -59995,8 +55743,6 @@ scribed in this subparagraph is a State that—
       graph (1)(B); and
 
 
-      HR 3590 EAS/PP
-                            2129
            ‘‘(ii) is the State with the highest percentage of
       its population insured during 2008, based on the Cur-
       rent Population Survey.
@@ -60023,8 +55769,6 @@ apply with respect to—
            (5) in subsection (aa), is amended by striking
       ‘‘without regard to this subsection and subsection (y)’’
 
-      HR 3590 EAS/PP
-                             2130
       and inserting ‘‘without regard to this subsection, sub-
       section (y), subsection (z), and section 10202 of the
       Patient Protection and Affordable Care Act’’ each
@@ -60051,8 +55795,6 @@ shall not be considered to be required contributions for pur-
 poses of this subsection. The treatment of voluntary con-
 tributions, and the treatment of contributions required by
 
-      HR 3590 EAS/PP
-                             2131
 a State under the State plan under this title, or State law,
 as provided by this subsection, shall also apply to the in-
 creases in the Federal medical assistance percentage under
@@ -60079,8 +55821,6 @@ ed—
                 YEAR    2013,  AND    SUCCEEDING    FISCAL
 
 
-      HR 3590 EAS/PP
-                            2132
                YEARS .—Notwithstanding the table set forth
                in paragraph (2) or paragraph (7):
                          ‘‘(I) D, 3RD, AND 4TH QUARTER
@@ -60107,8 +55847,6 @@ ed—
                     such limitation is necessary to ensure
                     that a hospital does not receive pay-
 
-      HR 3590 EAS/PP
-                            2133
                     ments in excess of the amounts de-
                     scribed in subsection (g), or as nec-
                     essary to ensure that such payments
@@ -60135,8 +55873,6 @@ ed—
                     State described in paragraph (5)(B)
                     and has spent not more than 99.90
 
-      HR 3590 EAS/PP
-                            2134
                     percent of the DSH allotments for the
                     State on average for the period of fiscal
                     years 2004 through 2008, as of Sep-
@@ -60163,8 +55899,6 @@ ed—
                     (5)(B) and has spent more than 99.90
                     percent of the DSH allotments for the
 
-      HR 3590 EAS/PP
-                            2135
                     State on average for the period of fiscal
                     years 2004 through 2008, as of Sep-
                     tember 30, 2009, the applicable per-
@@ -60191,8 +55925,6 @@ ed—
                     2004 through 2008, as of September
                     30, 2009, the applicable percentage is
 
-      HR 3590 EAS/PP
-                            2136
                     equal to the product of the percentage
                     reduction in uncovered individuals for
                     the fiscal year from the preceding fiscal
@@ -60219,8 +55951,6 @@ ed—
                     centage is equal to the product of the
                     percentage reduction in uncovered in-
 
-      HR 3590 EAS/PP
-                            2137
                     dividuals for the fiscal year from the
                     preceding fiscal year and 40 percent.’’;
                     (III) in subparagraph (E), by striking
@@ -60247,8 +55977,6 @@ health plan.’’.
 
 
 
-      HR 3590 EAS/PP
-                             2138
       (h) Clause (i) of subparagraph (C) of section 513(b)(2)
 of the Social Security Act, as added by section 2953 of this
 Act, is amended to read as follows:
@@ -60275,8 +56003,6 @@ demonstration project that provide for—
       ensure a meaningful level of public input;
            ‘‘(B) requirements relating to—
 
-      HR 3590 EAS/PP
-                            2139
                ‘‘(i) the goals of the program to be imple-
            mented or renewed under the demonstration
            project;
@@ -60303,8 +56029,6 @@ adding at the end the following:
 
 
 
-      HR 3590 EAS/PP
-                           2140
  ‘‘SEC. 3512. GAO STUDY AND REPORT ON CAUSES OF AC-
              TION.
      ‘‘(a) TUDY .—
@@ -60331,8 +56055,6 @@ adding at the end the following:
                ‘‘(G) Section 3008 (payment adjustment for
           conditions acquired in hospitals).
 
-      HR 3590 EAS/PP
-                           2141
               ‘‘(H) Section 3013 (quality measure devel-
           opment).
               ‘‘(I) Section 3014 (quality measurement).
@@ -60359,8 +56081,6 @@ Comptroller General under the study under subsection (a).’’.
  GRAM .—Notwithstanding section 1905(b) of the Social Se-
 curity Act (42 U.S.C. 1396d(b)), in the case of a balancing
 
-      HR 3590 EAS/PP
-                            2142
 incentive payment State, as defined in subsection (b), that
 meets the conditions described in subsection (c), during the
 balancing incentive period, the Federal medical assistance
@@ -60387,8 +56107,6 @@ ancing incentive payment State is a State—
       (c) CONDITIONS .—The conditions described in this
 subsection are the following:
 
-      HR 3590 EAS/PP
-                           2143
           (1) APPLICATION .—The State submits an appli-
       cation to the Secretary that includes, in addition to
       such other information as the Secretary shall re-
@@ -60415,8 +56133,6 @@ subsection are the following:
           based services under its State Medicaid program
           through a State plan amendment under section
 
-      HR 3590 EAS/PP
-                           2144
           1915(i) of the Social Security Act, at the option
           of the State, an election to increase the income
           eligibility for such services from 150 percent of
@@ -60443,8 +56159,6 @@ subsection are the following:
           centage for the State to achieve by not later than
           October 1, 2015, is that 50 percent of the total
 
-      HR 3590 EAS/PP
-                          2145
           expenditures for long-term services and supports
           under the State Medicaid program are for home
           and community-based services.
@@ -60471,8 +56185,6 @@ subsection are the following:
               (A) ‘‘N O  WRONG   DOOR — SINGLE   ENTRY
           POINT SYSTEM  ’’.—Development of a statewide
 
-      HR 3590 EAS/PP
-                            2146
           system to enable consumers to access all long-
           term services and supports through an agency,
           organization, coordinated network, or portal, in
@@ -60499,8 +56211,6 @@ subsection are the following:
           STRUMENTS  .—Development of core standardized
           assessment instruments for determining eligi-
 
-      HR 3590 EAS/PP
-                            2147
           bility for non-institutionally-based long-term
           services and supports described in subsection
           (f)(1)(B), which shall be used in a uniform man-
@@ -60527,8 +56237,6 @@ subsection are the following:
           sible to providers.
 
 
-      HR 3590 EAS/PP
-                          2148
               (C) O   UTCOMES    MEASURES .—Outcomes
           measures data on a selected set of core popu-
           lation-specific outcomes measures agreed upon by
@@ -60555,8 +56263,6 @@ FMAP.—The applicable percentage points increase is—
  TURES .—
 
 
-      HR 3590 EAS/PP
-                            2149
           (1) I N GENERAL  .—Subject to paragraph (2),
       medical assistance described in this subsection is med-
       ical assistance for non-institutionally-based long-term
@@ -60583,8 +56289,6 @@ FMAP.—The applicable percentage points increase is—
                facility for the mentally retarded described
 
 
-      HR 3590 EAS/PP
-                            2150
                in subsection (a)(15) of section 1905 of such
                Act.
                (B) N  ON -INSTITUTIONALLY -BASED   LONG -
@@ -60611,8 +56315,6 @@ FMAP.—The applicable percentage points increase is—
       has the meaning given that term in section 2110(c)(5)
       of the Social Security Act (42 U.S.C. 1397jj(c)(5)).
 
-      HR 3590 EAS/PP
-                           2151
           (4) S  TATE  MEDICAID   PROGRAM   .—The term
       ‘‘State Medicaid program’’ means the State program
       for medical assistance provided under a State plan
@@ -60639,8 +56341,6 @@ of 2009 (Public Law 111–3):
       ‘‘means’’ and all that follows through the period and
 
 
-      HR 3590 EAS/PP
-                            2152
       inserting ‘‘has the meaning given that term in section
       2105(c)(3)(A).’’.
           (2)(A) Section 1906A(a) of the Social Security
@@ -60667,8 +56367,6 @@ of 2009 (Public Law 111–3):
       Act (42 U.S.C. 1397ee(c)(3)(A)) is amended—
 
 
-      HR 3590 EAS/PP
-                            2153
                (A) in the matter preceding clause (i), by
           striking ‘‘to’’ and inserting ‘‘to—’’; and
                (B) in clause (ii), by striking the period
@@ -60695,8 +56393,6 @@ of 2009 (Public Law 111–3):
                been certified by the Secretary under sub-
                paragraph (C); or’’;
 
-      HR 3590 EAS/PP
-                            2154
                (B) in subparagraph (B), by striking ‘‘pro-
           vided coverage’’ and inserting ‘‘screened for eligi-
           bility for medical assistance under the State
@@ -60723,8 +56419,6 @@ of 2009 (Public Law 111–3):
           Care Act and shall certify those plans that offer
           benefits for children and impose cost-sharing
 
-      HR 3590 EAS/PP
-                           2155
           with respect to such benefits that the Secretary
           determines are at least comparable to the benefits
           offered and cost-sharing protections provided
@@ -60751,8 +56445,6 @@ ed—
           (i) in the subsection heading, by striking ‘‘2013’’
       and inserting ‘‘2015’’;
 
-      HR 3590 EAS/PP
-                            2156
           (ii) in paragraph (2)—
                (I) in the paragraph heading, by striking
           ‘‘201’’ and inserting 2014’’; and
@@ -60779,8 +56471,6 @@ ed—
                factor under paragraph (5) for fiscal year
                2013.
 
-      HR 3590 EAS/PP
-                            2157
                     ‘‘(ii) ROWTH FACTOR UPDATE FOR
                FISCAL YEAR 2014  .—For fiscal year 2014,
                the allotment of the State is equal to the
@@ -60807,8 +56497,6 @@ ed—
                     serting ‘‘2015’’; and
                     (IV) in subparagraph (D)—
 
-      HR 3590 EAS/PP
-                            2158
                          (aa) in clause (i)(I), by striking
                     ‘‘subsection (a)(16)(A)’’ and inserting
                     ‘‘subsection (a)(18)(A)’’; and
@@ -60835,8 +56523,6 @@ is amended—
                (I) in subparagraph (A)(ii)—
 
 
-      HR 3590 EAS/PP
-                            2159
                     (aa) by striking ‘‘2012’’ and inserting
                ‘‘2014’’; and
                     (bb) by striking ‘‘2013’’ and inserting
@@ -60863,8 +56549,6 @@ is amended—
            (ii) by adding at the end the following new
       paragraph:
 
-      HR 3590 EAS/PP
-                           2160
           ‘‘(6) XCEPTIONS TO EXCLUSION OF CHILDREN
      OF   EMPLOYEES   OF  A  PUBLIC  AGENCY   IN  THE
      STATE .—
@@ -60891,8 +56575,6 @@ is amended—
           age increase in the medical care expenditure cat-
           egory of the Consumer Price Index for All-Urban
 
-      HR 3590 EAS/PP
-                            2161
           Consumers (all items: U.S. City Average) for
           such preceding fiscal year.
                ‘‘(C) HARDSHIP EXCEPTION   .—For purposes
@@ -60919,8 +56601,6 @@ ber 1, 2014, and ending on March 31, 2015, under section
 2104(a)(18)(A) of the Social Security Act (42 U.S.C.
 1397dd(a)(18)(A)), to remain available until expended.
 
-      HR 3590 EAS/PP
-                           2162
 Such amount shall be used to provide allotments to States
 under paragraph (3) of section 2104(m) of the Social Secu-
 rity Act (42 U.S.C. 1397dd(m)) for the first 6 months of
@@ -60947,8 +56627,6 @@ allotments provided from such subsection (a)(18)(A).’’.
       Education Act of 1965 (20 U.S.C. 1001)) that has es-
       tablished and operates, or agrees to establish and op-
 
-      HR 3590 EAS/PP
-                            2163
       erate upon the receipt of a grant under this part, a
       pregnant and parenting student services office.
           (3) C OMMUNITY SERVICE CENTER      .—The term
@@ -60975,8 +56653,6 @@ allotments provided from such subsection (a)(18)(A).’’.
       ‘‘supportive social services’’ means transitional and
       permanent housing, vocational counseling, and indi-
 
-      HR 3590 EAS/PP
-                            2164
       vidual and group counseling aimed at preventing do-
       mestic violence, sexual violence, sexual assault, or
       stalking.
@@ -61003,8 +56679,6 @@ for receipt and administration of funding received under
 this part.
 
 
-      HR 3590 EAS/PP
-                          2165
  SEC. 10213. PERMISSIBLE USES OF FUND.
      (a) IN GENERAL .—A State shall use amounts received
 under a grant under section 10212 for the purposes de-
@@ -61031,8 +56705,6 @@ teens and women.
      ported by the funding an amount from non-Federal
      funds equal to 25 percent of the amount of the fund-
      ing provided. The non-Federal share may be in cash
-      HR 3590 EAS/PP
-                           2166
       or in-kind, fairly evaluated, including services, facili-
       ties, supplies, or equipment.
           (4) U SE OF FUNDS FOR ASSISTING PREGNANT
@@ -61059,8 +56731,6 @@ teens and women.
           eligible institution in meeting the following needs
 
 
-      HR 3590 EAS/PP
-                            2167
           of students enrolled in the eligible institution
           who are pregnant or are parents:
                     (i) The inclusion of maternity coverage
@@ -61087,8 +56757,6 @@ teens and women.
           stitution or within the local community, that are
           qualified to meet the needs described in subpara-
 
-      HR 3590 EAS/PP
-                           2168
           graph (B), and establishes programs with quali-
           fied providers to meet such needs.
                (D) Assist pregnant and parenting students,
@@ -61115,8 +56783,6 @@ teens and women.
                that an eligible institution of higher edu-
                cation receives funds under this subsection,
 
-      HR 3590 EAS/PP
-                            2169
                the eligible institution shall prepare and
                submit to the State, by the date determined
                by the State, a report that—
@@ -61143,8 +56809,6 @@ teens and women.
                     formance criteria or standards that
                     shall be used to prepare the report; and
 
-      HR 3590 EAS/PP
-                         2170
                       (II) may establish the form or for-
                   mat of the report.
               (B) REPORT BY STATE  .—The State shall
@@ -61171,8 +56835,6 @@ poses of this subsection.
      ceived under a grant under section 10212 to make
 
 
-      HR 3590 EAS/PP
-                            2171
       funding available tp its State Attorney General to as-
       sist Statewide offices in providing—
                (A) intervention services, accompaniment,
@@ -61199,8 +56861,6 @@ poses of this subsection.
       SCRIBED .—For purposes of paragraph (1)(B), tech-
       nical assistance and training is—
 
-      HR 3590 EAS/PP
-                            2172
                (A) the identification of eligible pregnant
           women experiencing domestic violence, sexual vi-
           olence, sexual assault, or stalking;
@@ -61227,8 +56887,6 @@ poses of this subsection.
           (4) E LIGIBLE PREGNANT WOMAN    .—In this sub-
       section, the term ‘‘eligible pregnant woman’’ means
 
-      HR 3590 EAS/PP
-                           2173
      any woman who is pregnant on the date on which
      such woman becomes a victim of domestic violence,
      sexual violence, sexual assault, or stalking or who was
@@ -61255,8 +56913,6 @@ Care Improvement Act to revise and extend that Act, and
 for other purposes.’’, as reported by the Committee on In-
 
 
-      HR 3590 EAS/PP
-                           2174
 dian Affairs of the Senate in December 2009, is enacted
 into law.
      (b) AMENDMENTS   .—
@@ -61283,8 +56939,6 @@ into law.
           tion by an Indian tribe or tribal organization
           under subparagraph (A), the Secretary, acting
 
-      HR 3590 EAS/PP
-                           2175
           through the Service, shall facilitate implementa-
           tion of the services elected.
           ‘‘(4) ACANCIES .—The Secretary shall not fill
@@ -61311,8 +56965,6 @@ provide any service authorized by any other Federal law.’’.
  LAW .—Any limitation pursuant to other Federal laws on
 the use of Federal funds appropriated to the Service shall
 
-      HR 3590 EAS/PP
-                          2176
 apply with respect to the performance or coverage of abor-
 tions.’’.
           (4) The bill referred to in subsection (a) is
@@ -61339,8 +56991,6 @@ at the end the following new subsection:
           and modification process for measures (including
           under section 1890 of the Social Security Act (42
 
-      HR 3590 EAS/PP
-                            2177
           U.S.C. 1395aaa) and section 1890A of such Act,
           as added by section 3014), to the extent feasible
           and practicable, of all dimensions of quality and
@@ -61367,8 +57017,6 @@ at the end the following new subsection:
           evant to the value-based purchasing program de-
           scribed in paragraph (1).
 
-      HR 3590 EAS/PP
-                           2178
           ‘‘(4) REPORT TO CONGRESS    .—Not later than
      January 1, 2011, the Secretary shall submit to Con-
      gress a report containing the plan developed under
@@ -61395,8 +57043,6 @@ adding at the end the following new subsection:
 
 
 
-      HR 3590 EAS/PP
-                           2179
           ‘‘(2) ATEGORIES OF MEASURES    .—The measures
       developed under this subsection shall include, to the
       extent determined appropriate by the Secretary—
@@ -61423,8 +57069,6 @@ adding at the end the following new subsection:
           of this Act, the Secretary shall develop not less
           than 10 measures described in paragraph (2)(A).
 
-      HR 3590 EAS/PP
-                           2180
               ‘‘(B) P RIMARY AND PREVENTIVE CARE    .—
           Not later than 36 months after the date of enact-
           ment of this Act, the Secretary shall develop not
@@ -61451,8 +57095,6 @@ at the end the following new paragraph:
           shall contract with the Institute to employ the
           results of the study performed under paragraph
 
-      HR 3590 EAS/PP
-                           2181
           (1) and the best methods identified by the Insti-
           tute for the purpose of identifying existing and
           new clinical practice guidelines that were devel-
@@ -61479,8 +57121,6 @@ added by section 3015, is amended to read as follows:
      reporting of performance information, as described in
      section 399JJ. Such strategic framework may include
 
-      HR 3590 EAS/PP
-                           2182
       methods and related timelines for implementing na-
       tionally consistent data collection, data aggregation,
       and analysis methods.
@@ -61507,8 +57147,6 @@ added by section 3015, is amended to read as follows:
 section 3021, is amended—
 
 
-      HR 3590 EAS/PP
-                            2183
           (1) in subsection (a), by inserting at the end the
       following new paragraph:
           ‘‘(5) T ESTING  WITHIN  CERTAIN   GEOGRAPHIC
@@ -61535,8 +57173,6 @@ section 3021, is amended—
                ties located in medically underserved areas
                and facilities of the Indian Health Service
 
-      HR 3590 EAS/PP
-                            2184
                (whether operated by such Service or by an
                Indian tribe or tribal organization (as those
                terms are defined in section 4 of the Indian
@@ -61563,8 +57199,6 @@ section 3021, is amended—
                note).’’; and
 
 
-      HR 3590 EAS/PP
-                            2185
                (C) in subparagraph (C), by adding at the
           end the following new clause:
                     ‘‘(viii) Whether the model demonstrates
@@ -61591,8 +57225,6 @@ section 3021, is amended—
           ‘‘(3) the Secretary determines that such expan-
       sion would not deny or limit the coverage or provi-
 
-      HR 3590 EAS/PP
-                          2186
      sion of benefits under the applicable title for applica-
      ble individuals.
 In determining which models or demonstration projects to
@@ -61619,8 +57251,6 @@ new subsections:
           such as at risk for some or all physicians’ serv-
           ices or all items and services under part B. The
 
-      HR 3590 EAS/PP
-                           2187
           Secretary may limit a partial capitation model
           to ACOs that are highly integrated systems of
           care and to ACOs capable of bearing risk, as de-
@@ -61647,8 +57277,6 @@ new subsections:
           graph (A) in a similar manner as such subpara-
 
 
-      HR 3590 EAS/PP
-                         2188
          graph (B) applies to the payment model under
          paragraph (2).
      ‘‘(j)NVOLVEMENT IN   PRIVATE P AYER AND  O THER
@@ -61675,8 +57303,6 @@ rity Act, as added by section 3023, is amended—
          any point after January 1, 2016, expand the du-
          ration and scope of the pilot program, to the ex-
 
-      HR 3590 EAS/PP
-                          2189
           tent determined appropriate by the Secretary,
           if—
                    ‘‘(i) the Secretary determines that such
@@ -61703,8 +57329,6 @@ rity Act, as added by section 3023, is amended—
      program so as to separately pilot test the continuing
      care hospital model.
 
-      HR 3590 EAS/PP
-                           2190
           ‘‘(2) PECIAL RULES  .—In pilot testing the con-
       tinuing care hospital model under paragraph (1), the
       following rules shall apply:
@@ -61731,8 +57355,6 @@ rity Act, as added by section 3023, is amended—
       (b) ECHNICAL  A MENDMENTS  .—
 
 
-      HR 3590 EAS/PP
-                           2191
           (1) Section 3023 is amended by striking
       ‘‘1886C’’ and inserting ‘‘1866C’’.
           (2) Title XVIII of the Social Security Act is
@@ -61759,8 +57381,6 @@ the Social Security Act (42 U.S.C. 1395m(l)(13)(A)), as
 amended by section 3105(a), is further amended—
           (1) in the matter preceding clause (i)—
 
-      HR 3590 EAS/PP
-                           2192
                (A) by striking ‘‘2007, for’’ and inserting
           ‘‘2007, and for’’; and
                (B) by striking ‘‘2010, and for such services
@@ -61787,8 +57407,6 @@ and before January 1, 2011’’ and inserting ‘‘2011’’.
 
 
 
-      HR 3590 EAS/PP
-                          2193
  SEC. 10312. CERTAIN PAYMENT RULES FOR LONG-TERM
              CARE HOSPITAL SERVICES AND MORATORIUM
              ON THE ESTABLISHMENT OF CERTAIN HOS-
@@ -61816,8 +57434,6 @@ to read as follows:
      ‘‘(g) IV-YEAR E XTENSION OF D EMONSTRATION P RO-
  GRAM .—
 
-      HR 3590 EAS/PP
-                           2194
           ‘‘(1) IN GENERAL  .—Subject to the succeeding
       provisions of this subsection, the Secretary shall con-
       duct the demonstration program under this section for
@@ -61844,8 +57460,6 @@ to read as follows:
           ‘‘(4) HOSPITALS IN DEMONSTRATION PROGRAM
       ON DATE OF ENACTMENT     .—In the case of a rural
 
-      HR 3590 EAS/PP
-                            2195
       community hospital that is participating in the dem-
       onstration program under this section as of the last
       day of the initial 5-year period, the Secretary—
@@ -61872,8 +57486,6 @@ to read as follows:
                first cost reporting period beginning on or
 
 
-      HR 3590 EAS/PP
-                            2196
                after the implementation of the demonstra-
                tion program.’’.
       (b) CONFORMING   AMENDMENTS   .—Subsection (a)(5) of
@@ -61900,8 +57512,6 @@ cial Security Act, as added by section 3131, is amended—
           (2) in subclause (I), by striking ‘‘2013’’ and in-
       serting ‘‘2014’’; and
 
-      HR 3590 EAS/PP
-                         2197
          (3) in subclause (II), by striking ‘‘2016’’ and in-
      serting ‘‘2017’’.
      (b) REVISION OF H OME H EALTH  STUDY AND  R E-
@@ -61928,8 +57538,6 @@ cial Security Act, as added by section 3131, is amended—
 
 
 
-     HR 3590 EAS/PP
-                            2198
                     ‘‘(i) payment adjustments for services
                that may involve additional or fewer re-
                sources;
@@ -61956,8 +57564,6 @@ cial Security Act, as added by section 3131, is amended—
           needed.
 
 
-      HR 3590 EAS/PP
-                            2199
                ‘‘(D) Other items determined appropriate
           by the Secretary.
           ‘‘(2) ONSIDERATIONS  .—In conducting the study
@@ -61984,8 +57590,6 @@ cial Security Act, as added by section 3131, is amended—
       tive action as the Secretary determines appropriate.
 
 
-      HR 3590 EAS/PP
-                           2200
           ‘‘(4) ONSULTATIONS  .—In conducting the study
      under paragraph (1), the Secretary shall consult with
      appropriate stakeholders, such as groups representing
@@ -62012,8 +57616,6 @@ cial Security Act, as added by section 3131, is amended—
           payments during such period resulting from the
 
 
-      HR 3590 EAS/PP
-                           2201
           application of the payment adjustments under
           subparagraph (A).
                ‘‘(C) NO EFFECT ON SUBSEQUENT PERI       -
@@ -62040,8 +57642,6 @@ cial Security Act, as added by section 3131, is amended—
           retary determines appropriate, of $500,000,000
           for the period of fiscal years 2015 through 2018.
 
-      HR 3590 EAS/PP
-                            2202
           Such funds shall be made available for the study
           described in paragraph (1) and the design, im-
           plementation and evaluation of the demonstra-
@@ -62068,8 +57668,6 @@ added by section 3133, is amended—
           by striking ‘‘(divided by 100)’’;
 
 
-      HR 3590 EAS/PP
-                           2203
                (B) in subclause (I), by striking ‘‘2012’’
           and inserting ‘‘2013’’;
                (C) in subclause (II), by striking the period
@@ -62096,8 +57694,6 @@ added by section 3133, is amended—
       of division B of the Tax Relief and Health Care Act
       of 2006 (42 U.S.C. 1395 note), as amended by section
 
-      HR 3590 EAS/PP
-                           2204
      117 of the Medicare, Medicaid, and SCHIP Extension
      Act of 2007 (Public Law 110–173) and section 124
      of the Medicare Improvements for Patients and Pro-
@@ -62124,8 +57720,6 @@ added by section 3133, is amended—
           corrections.
 
 
-      HR 3590 EAS/PP
-                           2205
                ‘‘(B) EXCEPTION .—Beginning on April 1,
           2010, in determining the wage index applicable
           to hospitals that qualify for wage index reclassi-
@@ -62152,8 +57746,6 @@ added by section 3133, is amended—
                2010, was lower than for the period begin-
                ning on April 1, 2010, and ending on Sep-
 
-      HR 3590 EAS/PP
-                          2206
               tember 30, 2010, by reason of the applica-
               tion of paragraph (2)(B);
           the Secretary shall pay such hospital an addi-
@@ -62180,8 +57772,6 @@ section 3401(a), is amended—
      new subclause:
 
 
-      HR 3590 EAS/PP
-                           2207
           ‘‘(II) for each of fiscal years 2012 and 2013, by
      0.1 percentage point; and’’; and
           (4) in subclause (III), as redesignated by para-
@@ -62208,8 +57798,6 @@ section 3401(a), is amended—
           paragraph (B), by striking ‘‘2012’’ and inserting
           ‘‘2014’’; and
 
-      HR 3590 EAS/PP
-                          2208
           (2) in subparagraph (B), by striking ‘‘(A)(ii)’’
      and inserting ‘‘(A)(iv)’’.
      (c) NPATIENT  REHABILITATION  FACILITIES.—Section
@@ -62236,8 +57824,6 @@ amended—
           (1) in clause (i), by striking ‘‘and’’ at the end;
           (2) by redesignating clause (ii) as clause (iii);
 
-      HR 3590 EAS/PP
-                           2209
           (3) by inserting after clause (ii) the following
       new clause:
                    ‘‘(ii) for each of the rate years begin-
@@ -62264,8 +57850,6 @@ tion 3401(i), is amended—
                         ‘‘(II) for each of 2012 and 2013,
                    0.1 percentage point; and’’; and
 
-      HR 3590 EAS/PP
-                           2210
           (4) in subclause (III), as redesignated by para-
      graph (2), by striking ‘‘2012’’ and inserting ‘‘2014’’.
  SEC. 10320. EXPANSION OF THE SCOPE OF, AND ADDI-
@@ -62292,8 +57876,6 @@ rity Act, as added by section 3403, is amended—
                ters for Medicare & Medicaid Services has
                made a determination described in sub-
 
-      HR 3590 EAS/PP
-                            2211
                section (e)(3)(B)(i)(II) in the determination
                year, the proposal shall be designed to help
                reduce the growth rate described in para-
@@ -62320,8 +57902,6 @@ rity Act, as added by section 3403, is amended—
                BOARD PROPOSAL TO CONGRESS AND THE
                PRESIDENT  ’’;
 
-      HR 3590 EAS/PP
-                            2212
                     (ii) in subparagraph (A)(i), by strik-
                ing ‘‘transmit a proposal under this section
                to the President’’ and insert ‘‘submit a pro-
@@ -62348,8 +57928,6 @@ rity Act, as added by section 3403, is amended—
           culated as the sum of per capita spending under
           each of parts A, B, and D)’’;
 
-      HR 3590 EAS/PP
-                           2213
           (2) in subsection (d)—
                (A) in paragraph (1)(A)—
                    (i) by inserting ‘‘the Board or’’ after
@@ -62376,8 +57954,6 @@ rity Act, as added by section 3403, is amended—
                (A) and (B) as clauses (i) and (ii), respec-
                tively, and indenting appropriately; and
 
-      HR 3590 EAS/PP
-                           2214
                    (iii) by adding at the end the following
                new subparagraph:
                ‘‘(B) IMITED ADDITIONAL EXCEPTION   .—
@@ -62404,8 +57980,6 @@ rity Act, as added by section 3403, is amended—
                YEARS .—This subparagraph shall not apply
                if the recommendations contained in a pro-
 
-      HR 3590 EAS/PP
-                           2215
                posal submitted by the Board or the Presi-
                dent to Congress pursuant to this section in
                the year preceding the proposal year were
@@ -62432,8 +58006,6 @@ rity Act, as added by section 3403, is amended—
 
 
 
-      HR 3590 EAS/PP
-                           2216
                (B) by inserting ‘‘or produce the public re-
           port under subsection (n)’’ after ‘‘this section’’;
           and
@@ -62460,8 +58032,6 @@ rity Act, as added by section 3403, is amended—
                ‘‘(B) Beneficiary and consumer access to
           care, patient and caregiver experience of care,
 
-      HR 3590 EAS/PP
-                          2217
           and the cost-sharing or out-of-pocket burden on
           patients.
               ‘‘(C) Epidemiological shifts and demo-
@@ -62488,8 +58058,6 @@ rity Act, as added by section 3403, is amended—
               ‘‘(B) that may require legislation to be en-
           acted by Congress in order to be implemented;
 
-      HR 3590 EAS/PP
-                           2218
                ‘‘(C) that may require legislation to be en-
           acted by State or local governments in order to
           be implemented;
@@ -62516,8 +58084,6 @@ Medicare Advisory Board, as established under section
 1899A of the Social Security Act (as added by section
 
 
-      HR 3590 EAS/PP
-                           2219
 3403), from solely using data from public or private sources
 to carry out the amendments made by subsection (a)(4).
  SEC. 10321. REVISION TO COMMUNITY HEALTH TEAMS.
@@ -62544,8 +58110,6 @@ at the end the following new paragraph:
               (2), shall be reduced by 2 percentage points.
 
 
-      HR 3590 EAS/PP
-                           2220
                    ‘‘(ii) PECIAL RULE .—The application
                of this subparagraph may result in such an-
                nual update being less than 0.0 for a rate
@@ -62572,8 +58136,6 @@ at the end the following new paragraph:
                    ‘‘(i) N GENERAL  .—Subject to clause
                (ii), any measure specified by the Secretary
 
-      HR 3590 EAS/PP
-                            2221
                under this subparagraph must have been
                endorsed by the entity with a contract
                under section 1890(a).
@@ -62600,8 +58162,6 @@ at the end the following new paragraph:
           dures shall ensure that a psychiatric hospital
           and a psychiatric unit has the opportunity to re-
 
-      HR 3590 EAS/PP
-                          2222
           view the data that is to be made public with re-
           spect to the hospital or unit prior to such data
           being made public. The Secretary shall report
@@ -62628,8 +58188,6 @@ section 1881 the following new section:
      for benefits under this title, an individual determined
      under subsection (c) to be an environmental exposure
 
-      HR 3590 EAS/PP
-                          2223
      affected individual described in subsection (e)(2) shall
      be deemed to meet the conditions specified in section
      226(a).
@@ -62656,8 +58214,6 @@ section 1881 the following new section:
           approaches to furnishing comprehensive, coordi-
 
 
-      HR 3590 EAS/PP
-                           2224
           nated, and cost-effective care under this title to
           individuals described in paragraph (2)(A).
                ‘‘(B) O PTIONAL  PILOT  PROGRAMS   .—The
@@ -62684,8 +58240,6 @@ section 1881 the following new section:
           individual described in subsection (e)(3) who—
 
 
-      HR 3590 EAS/PP
-                           2225
                    ‘‘(i) is deemed under subsection (a)(2);
                and
                    ‘‘(ii) meets such other criteria or con-
@@ -62712,8 +58266,6 @@ section 1881 the following new section:
                ‘‘(B) may develop and implement innova-
           tive approaches to reimbursing providers for any
 
-      HR 3590 EAS/PP
-                            2226
           benefits, items, or services furnished under this
           subsection.
           ‘‘(5) L  IMITATION.—Consistent with section
@@ -62740,8 +58292,6 @@ section 1881 the following new section:
       Medicare & Medicaid Services Program Management
       Account.
 
-      HR 3590 EAS/PP
-                          2227
           ‘‘(8) WAIVER  OF  BUDGET  NEUTRALITY  .—The
      Secretary shall not require that pilot programs under
      this subsection be budget neutral with respect to ex-
@@ -62768,8 +58318,6 @@ Compensation, and Liability Act of 1980.
      means—
 
 
-      HR 3590 EAS/PP
-                           2228
                ‘‘(A) an individual described in paragraph
           (2); and
                ‘‘(B) an individual described in paragraph
@@ -62796,8 +58344,6 @@ Compensation, and Liability Act of 1980.
                    ‘‘(iii) files an application for benefits
                under this title (or has an application filed
 
-      HR 3590 EAS/PP
-                            2229
                on behalf of the individual), including pur-
                suant to this section; and
                     ‘‘(iv) is determined under this section
@@ -62824,8 +58370,6 @@ Compensation, and Liability Act of 1980.
                the lung, colon, rectum, larynx, stomach,
 
 
-      HR 3590 EAS/PP
-                           2230
                esophagus, pharynx, or ovary, as established
                by—
                         ‘‘(I) pathologic examination of bi-
@@ -62852,8 +58396,6 @@ Compensation, and Liability Act of 1980.
           tions, diagnostic standards, and other criteria as
           the Secretary specifies;
 
-      HR 3590 EAS/PP
-                         2231
              ‘‘(C) as demonstrated in such manner as the
          Secretary determines appropriate, has been
          present for an aggregate total of 6 months in the
@@ -62880,8 +58422,6 @@ competitive grants to eligible entities specified in subsection
 (b) for the purpose of—
 
 
-     HR 3590 EAS/PP
-                           2232
           ‘‘(1) screening at-risk individuals (as defined in
       subsection (c)(1)) for environmental health conditions
       (as defined in subsection (c)(3)); and
@@ -62908,8 +58448,6 @@ competitive grants to eligible entities specified in subsection
                ‘‘(C) A facility of the Indian Health Serv-
           ice.
 
-      HR 3590 EAS/PP
-                            2233
                ‘‘(D) A National Cancer Institute-des-
           ignated cancer center.
                ‘‘(E) An agency of any State or local gov-
@@ -62936,8 +58474,6 @@ competitive grants to eligible entities specified in subsection
                ating Unit 7; or
 
 
-      HR 3590 EAS/PP
-                           2234
                ‘‘(ii) meets such other criteria as the Sec-
           retary determines appropriate considering the
           type of environmental health condition at issue;
@@ -62964,8 +58500,6 @@ competitive grants to eligible entities specified in subsection
                    ‘‘(ii) such other diagnostic standards
                as the Secretary specifies;
 
-      HR 3590 EAS/PP
-                            2235
                ‘‘(B) mesothelioma, or malignancies of the
           lung, colon, rectum, larynx, stomach, esophagus,
           pharynx, or ovary, as established by—
@@ -62992,8 +58526,6 @@ competitive grants to eligible entities specified in subsection
       site’ means a site included on the National Priorities
       List developed by the President in accordance with
 
-      HR 3590 EAS/PP
-                           2236
      section 105(a)(8)(B) of the Comprehensive Environ-
      mental Response, Compensation, and Liability Act of
      1980 (42 U.S.C. 9605(a)(8)(B)).
@@ -63020,8 +58552,6 @@ relating to an at-risk individual.
      2005(a) shall apply to a grant awarded under this
      section to the same extent and in the same manner
 
-      HR 3590 EAS/PP
-                          2237
      as such section applies to payments to States under
      this title, except that paragraph (4) of such section
      shall not be construed to prohibit grantees from con-
@@ -63048,8 +58578,6 @@ relating to an at-risk individual.
                   subclause (II)) may not be less than
                   1.00.
 
-      HR 3590 EAS/PP
-                          2238
                        ‘‘(II) FRONTIER    STATE   DE -
                   FINED .—In this clause, the term ‘fron-
                   tier State’ means a State in which at
@@ -63076,8 +58604,6 @@ relating to an at-risk individual.
  H OSPITAL OUTPATIENT  DEPARTMENT   SERVICES IN FRON -
  TIER STATES .—Section 1833(t) of the Social Security Act
 
-      HR 3590 EAS/PP
-                           2239
 (42 U.S.C. 1395l(t)), as amended by section 3138, is
 amended—
           (1) in paragraph (2)(D), by striking ‘‘the Sec-
@@ -63104,8 +58630,6 @@ amended—
           lated share adjustment under section
           1886(d)(5)(H).’’.
 
-      HR 3590 EAS/PP
-                          2240
      (c) FLOOR FOR  PRACTICE  EXPENSE  INDEX FOR  PHY -
  SICIANS’ SERVICES  FURNISHED IN   FRONTIER  STATES .—
 Section 1848(e)(1) of the Social Security Act (42 U.S.C.
@@ -63132,8 +58656,6 @@ Section 1848(e)(1) of the Social Security Act (42 U.S.C.
               State that receives a non-labor related share
               adjustment under section 1886(d)(5)(H).’’.
 
-      HR 3590 EAS/PP
-                            2241
  SEC. 10325. REVISION TO SKILLED NURSING FACILITY PRO-
               SPECTIVE PAYMENT SYSTEM.
       (a) T EMPORARY     DELAY   OF   RUG–IV.—Notwith-
@@ -63160,8 +58682,6 @@ interpreted as delaying the implementation of Version 3.0
 of the Minimum Data Sets (MDS 3.0) beyond the planned
 implementation date of October 1, 2010.
 
-      HR 3590 EAS/PP
-                           2242
  SEC. 10326. PILOT TESTING PAY-FOR-PERFORMANCE PRO-
              GRAMS FOR CERTAIN MEDICARE PROVIDERS.
      (a) IN  GENERAL .—Not later than January 1, 2016,
@@ -63188,8 +58708,6 @@ in this paragraph are the following:
      1861(dd)(2) of such Act (42 U.S.C. 1395x(dd)(2))).
      (c) W AIVER  AUTHORITY .—The Secretary may waive
 such requirements of titles XI and XVIII of the Social Secu-
-      HR 3590 EAS/PP
-                           2243
 rity Act as may be necessary solely for purposes of carrying
 out the pilot programs under this section.
      (d) NO A DDITIONAL P ROGRAM  EXPENDITURES  .—Pay-
@@ -63216,8 +58734,6 @@ retary, if—
               (B) improve the quality of care and reduce
           spending;
 
-      HR 3590 EAS/PP
-                           2244
           (2) the Chief Actuary of the Centers for Medicare
      & Medicaid Services certifies that such expansion
      would reduce program spending under such title
@@ -63244,8 +58760,6 @@ at the end the following new paragraph:
           professional shall meet the following require-
           ments:
 
-      HR 3590 EAS/PP
-                            2245
                     ‘‘(i) The eligible professional shall—
                         ‘‘(I) satisfactorily submit data on
                     quality measures for purposes of para-
@@ -63272,8 +58786,6 @@ at the end the following new paragraph:
                     fined in subparagraph (C)(ii)) for such
                     year.
 
-      HR 3590 EAS/PP
-                            2246
                     ‘‘(iii) A Maintenance of Certification
                program submits to the Secretary, on behalf
                of the eligible professional, information—
@@ -63300,8 +58812,6 @@ at the end the following new paragraph:
                ment program, such as qualified American
                Board of Medical Specialties Maintenance
 
-      HR 3590 EAS/PP
-                            2247
                of Certification program or an equivalent
                program (as determined by the Secretary),
                that advances quality and the lifelong
@@ -63328,8 +58838,6 @@ at the end the following new paragraph:
                     agnostic skills, medical knowledge, and
 
 
-      HR 3590 EAS/PP
-                            2248
                     clinical judgment to provide quality
                     care in their respective specialty.
                          ‘‘(IV) The program requires suc-
@@ -63356,8 +58864,6 @@ at the end the following new paragraph:
                     measure to assess performance im-
                     provement after such intervention.’’.
 
-      HR 3590 EAS/PP
-                           2249
      (b) A UTHORITY .—Section 3002(c) of this Act is
 amended by adding at the end the following new paragraph:
           ‘‘(3) UTHORITY  .—For years after 2014, if the
@@ -63384,8 +58890,6 @@ amended by adding at the end the following new paragraph:
 
 
 
-      HR 3590 EAS/PP
-                           2250
  SEC. 10328. IMPROVEMENT IN PART D MEDICATION THER-
              APY MANAGEMENT (MTM) PROGRAMS.
      (a) IN G ENERAL .—Section 1860D–4(c)(2) of the So-
@@ -63412,8 +58916,6 @@ ed—
               the Secretary) by a licensed pharmacist or
               other qualified provider. The comprehensive
               medication review—
-      HR 3590 EAS/PP
-                            2251
                         ‘‘(I) shall include a review of the
                     individual’s medications and may re-
                     sult in the creation of a recommended
@@ -63440,8 +58942,6 @@ ed—
           sess, at least on a quarterly basis, the medication
           use of individuals who are at risk but not en-
 
-      HR 3590 EAS/PP
-                            2252
           rolled in the medication therapy management
           program, including individuals who have experi-
           enced a transition in care, if the prescription
@@ -63468,8 +58968,6 @@ for Medicare and Medicaid Innovation under section 1115A
 of such Act, as added by section 3021.
 
 
-      HR 3590 EAS/PP
-                            2253
  SEC. 10329. DEVELOPING METHODOLOGY TO ASSESS
               HEALTH PLAN VALUE.
       (a) D EVELOPMENT  .—The Secretary of Health and
@@ -63496,8 +58994,6 @@ gress a report concerning the methodology developed under
 subsection (a).
 
 
-      HR 3590 EAS/PP
-                           2254
  SEC. 10330. MODERNIZING COMPUTER AND DATA SYSTEMS
              OF THE CENTERS FOR MEDICARE & MED-
              ICAID SERVICES TO SUPPORT IMPROVE-
@@ -63524,8 +59020,6 @@ tem could—
 after the date of the enactment of this Act, the Secretary
 shall post on the website of the Centers for Medicare & Med-
 icaid Services the plan described in subsection (a).
-      HR 3590 EAS/PP
-                           2255
  SEC. 10331. PUBLIC REPORTING OF PERFORMANCE INFOR-
              MATION.
      (a) ING ENERAL .—
@@ -63552,8 +59046,6 @@ icaid Services the plan described in subsection (a).
      quirements of this section are available, such informa-
      tion, to the extent practicable, shall include—
 
-      HR 3590 EAS/PP
-                           2256
                (A) measures collected under the Physician
           Quality Reporting Initiative;
                (B) an assessment of patient health out-
@@ -63580,8 +59072,6 @@ clude—
      Secretary;
 
 
-      HR 3590 EAS/PP
-                            2257
           (2) processes by which a physician or other eligi-
       ble professional whose performance on measures is
       being publicly reported has a reasonable opportunity,
@@ -63608,8 +59098,6 @@ clude—
       that support valid, reliable, and accurate public re-
       porting activities authorized under this section.
 
-      HR 3590 EAS/PP
-                          2258
      (c) ENSURING P ATIENT PRIVACY.—The Secretary shall
 ensure that information on physician performance and pa-
 tient experience is not disclosed under this section in a
@@ -63636,8 +59124,6 @@ on the Physician Compare Internet website developed under
 subsection (a)(1). Such report shall include information on
 the efforts of and plans made by the Secretary to collect
 
-      HR 3590 EAS/PP
-                          2259
 and publish data on physician quality and efficiency and
 on patient experience of care in support of value-based pur-
 chasing and consumer choice, together with recommenda-
@@ -63664,8 +59150,6 @@ program does not disadvantage those beneficiaries without
 reasonable access to high performing physicians or create
 financial inequities under such title.
 
-      HR 3590 EAS/PP
-                           2260
      (i) DEFINITIONS.—In this section:
           (1) ELIGIBLE PROFESSIONAL  .—The term ‘‘eligi-
      ble professional’’ has the meaning given that term for
@@ -63692,8 +59176,6 @@ the following new subsection:
      graph (3) for the evaluation of the performance of
      providers of services and suppliers.
 
-      HR 3590 EAS/PP
-                            2261
           ‘‘(2) QUALIFIED ENTITIES .—For purposes of this
       subsection, the term ‘qualified entity’ means a public
       or private entity that—
@@ -63720,8 +59202,6 @@ the following new subsection:
           (3) shall be made available to a qualified entity
           under this subsection at a fee equal to the cost
 
-      HR 3590 EAS/PP
-                            2262
           of making such data available. Any fee collected
           pursuant to the preceding sentence shall be de-
           posited into the Federal Supplementary Medical
@@ -63748,8 +59228,6 @@ the following new subsection:
                cost-effective, or relevant to dimensions of
 
 
-      HR 3590 EAS/PP
-                           2263
                quality and resource use not addressed by
                such standard measures;
                    ‘‘(iii) include data made available
@@ -63776,8 +59254,6 @@ the following new subsection:
                tion of the measures, which shall include
                quality measures and the rationale for use
 
-      HR 3590 EAS/PP
-                            2264
                of other measures described in subparagraph
                (B)(ii)(II), risk adjustment methods, physi-
                cian attribution methods, other applicable
@@ -63804,8 +59280,6 @@ the following new subsection:
           the information on the evaluation of performance
           of providers of services and suppliers. Such enti-
 
-      HR 3590 EAS/PP
-                          2265
           ty shall only use such data, and information de-
           rived from such evaluation, for the reports under
           subparagraph (C). Data released to a qualified
@@ -63832,8 +59306,6 @@ care networks that meet the requirements of subsection (b).
           ‘‘(1)ESCRIPTION .—A community-based collabo-
      rative care network (referred to in this section as a
 
-      HR 3590 EAS/PP
-                            2266
       ‘network’) shall be a consortium of health care pro-
       viders with a joint governance structure (including
       providers within a single entity) that provides com-
@@ -63860,8 +59332,6 @@ care networks that meet the requirements of subsection (b).
           dividuals; and
 
 
-      HR 3590 EAS/PP
-                           2267
                ‘‘(C) a county or municipal department of
           health.
      ‘‘(c) PPLICATION .—
@@ -63888,8 +59358,6 @@ care networks that meet the requirements of subsection (b).
                ‘‘(D) Provide transportation.
 
 
-      HR 3590 EAS/PP
-                          2268
               ‘‘(E) Expand capacity, including through
           telehealth, after-hours services or urgent care.
               ‘‘(F) Provide direct patient care services.
@@ -63916,8 +59384,6 @@ through 2015.’’.
           fice of the Secretary in such manner that there
           is established in the Office of the Secretary, the
 
-      HR 3590 EAS/PP
-                            2269
           Office of Minority Health, which shall be headed
           by the Deputy Assistant Secretary for Minority
           Health who shall report directly to the Secretary,
@@ -63944,8 +59410,6 @@ through 2015.’’.
           ties, language services, workforce cultural com-
 
 
-      HR 3590 EAS/PP
-                            2270
           petence, and other areas as determined by the
           Secretary.’’; and
                (B) by striking subsection (h) and inserting
@@ -63972,8 +59436,6 @@ of fiscal years 2011 through 2016.’’.
       date of enactment of this section, and biennially
       thereafter, the Secretary of Health and Human Serv-
 
-      HR 3590 EAS/PP
-                         2271
      ices shall prepare and submit to the appropriate com-
      mittees of Congress a report describing the activities
      carried out under section 1707 of the Public Health
@@ -64000,8 +59462,6 @@ in subsection (b)(1) shall establish within the agency an of-
 fice to be known as the Office of Minority Health. The head
 of each such Office shall be appointed by the head of the
 
-      HR 3590 EAS/PP
-                            2272
 agency within which the Office is established, and shall re-
 port directly to the head of the agency. The head of such
 agency shall carry out this section (as this section relates
@@ -64028,8 +59488,6 @@ in the Office of the Secretary.
       priated for a specified agency for a fiscal year, the
       Secretary must designate an appropriate amount of
 
-      HR 3590 EAS/PP
-                           2273
       funds for the purpose of carrying out activities under
       this section through the minority health office of the
       agency. In reserving an amount under the preceding
@@ -64056,8 +59514,6 @@ in the Office of the Secretary.
       Department of Health and Human Services on the
       date of enactment of this section shall not be termi-
 
-      HR 3590 EAS/PP
-                          2274
      nated, reorganized, or have any of its power or duties
      transferred unless such termination, reorganization,
      or transfer is approved by an Act of Congress.
@@ -64084,8 +59540,6 @@ in the Office of the Secretary.
 
 
 
-      HR 3590 EAS/PP
-                            2275
                     (iii) by striking ‘‘Center’’ each place
                such term appears and inserting ‘‘Insti-
                tute’’.
@@ -64112,8 +59566,6 @@ view and evaluate research and other activities conducted
 or supported by the Institutes and Centers of the National
 Institutes of Health.’’.
 
-      HR 3590 EAS/PP
-                           2276
           (3) T ECHNICAL    AND  CONFORMING    AMEND   -
      MENTS .—
               (A) Section 401(b)(24) of the Public Health
@@ -64140,8 +59592,6 @@ by inserting ‘‘, other than measures of readmissions,’’ after
      furnished to such beneficiaries for the treatment of
      end stage renal disease in the bundled prospective
 
-      HR 3590 EAS/PP
-                            2277
       payment system under section 1881(b)(14) of the So-
       cial Security Act (42 U.S.C. 1395rr(b)(14)) (pursu-
       ant to the proposed rule published by the Secretary of
@@ -64168,8 +59618,6 @@ by inserting ‘‘, other than measures of readmissions,’’ after
       injectable equivalent (or other non-oral form of ad-
       ministration).
 
-      HR 3590 EAS/PP
-                            2278
       (b) REPORT .—Not later than 1 year after the date of
 the enactment of this Act, the Comptroller General of the
 United States shall submit to Congress a report containing
@@ -64196,8 +59644,6 @@ ing ‘‘a Gateway’’ and inserting ‘‘an Exchange’’.
 ice Act, as added by section 4101(b) of this Act, is amended
 by inserting ‘‘and vision’’ after ‘‘oral’’.
 
-      HR 3590 EAS/PP
-                            2279
       (b) Section 1861(hhh)(4)(G) of the Social Security Act,
 as added by section 4103(b), is amended to read as follows:
                ‘‘(G) A beneficiary shall be eligible to re-
@@ -64224,8 +59670,6 @@ as added by section 4103(b), is amended to read as follows:
 
 
 
-      HR 3590 EAS/PP
-                          2280
  SEC. 10404. AMENDMENTS TO SUBTITLE D.
      Section 399MM(2) of the Public Health Service Act,
 as added by section 4303 of this Act, is amended by striking
@@ -64252,8 +59696,6 @@ Act (42 U.S.C. 1395l(a)(1)), as amended by section
           percent’’ for ‘‘80 percent’’)’ after ‘subparagraph
           (D)’; and
 
-      HR 3590 EAS/PP
-                           2281
               ‘‘(B) in clause (ii), by striking ‘80 percent’
           and inserting ‘100 percent’;
           ‘‘(3) by striking ‘and’ before ‘(X)’; and
@@ -64280,8 +59722,6 @@ Act (42 U.S.C. 1395l(a)(1)), as amended by section
      tion with the Director of the Centers for Disease Con-
      trol and Prevention (referred to in this section as the
 
-      HR 3590 EAS/PP
-                           2282
      ‘‘Director’’), shall prepare on a biennial basis a na-
      tional diabetes report card (referred to in this section
      as a ‘‘Report Card’’) and, to the extent possible, for
@@ -64308,8 +59748,6 @@ Act (42 U.S.C. 1395l(a)(1)), as amended by section
                velopment.
 
 
-      HR 3590 EAS/PP
-                           2283
           (3) AVAILABILITY.—The Secretary, in collabora-
      tion with the Director, shall make each Report Card
      publicly available, including by posting the Report
@@ -64336,8 +59774,6 @@ Act (42 U.S.C. 1395l(a)(1)), as amended by section
      retary may promote improvements to the collection of
      diabetes mortality data, including the addition of a
 
-      HR 3590 EAS/PP
-                          2284
      question for the individual certifying the cause of
      death regarding whether the deceased had diabetes.
      (d) STUDY ON   APPROPRIATE   LEVEL OF  D IABETES
@@ -64364,8 +59800,6 @@ sums as may be necessary.
 
 
 
-      HR 3590 EAS/PP
-                          2285
  SEC. 10408. GRANTS FOR SMALL BUSINESSES TO PROVIDE
              COMPREHENSIVE WORKPLACE WELLNESS
              PROGRAMS.
@@ -64392,8 +59826,6 @@ described under subsection (c)).
      consistent with evidence-based research and best prac-
      tices, including research and practices as provided in
      the Guide to Community Preventive Services, the
-      HR 3590 EAS/PP
-                            2286
       Guide to Clinical Preventive Services, and the Na-
       tional Registry for Effective Programs.
           (2) R  EQUIREMENTS  .—A comprehensive work-
@@ -64420,8 +59852,6 @@ submit an application to the Secretary, in such manner
 and containing such information as the Secretary may re-
 quire, which shall include a proposal for a comprehensive
 
-      HR 3590 EAS/PP
-                         2287
 workplace wellness program that meet the criteria and re-
 quirements described under subsection (c).
      (e) AUTHORIZATION OF   APPROPRIATION.—For pur-
@@ -64448,8 +59878,6 @@ is amended—
      (c) ACCEPTING GIFTS T O SUPPORT THE  C URES A C-
  CELERATION  NETWORK .—Section 499(c)(1) of the Public
 
-      HR 3590 EAS/PP
-                           2288
 Health Service Act (42 U.S.C. 290b(c)(1)) is amended by
 adding at the end the following:
               ‘‘(E) The Cures Acceleration Network de-
@@ -64476,8 +59904,6 @@ Act is amended by inserting after section 402B (42 U.S.C.
      NIH—
 
 
-      HR 3590 EAS/PP
-                           2289
                ‘‘(A) is a priority to diagnose, mitigate,
           prevent, or treat harm from any disease or con-
           dition; and
@@ -64504,8 +59930,6 @@ Cures Acceleration Network (referred to in this section as
      development of medical products and behavioral
      therapies.
 
-      HR 3590 EAS/PP
-                            2290
       ‘‘(c) UNCTIONS .—The functions of the CAN are to—
           ‘‘(1) conduct and support revolutionary advances
       in basic research, translating scientific discoveries
@@ -64532,8 +59956,6 @@ Cures Acceleration Network (referred to in this section as
           expediting the development and approval of
           countermeasures and products; and
 
-      HR 3590 EAS/PP
-                           2291
               ‘‘(C) connecting interested persons with ad-
           ditional technical assistance made available
           under section 565 of the Federal Food, Drug,
@@ -64560,8 +59982,6 @@ Cures Acceleration Network (referred to in this section as
                    ‘‘(i)N GENERAL  .—Each member shall
               be appointed to serve a 4-year term, except
 
-      HR 3590 EAS/PP
-                            2292
                that any member appointed to fill a va-
                cancy occurring prior to the expiration of
                the term for which the member’s predecessor
@@ -64588,8 +60008,6 @@ Cures Acceleration Network (referred to in this section as
                              ‘‘(aa) basic research;
                              ‘‘(bb) medicine;
 
-      HR 3590 EAS/PP
-                            2293
                              ‘‘(cc) biopharmaceuticals;
                              ‘‘(dd) discovery and delivery
                         of medical products;
@@ -64616,8 +60034,6 @@ Cures Acceleration Network (referred to in this section as
           the Board—
 
 
-      HR 3590 EAS/PP
-                           2294
                    ‘‘(i) a representative of the National
                Institutes of Health, recommended by the
                Secretary of the Department of Health and
@@ -64644,8 +60060,6 @@ Cures Acceleration Network (referred to in this section as
           ‘‘(4) ESPONSIBILITIES OF THE BOARD AND THE
       DIRECTOR OF NIH .—
 
-      HR 3590 EAS/PP
-                           2295
                ‘‘(A) ESPONSIBILITIES OF THE BOARD   .—
                    ‘‘(i) N GENERAL   .—The Board shall
                advise, and provide recommendations to, the
@@ -64672,8 +60086,6 @@ Cures Acceleration Network (referred to in this section as
           Director will implement such recommendation.
           In the case that the Director of NIH indicates a
 
-      HR 3590 EAS/PP
-                           2296
           recommendation of the Board will not be imple-
           mented, such Director shall provide an expla-
           nation of the reasons for not implementing such
@@ -64700,8 +60112,6 @@ Cures Acceleration Network (referred to in this section as
                ital or private equity organization.
           ‘‘(6) OMPENSATION AND TRAVEL EXPENSES     .—
 
-      HR 3590 EAS/PP
-                           2297
                ‘‘(A) COMPENSATION  .—Members shall re-
           ceive compensation at a rate to be fixed by the
           Chairperson but not to exceed a rate equal to the
@@ -64728,8 +60138,6 @@ Cures Acceleration Network (referred to in this section as
       the purposes described in this section, the Director of
       NIH shall award contracts, grants, or cooperative
 
-      HR 3590 EAS/PP
-                           2298
       agreements to the entities described in paragraph (2),
       to—
                ‘‘(A) promote innovation in technologies
@@ -64756,8 +60164,6 @@ Cures Acceleration Network (referred to in this section as
           tion, an institution of higher education, a med-
           ical center, a biotechnology company, a pharma-
 
-      HR 3590 EAS/PP
-                            2299
           ceutical company, a disease advocacy organiza-
           tion, a patient advocacy organization, or an
           academic research institution;
@@ -64784,8 +60190,6 @@ Cures Acceleration Network (referred to in this section as
                Drug Administration standards and regu-
                latory requirements at all stages of develop-
 
-      HR 3590 EAS/PP
-                           2300
                ment, manufacturing, review, approval, and
                safety surveillance of a medical product;
                and
@@ -64812,8 +60216,6 @@ Cures Acceleration Network (referred to in this section as
                subsequent to the initial award under clause
                (i).
 
-      HR 3590 EAS/PP
-                           2301
                    ‘‘(iii) ATCHING FUNDS  .—As a condi-
               tion for receiving an award under this sub-
               section, an eligible entity shall contribute to
@@ -64840,8 +60242,6 @@ Cures Acceleration Network (referred to in this section as
               ting to the Board the information required
               under subparagraphs (B) and (C) of para-
 
-      HR 3590 EAS/PP
-                            2302
                graph (2). The Director of NIH may fund
                a project of such eligible entity in an
                amount not to exceed $15,000,000 for a fis-
@@ -64868,8 +60268,6 @@ Cures Acceleration Network (referred to in this section as
       funds.
 
 
-      HR 3590 EAS/PP
-                           2303
           ‘‘(5) UDITS .—The Director of NIH may enter
      into agreements with other entities to conduct peri-
      odic audits of the projects funded by grants or con-
@@ -64896,8 +60294,6 @@ shall be awarded on a competitive basis.
           ‘‘(2) IMITATION ON USE OF FUNDS OTHERWISE
      APPROPRIATED  .—No funds appropriated under this
 
-      HR 3590 EAS/PP
-                          2304
      Act, other than funds appropriated under paragraph
      (1), may be allocated to the Cures Acceleration Net-
      work.’’.
@@ -64924,8 +60320,6 @@ bipolar disorder, and related mood disorders.
      in this section as ‘Centers’), which shall engage in ac-
 
 
-      HR 3590 EAS/PP
-                           2305
       tivities related to the treatment of depressive dis-
       orders.
           ‘‘(2) LLOCATION OF AWARDS   .—If the funds au-
@@ -64952,8 +60346,6 @@ bipolar disorder, and related mood disorders.
       ment and ongoing activities of the recipient of such
       funds.
 
-      HR 3590 EAS/PP
-                            2306
           ‘‘(5) ELIGIBLE ENTITIES .—
                ‘‘(A) REQUIREMENTS  .—To be eligible to re-
           ceive a grant under this section, an entity
@@ -64980,8 +60372,6 @@ bipolar disorder, and related mood disorders.
 
 
 
-      HR 3590 EAS/PP
-                            2307
                          ‘‘(III) is capable of training
                     health professionals about mental
                     health; and
@@ -65008,8 +60398,6 @@ bipolar disorder, and related mood disorders.
                practices, and interventions available.
 
 
-      HR 3590 EAS/PP
-                           2308
                    ‘‘(vi) Demonstrated capacity to estab-
                lish cooperative and collaborative agree-
                ments with community mental health cen-
@@ -65036,8 +60424,6 @@ bipolar disorder, and related mood disorders.
                ‘‘(C) D UTIES.—The coordinating center
           shall—
 
-      HR 3590 EAS/PP
-                            2309
                     ‘‘(i) develop, administer, and coordi-
                nate the network of Centers under this sec-
                tion;
@@ -65064,8 +60450,6 @@ bipolar disorder, and related mood disorders.
       directly or through donations from public or private
 
 
-      HR 3590 EAS/PP
-                            2310
       entities and may be in cash or in-kind, fairly evalu-
       ated, including plant, equipment, or services.
       ‘‘(c)CTIVITIES OF THE  CENTERS  .—Each Center shall
@@ -65092,8 +60476,6 @@ carry out the following activities:
           sive disorders to reduce stigma and raise aware-
           ness of treatments.
 
-      HR 3590 EAS/PP
-                            2311
            ‘‘(2) MPROVED TREATMENT STANDARDS       , CLIN-
       ICAL GUIDELINES  ,DIAGNOSTIC PROTOCOLS   , AND CARE
       COORDINATION PRACTICE   .—Each Center shall collabo-
@@ -65120,8 +60502,6 @@ carry out the following activities:
 
 
 
-      HR 3590 EAS/PP
-                           2312
           ‘‘(3) RANSLATIONAL RESEARCH THROUGH COL       -
       LABORATION OF CENTERS AND COMMUNITY     BASED OR  -
       GANIZATIONS .—Each Center shall—
@@ -65148,8 +60528,6 @@ carry out the following activities:
 
 
 
-      HR 3590 EAS/PP
-                          2313
           ‘‘(2) ATA COLLECTION .—Each Center shall sub-
      mit data gathered at such center, as appropriate, to
      the coordinating center regarding—
@@ -65176,8 +60554,6 @@ carry out the following activities:
 
 
 
-      HR 3590 EAS/PP
-                           2314
           ‘‘(1) STABLISHMENT OF STANDARDS     .—The Sec-
       retary, acting through the Administrator, shall estab-
       lish performance standards for—
@@ -65204,8 +60580,6 @@ carry out the following activities:
 
 
 
-      HR 3590 EAS/PP
-                           2315
                ‘‘(B) make recommendations to Congress for
           expanding the Centers to serve individuals with
           other types of mental disorders.
@@ -65232,8 +60606,6 @@ carry out the following activities:
       more than $10,000,000 to the coordinating center.’’.
 
 
-      HR 3590 EAS/PP
-                          2316
  SEC. 10411. PROGRAMS RELATING TO CONGENITAL HEART
              DISEASE.
      (a) SHORT T ITLE.—This subtitle may be cited as the
@@ -65260,8 +60632,6 @@ may—
          ‘‘(2) award a grant to one eligible entity to un-
      dertake the activities described in paragraph (1).
 
-      HR 3590 EAS/PP
-                            2317
       ‘‘(b) URPOSE  .—The purpose of the Congenital Heart
 Disease Surveillance System shall be to facilitate further
 research into the types of health services patients use and
@@ -65288,8 +60658,6 @@ veillance System—
            congenital heart disease patients; and
 
 
-      HR 3590 EAS/PP
-                           2318
           ‘‘(3) may ensure the collection and analysis of
       longitudinal data related to individuals of all ages
       with congenital heart disease, including infants,
@@ -65316,8 +60684,6 @@ a grant under subsection (a)(2), an entity shall—
       adding at the end the following:
 
 
-      HR 3590 EAS/PP
-                          2319
  ‘‘SEC. 425. CONGENITAL HEART DISEASE.
      ‘‘(a) N GENERAL .—The Director of the Institute may
 expand, intensify, and coordinate research and related ac-
@@ -65344,8 +60710,6 @@ institutions and may develop research networks.
  MUNITIES .—In carrying out the activities described in this
 section, the Director of the Institute shall consider the appli-
 
-      HR 3590 EAS/PP
-                           2320
 cation of such research and other activities to minority and
 medically underserved communities.’’.
      (c) AUTHORIZATION OF   A PPROPRIATIONS .—There are
@@ -65372,8 +60736,6 @@ U.S.C. 244) is amended—
 ‘‘Young Women’s Breast Health Education and Awareness
 
 
-      HR 3590 EAS/PP
-                          2321
 Requires Learning Young Act of 2009’’ or the ‘‘EARLY
 Act’’.
      (b) AMENDMENT  .—Title III of the Public Health Serv-
@@ -65400,8 +60762,6 @@ is further amended by adding at the end the following:
           familial, racial, ethnic, and cultural back-
           grounds such as Ashkenazi Jewish populations;
 
-      HR 3590 EAS/PP
-                            2322
                ‘‘(D) evidence-based information that would
           encourage young women and their health care
           professional to increase early detection of breast
@@ -65428,8 +60788,6 @@ is further amended by adding at the end the following:
                ‘‘(A) ESTABLISHMENT  .—Not later than 60
           days after the date of the enactment of this sec-
 
-      HR 3590 EAS/PP
-                           2323
           tion, the Secretary, acting through the Director
           of the Centers for Disease Control and Preven-
           tion, shall establish an advisory committee to as-
@@ -65456,8 +60814,6 @@ campaign among physicians and other health care profes-
 sionals to increase awareness—
 
 
-      HR 3590 EAS/PP
-                            2324
           ‘‘(1) of breast health, symptoms, and early diag-
       nosis and treatment of breast cancer in young women,
       including specific risk factors such as family history
@@ -65484,8 +60840,6 @@ sionals to increase awareness—
       young women diagnosed with breast cancer.
 
 
-      HR 3590 EAS/PP
-                           2325
      ‘‘(c) PREVENTION  R ESEARCH  A CTIVITIES.—The Sec-
 retary, acting through—
           ‘‘(1) the Director of the Centers for Disease Con-
@@ -65512,8 +60866,6 @@ retary, acting through—
      new screening tests and methods for prevention and
      early detection of breast cancer in young women.
 
-      HR 3590 EAS/PP
-                          2326
      ‘‘(d) UPPORT FOR  YOUNG W OMEN  DIAGNOSED  W ITH
  BREAST C ANCER.—
          ‘‘(1) N GENERAL  .—The Secretary shall award
@@ -65540,8 +60892,6 @@ and Prevention, shall—
          cer history, specific risk factors and early warn-
 
 
-      HR 3590 EAS/PP
-                            2327
           ing signs, and young women’s proactive efforts
           at early detection;
                ‘‘(B) the number or percentage of young
@@ -65568,8 +60918,6 @@ to be appropriated $9,000,000 for each of the fiscal years
 
 
 
-      HR 3590 EAS/PP
-                           2328
   Subtitle E—Provisions Relating to
                        Title V
  SEC. 10501. AMENDMENTS TO THE PUBLIC HEALTH SERV-
@@ -65596,8 +60944,6 @@ ing at the end the following:
 
 
 
-      HR 3590 EAS/PP
-                            2329
  ‘‘SEC. 5104. INTERAGENCY TASK FORCE TO ASSESS AND IM-
               PROVE ACCESS TO HEALTH CARE IN THE
               STATE OF ALASKA.
@@ -65624,8 +60970,6 @@ follows:
           icaid Services.
                ‘‘(C) The Indian Health Service.
 
-      HR 3590 EAS/PP
-                            2330
           ‘‘(2) The Secretary of Defense shall appoint one
       representative of the TRICARE Management Activity.
           ‘‘(3) The Secretary of the Army shall appoint
@@ -65652,8 +60996,6 @@ of enactment of this Act, the Task Force shall submit to
 Congress a report detailing the activities of the Task Force
 and containing the findings, strategies, recommendations,
 
-      HR 3590 EAS/PP
-                             2331
 policies, and initiatives developed pursuant to the duty de-
 scribed in subsection (b)(2). In preparing such report, the
 Task Force shall consider completed and ongoing efforts by
@@ -65680,8 +61022,6 @@ ing at the end the following:
 
 
 
-      HR 3590 EAS/PP
-                            2332
  ‘‘SEC. 5316. DEMONSTRATION GRANTS FOR FAMILY NURSE
               PRACTITIONER TRAINING PROGRAMS.
       ‘‘(a) STABLISHMENT OF    P ROGRAM  .—The Secretary
@@ -65708,8 +61048,6 @@ able each grant recipient to—
       tionwide.
       ‘‘(c) GRANTS .—The Secretary shall award 3-year
 grants to eligible entities that meet the requirements estab-
-      HR 3590 EAS/PP
-                           2333
 lished by the Secretary, for the purpose of operating the
 nurse practitioner primary care programs described in sub-
 section (a) in such entities.
@@ -65736,8 +61074,6 @@ to eligible entities that—
       entity;
 
 
-      HR 3590 EAS/PP
-                           2334
           ‘‘(2) will assign not less than 1 staff nurse prac-
       titioner or physician to each of 4 precepted clinics;
           ‘‘(3) will provide to each awardee specialty rota-
@@ -65764,8 +61100,6 @@ to eligible entities that—
 
 
 
-      HR 3590 EAS/PP
-                          2335
               ‘‘(B) demonstrate commitment to a career
           as a primary care provider in a FQHC or in a
           NMHC.
@@ -65792,8 +61126,6 @@ tablishing a nurse practitioner residency training program.
 Such technical assistance grants shall be for the purpose
 
 
-      HR 3590 EAS/PP
-                             2336
 of providing technical assistance to other recipients of
 grants under subsection (c).
       ‘‘(i) UTHORIZATION OF    APPROPRIATIONS   .—To carry
@@ -65820,8 +61152,6 @@ and inserting ‘‘399V–1’’.
 Act 42 U.S.C. 280g et seq.), as amended by section 10411,
 is amended by adding at the end the following:
 
-      HR 3590 EAS/PP
-                            2337
  ‘‘SEC. 399V–3. NATIONAL DIABETES PREVENTION PROGRAM.
       ‘‘(a)NIG ENERAL .—The Secretary, acting through the
 Director of the Centers for Disease Control and Prevention,
@@ -65848,8 +61178,6 @@ health department, a tribal organization, a national net-
 work of community-based non-profits focused on health and
 wellbeing, an academic institution, or other entity, as the
 Secretary determines.
-      HR 3590 EAS/PP
-                           2338
      ‘‘(d) AUTHORIZATION OF   APPROPRIATIONS .—For the
 purpose of carrying out this section, there are authorized
 to be appropriated such sums as may be necessary for each
@@ -65876,8 +61204,6 @@ by adding at the end the following new subsection:
               ‘‘(A) N GENERAL  .—The Secretary shall de-
           velop a prospective payment system for payment
 
-      HR 3590 EAS/PP
-                            2339
           for Federally qualified health center services fur-
           nished by Federally qualified health centers
           under this title. Such system shall include a
@@ -65904,8 +61230,6 @@ by adding at the end the following new subsection:
           tion 1833(a)(3)(A), the Secretary shall provide,
           for cost reporting periods beginning on or after
 
-      HR 3590 EAS/PP
-                           2340
           October 1, 2014, for payments of prospective
           payment rates for Federally qualified health cen-
           ter services furnished by Federally qualified
@@ -65932,8 +61256,6 @@ by adding at the end the following new subsection:
                mented.
 
 
-      HR 3590 EAS/PP
-                            2341
                     ‘‘(ii) PAYMENTS    IN   SUBSEQUENT
                YEARS .—Payment rates in years after the
                year of implementation of such system shall
@@ -65960,8 +61282,6 @@ by adding at the end the following new subsection:
           codes to be used under the prospective payment
           system under this section.’’.
 
-      HR 3590 EAS/PP
-                            2342
       (B) Section 1833(a)(1) of the Social Security Act (42
 U.S.C. 1395l(a)(1)), as amended by section 4104, is amend-
 ed—
@@ -65988,8 +61308,6 @@ U.S.C. 1395l(a)) is amended—
           (ii) by adding at the end the following flush sen-
       tence:
 
-      HR 3590 EAS/PP
-                           2343
       ‘‘Paragraph (3)(A) shall not apply to Federally
       qualified health center services furnished on or after
       the implementation date of the prospective payment
@@ -66016,8 +61334,6 @@ ing at the end the following:
 health care providers who treat a high percentage, as deter-
 
 
-      HR 3590 EAS/PP
-                           2344
 mined by such State, of medically underserved populations
 or other special populations in such State.
       ‘‘(b) OURCE OF   F UNDS .—A grant program estab-
@@ -66044,8 +61360,6 @@ Act (42 U.S.C. 293k et seq.) is amended—
       ‘‘(a)NIG ENERAL .—The Secretary, acting through the
 Administrator of the Health Resources and Services Admin-
 
-      HR 3590 EAS/PP
-                            2345
 istration, shall establish a grant program for the purposes
 of assisting eligible entities in recruiting students most like-
 ly to practice medicine in underserved rural communities,
@@ -66072,8 +61386,6 @@ that—
       practice medicine in underserved rural communities;
 
 
-      HR 3590 EAS/PP
-                           2346
           ‘‘(2) demonstrate that an existing academic pro-
      gram of the eligible entity produces a high percentage,
      as determined by the Secretary, of graduates from
@@ -66100,8 +61412,6 @@ that—
           ‘‘(2) TRUCTURE OF PROGRAM    .—An eligible en-
      tity shall—
 
-      HR 3590 EAS/PP
-                           2347
                ‘‘(A) enroll no fewer than 10 students per
           class year into the Program; and
                ‘‘(B) develop criteria for admission to the
@@ -66128,8 +61438,6 @@ that—
      Where available, the Program shall assist all students
      of the Program in obtaining clinical training experi-
 
-      HR 3590 EAS/PP
-                           2348
      ences in locations with postgraduate programs offer-
      ing residency training opportunities in underserved
      rural communities, or in local residency training pro-
@@ -66156,8 +61464,6 @@ ty receiving funds under this section shall use such funds
 to supplement, not supplant, any other Federal, State, and
 
 
-      HR 3590 EAS/PP
-                            2349
 local funds that would otherwise be expended by such entity
 to carry out the activities described in this section.
       ‘‘(h) MAINTENANCE OF   E FFORT .—With respect to ac-
@@ -66184,8 +61490,6 @@ cine specialties.
       ‘‘(b) LIGIBILITY.—To be eligible for a grant or con-
 tract under subsection (a), an entity shall be—
 
-      HR 3590 EAS/PP
-                            2350
           ‘‘(1) an accredited school of public health or
       school of medicine or osteopathic medicine;
           ‘‘(2) an accredited public or private nonprofit
@@ -66212,8 +61516,6 @@ or contract under this section shall be used to—
 
 
 
-      HR 3590 EAS/PP
-                            2351
       ‘‘(d) EPORT .—The Secretary shall submit to the Con-
 gress an annual report on the program carried out under
 this section.’’.
@@ -66240,8 +61542,6 @@ Service Act is amended—
       ical practice that is half time.’’;
           (B) in paragraph (2)—
 
-      HR 3590 EAS/PP
-                            2352
                (i) in subparagraphs (A)(ii) and (B), by
           striking ‘‘less than full time’’ each place it ap-
           pears and inserting ‘‘half time’’;
@@ -66268,8 +61568,6 @@ Service Act is amended—
       a demonstration project described in paragraph (1)’’
 
 
-      HR 3590 EAS/PP
-                            2353
       and inserting ‘‘In evaluating waivers issued under
       paragraph (1)’’.
       (2) Subsection (j) of section 331 of the Public Health
@@ -66296,8 +61594,6 @@ is amended—
            (A) by striking the second sentence and inserting
       the following: ‘‘The Secretary may treat teaching as
 
-      HR 3590 EAS/PP
-                            2354
       clinical practice for up to 20 percent of such period
       of obligated service.’’; and
            (B) by adding at the end the following: ‘‘Not-
@@ -66324,8 +61620,6 @@ States that contains a State’s sole public academic medical
 and dental school.
 
 
-      HR 3590 EAS/PP
-                            2355
       (b) REQUIREMENT  .—Amount appropriated under sub-
 section (a) may only be made available by the Secretary
 of Health and Human Services upon the receipt of an ap-
@@ -66352,8 +61646,6 @@ through the Office of the Secretary of the Department of
 Health and Human Services to provide for expanded and
 sustained national investment in community health centers
 
-      HR 3590 EAS/PP
-                           2356
 under section 330 of the Public Health Service Act and the
 National Health Service Corps.
       (b) UNDING .—There is authorized to be appropriated,
@@ -66380,8 +61672,6 @@ ury not otherwise appropriated, to the CHC Fund—
                (E) $310,000,000 for fiscal year 2015.
 
 
-      HR 3590 EAS/PP
-                            2357
       (c) ONSTRUCTION  .—There is authorized to be appro-
 priated, and there is appropriated, out of any monies in
 the Treasury not otherwise appropriated, $1,500,000,000 to
@@ -66408,8 +61698,6 @@ health care services to the uninsured at reduced fees. The
 Secretary shall evaluate the feasibility of expanding the
 project to additional States.
 
-      HR 3590 EAS/PP
-                           2358
      (b) E LIGIBILIT.—To be eligible to participate in the
 demonstration project, an entity shall be a State-based,
 nonprofit, public-private partnership that provides access
@@ -66436,8 +61724,6 @@ rity Act, as added by section 6001(a), is amended—
                (B) in clause (iv), by striking ‘‘July 1,
           2011’’ and inserting ‘‘January 1, 2012’’.
 
-      HR 3590 EAS/PP
-                           2359
      (b) CONFORMING   AMENDMENT  .—Section 6001(b)(2) of
 this Act is amended by striking ‘‘November 1, 2011’’ and
 inserting ‘‘May 1, 2012’’.
@@ -66464,8 +61750,6 @@ section 6301) is amended—
                viduals, entities, or instrumentalities that
                have a financial interest in the results, un-
 
-      HR 3590 EAS/PP
-                           2360
                less approved under a data use agreement
                with the Institute.’’;
           (2) in subsection (d)(8)(A)(iv), by striking ‘‘not
@@ -66492,8 +61776,6 @@ Security Act, as added by section 6401(a), is amended—
       (b) TECHNICAL  C ORRECTION .—Section 6401(a)(2) of
 this Act is amended to read as follows:
 
-      HR 3590 EAS/PP
-                            2361
           ‘‘(2) by redesignating paragraph (2) as para-
       graph (8); and’’.
  SEC. 10604. TECHNICAL CORRECTION TO SECTION 6405.
@@ -66520,8 +61802,6 @@ tion 6407(a)(1), is amended by inserting ‘‘, or a nurse prac-
 titioner or clinical nurse specialist (as those terms are de-
 fined in section 1861(aa)(5)) who is working in collabora-
 
-      HR 3590 EAS/PP
-                           2362
 tion with the physician in accordance with State law, or
 a certified nurse-midwife (as defined in section 1861(gg))
 as authorized by State law, or a physician assistant (as
@@ -66548,8 +61828,6 @@ ment that the physician’’.
       States Code, and in accordance with this subsection,
       the United States Sentencing Commission shall—
 
-      HR 3590 EAS/PP
-                           2363
                (A) review the Federal Sentencing Guide-
           lines and policy statements applicable to persons
           convicted of Federal health care offenses;
@@ -66576,8 +61854,6 @@ ment that the physician’’.
                ernment health care program which involves
 
 
-      HR 3590 EAS/PP
-                           2364
                a loss of not less than $7,000,000 and less
                than $20,000,000;
                    (iii) a 4-level increase in the offense
@@ -66604,8 +61880,6 @@ ment that the physician’’.
                in appropriate circumstances;
 
 
-      HR 3590 EAS/PP
-                          2365
               (B) consult with individuals or groups rep-
           resenting health care fraud victims, law enforce-
           ment officials, the health care industry, and the
@@ -66632,8 +61906,6 @@ amended—
      ingly’’; and
           (2) by adding at the end the following:
 
-      HR 3590 EAS/PP
-                         2366
      ‘‘(b) With respect to violations of this section, a person
 need not have actual knowledge of this section or specific
 intent to commit a violation of this section.’’.
@@ -66660,8 +61932,6 @@ of title 18, United States Code, is amended—
               (B) in paragraph (2)—
 
 
-      HR 3590 EAS/PP
-                           2367
                    (i) in subparagraph (A), by striking
                ‘‘grand jury subpoena’’ and inserting ‘‘sub-
                poena for records’’; and
@@ -66688,8 +61958,6 @@ States.
      ‘‘(b) I SSUANCE   AND    ENFORCEMENT    OF    SUB -
  POENAS .—
 
-      HR 3590 EAS/PP
-                           2368
           ‘‘(1) SSUANCE  .—Subpoenas issued under this
      section—
                ‘‘(A) shall bear the signature of the Attor-
@@ -66716,8 +61984,6 @@ tion—
           ‘‘(1) may not be used for any purpose other than
      to protect the rights, privileges, or immunities secured
 
-      HR 3590 EAS/PP
-                           2369
      or protected by the Constitution or laws of the United
      States of persons who reside, have resided, or will re-
      side in an institution;
@@ -66744,8 +62010,6 @@ amended by adding at the end the following:
 award demonstration grants to States for the development,
 implementation, and evaluation of alternatives to current
 
-      HR 3590 EAS/PP
-                           2370
 tort litigation for resolving disputes over injuries allegedly
 caused by health care providers or health care organiza-
 tions. In awarding such grants, the Secretary shall ensure
@@ -66772,8 +62036,6 @@ under subsection (a) for a period not to exceed 5 years.
 
 
 
-      HR 3590 EAS/PP
-                            2371
                ‘‘(A) makes the medical liability system
           more reliable by increasing the availability of
           prompt and fair resolution of disputes;
@@ -66800,8 +62062,6 @@ under subsection (a) for a period not to exceed 5 years.
                ‘‘(I) would not limit or curtail a patient’s
           existing legal rights, ability to file a claim in or
 
-      HR 3590 EAS/PP
-                            2372
           access a State’s legal system, or otherwise abro-
           gate a patient’s ability to file a medical mal-
           practice claim.
@@ -66828,8 +62088,6 @@ under subsection (a) for a period not to exceed 5 years.
           health care payer or patient population.
 
 
-      HR 3590 EAS/PP
-                            2373
                ‘‘(B) NOTIFICATION OF PATIENTS  .—A State
           shall demonstrate how patients would be notified
           that they are receiving health care services that
@@ -66856,8 +62114,6 @@ under subsection (a) for a period not to exceed 5 years.
           events; and
 
 
-      HR 3590 EAS/PP
-                           2374
                ‘‘(C) that make proposals that are likely to
           improve access to liability insurance.
       ‘‘(d) PPLICATION.—
@@ -66884,8 +62140,6 @@ under subsection (a) for a period not to exceed 5 years.
                entities receive fair representation on such
                panel:
 
-      HR 3590 EAS/PP
-                            2375
                         ‘‘(I) Patient advocates.
                         ‘‘(II) Health care providers and
                     health care organizations.
@@ -66912,8 +62166,6 @@ under subsection (a) for a period not to exceed 5 years.
           partment or agency of the United States any in-
           formation that such panel considers necessary to
 
-      HR 3590 EAS/PP
-                           2376
           carry out its duties. To the extent consistent with
           applicable laws and regulations, the head of such
           department or agency shall furnish the requested
@@ -66940,8 +62192,6 @@ under subsection (a) for a period not to exceed 5 years.
       technical assistance to the States applying for or
       awarded grants under subsection (a).
 
-      HR 3590 EAS/PP
-                            2377
           ‘‘(2) R  EQUIREMENTS   .—Technical assistance
       under paragraph (1) shall include—
                ‘‘(A) guidance on non-economic damages,
@@ -66968,8 +62218,6 @@ under subsection (a) for a period not to exceed 5 years.
       propriate research organization to conduct an overall
       evaluation of the effectiveness of grants awarded
 
-      HR 3590 EAS/PP
-                            2378
       under subsection (a) and to annually prepare and
       submit a report to Congress. Such an evaluation shall
       begin not later than 18 months following the date of
@@ -66996,8 +62244,6 @@ under subsection (a) for a period not to exceed 5 years.
           measures described in paragraph (3), of—
 
 
-      HR 3590 EAS/PP
-                            2379
                     ‘‘(i) States receiving grants under sub-
                section (a);
                     ‘‘(ii) States that enacted, prior to the
@@ -67024,8 +62270,6 @@ under subsection (a) for a period not to exceed 5 years.
 
 
 
-      HR 3590 EAS/PP
-                           2380
                ‘‘(C) the disposition of disputes and claims,
           including the length of time and estimated costs
           to all parties;
@@ -67052,8 +62296,6 @@ under subsection (a) for a period not to exceed 5 years.
      care program under title XVIII of the Social Security
      Act, and its beneficiaries.
 
-      HR 3590 EAS/PP
-                           2381
           ‘‘(2) MACPAC.—The Medicaid and CHIP Pay-
      ment and Access Commission shall conduct an inde-
      pendent review of the alternatives to current tort liti-
@@ -67080,8 +62322,6 @@ States for the development of demonstration project applica-
 tions meeting the criteria described in subsection (c). In se-
 lecting States to receive such planning grants, the Secretary
 
-      HR 3590 EAS/PP
-                           2382
 shall give preference to those States in which State law at
 the time of the application would not prohibit the adoption
 of an alternative to current tort litigation.
@@ -67108,8 +62348,6 @@ of an alternative to current tort litigation.
 
 
 
-      HR 3590 EAS/PP
-                          2383
               ‘‘(B) required to be so licensed, registered,
           or certified but that is exempted by other statute
           or regulation.
@@ -67137,8 +62375,6 @@ a free clinic shall in providing services for the free clinic,’’.
 section shall take effect on the date of enactment of this Act
 
 
-      HR 3590 EAS/PP
-                            2384
 and apply to any act or omission which occurs on or after
 that date.
  SEC. 10609. LABELING CHANGES.
@@ -67165,8 +62401,6 @@ under section 502 if—
       subsection agrees to submit revised labeling of the
       drug that is the subject of such application not later
 
-      HR 3590 EAS/PP
-                           2385
       than 60 days after the notification of any changes to
       such labeling required by the Secretary; and
           ‘‘(iv) such application otherwise meets the appli-
@@ -67193,8 +62427,6 @@ added by section 8002(a)(1), is amended—
           part of their automatic enrollment in the
           CLASS program,’’; and
 
-      HR 3590 EAS/PP
-                            2386
           (2) in section 3204—
                (A) in subsection (c)(2), by striking sub-
           paragraph (A) and inserting the following:
@@ -67221,8 +62453,6 @@ Act of 2005, as added by section 8002(d) of this Act, is
 amended by striking ‘‘and coverage available’’ and all that
 follows through ‘‘that program,’’.
 
-      HR 3590 EAS/PP
-                         2387
 
   Subtitle H—Provisions Relating to
                     Title IX
@@ -67250,8 +62480,6 @@ ber 31, 2012.
 
 
 
-     HR 3590 EAS/PP
-                          2388
  SEC. 10902. INFLATION ADJUSTMENT OF LIMITATION ON
              HEALTH FLEXIBLE SPENDING ARRANGE-
              MENTS UNDER CAFETERIA PLANS.
@@ -67278,8 +62506,6 @@ of this Act, is amended to read as follows:
           in which such taxable year begins by sub-
           stituting ‘calendar year 2010’ for ‘calendar year
           1992’ in subparagraph (B) thereof.
-      HR 3590 EAS/PP
-                          2389
      If any increase determined under this paragraph is
      not a multiple of $50, such increase shall be rounded
      to the next lowest multiple of $50.’’.
@@ -67306,8 +62532,6 @@ ed—
      after ‘‘$2,000,000,000’’, and
 
 
-      HR 3590 EAS/PP
-                          2390
           (3) by striking ‘‘2008’’ in subsection (i) and in-
      serting ‘‘2009’’.
      (b) EFFECTIVE D ATE.—The amendments made by this
@@ -67334,8 +62558,6 @@ section 9009.
           ‘‘(2) MOUNTS TAKEN INTO ACCOUNT  .—For pur-
      poses of paragraph (1), the net premiums written
 
-      HR 3590 EAS/PP
-                              2391
        with respect to health insurance for any United
        States health risk that are taken into account during
        any calendar year with respect to any covered entity
@@ -67368,8 +62590,6 @@ in accordance with the following table:
     ‘‘Calendar year                             Applicable
                                                   amount
         2011 ...................................$2,000,000,000............................
-       HR 3590 EAS/PP
-                            2392
        2012 ................................$4,000,000,000...............................
        2013 ................................$7,000,000,000...............................
        2014, 2015 and 2016 .................$9,000,000,000...................
@@ -67398,8 +62618,6 @@ ing at the end the following new subparagraphs:
                of last resort in the State and is subject to
                State guarantee issue requirements, and
 
-      HR 3590 EAS/PP
-                            2393
                     ‘‘(iv) for which the medical loss ratio
                (determined in a manner consistent with
                the determination of such ratio under sec-
@@ -67426,8 +62644,6 @@ ing at the end the following new subparagraphs:
 
 
 
-      HR 3590 EAS/PP
-                            2394
                         ‘‘(II) with respect to all such mar-
                     kets for such entity for the calendar
                     year is not less than 92 percent, or
@@ -67454,8 +62670,6 @@ ing at the end the following new subparagraphs:
                to all such markets for such entity for the
                preceding calendar year is not less than 89
 
-      HR 3590 EAS/PP
-                           2395
               percent (except that with respect to such an-
               nual payment date for 2012, the calculation
               under 2718(b)(1)(B)(ii) of such Act is deter-
@@ -67482,8 +62696,6 @@ prescribe such regulations as are necessary or appropriate
 to prevent avoidance of the purposes of this section, includ-
 
 
-      HR 3590 EAS/PP
-                            2396
 ing inappropriate actions taken to qualify as an exempt
 entity under subsection (c)(2)’’ after ‘‘section’’.
       (f) ONFORMING   AMENDMENTS   .—
@@ -67510,8 +62722,6 @@ entity under subsection (c)(2)’’ after ‘‘section’’.
 
 
 
-      HR 3590 EAS/PP
-                           2397
               (B) by striking ‘‘, and any third party ad-
           ministration agreement fees received after such
           date’’.
@@ -67538,8 +62748,6 @@ and taxable years beginning, after December 31, 2012.
 made by, section 9017 of this Act are hereby deemed null,
 void, and of no effect.
 
-      HR 3590 EAS/PP
-                          2398
      (b) EXCISE  TAX ON  INDOOR  T ANNING  SERVICES.—
 Subtitle D of the Internal Revenue Code of 1986, as amend-
 ed by this Act, is amended by adding at the end the fol-
@@ -67566,8 +62774,6 @@ section—
      service performed by a licensed medical professional.
      ‘‘(c) AYMENT OF T AX.—
 
-      HR 3590 EAS/PP
-                            2399
            ‘‘(1)N GENERAL  .—The tax imposed by this sec-
       tion shall be paid by the individual on whom the
       service is performed.
@@ -67594,8 +62800,6 @@ section shall apply to services performed on or after July
 
 
 
-      HR 3590 EAS/PP
-                          2400
  SEC. 10908. EXCLUSION FOR ASSISTANCE PROVIDED TO
              PARTICIPANTS IN STATE STUDENT LOAN RE-
              PAYMENT PROGRAMS FOR CERTAIN HEALTH
@@ -67622,8 +62826,6 @@ in taxable years beginning after December 31, 2008.
      (a) NCREASE IN D OLLAR LIMITATION .—
           (1) DOPTION CREDIT .—
 
-      HR 3590 EAS/PP
-                            2401
                 (A) IN GENERAL  .—Paragraph (1) of section
            23(b) of the Internal Revenue Code of 1986 (re-
            lating to dollar limitation) is amended by strik-
@@ -67650,8 +62852,6 @@ in taxable years beginning after December 31, 2008.
            mined under section 1(f)(3) for the calendar year
            in which the taxable year begins, determined by
 
-      HR 3590 EAS/PP
-                           2402
           substituting ‘calendar year 2009’ for ‘calendar
           year 1992’ in subparagraph (B) thereof.
       If any amount as increased under the preceding sen-
@@ -67678,8 +62878,6 @@ in taxable years beginning after December 31, 2008.
                (B) C HILD WITH SPECIAL NEEDS    .—Para-
           graph (2) of section 137(a) of such Code (relat-
 
-      HR 3590 EAS/PP
-                            2403
            ing to $10,000 exclusion for adoption of child
            with special needs regardless of expenses) is
            amended—
@@ -67706,8 +62904,6 @@ in taxable years beginning after December 31, 2008.
       tence is not a multiple of $10, such amount shall be
       rounded to the nearest multiple of $10.
 
-      HR 3590 EAS/PP
-                          2404
           ‘‘(2)NCOME LIMITATION  .—In the case of a tax-
      able year beginning after December 31, 2002, the dol-
      lar amount in subsection (b)(2)(A) shall be increased
@@ -67734,8 +62930,6 @@ in taxable years beginning after December 31, 2008.
           A of chapter 1.
           (2) CONFORMING AMENDMENTS   .—
 
-      HR 3590 EAS/PP
-                            2405
                (A) Section 24(b)(3)(B) of such Code is
           amended by striking ‘‘23,’’.
                (B) Section 25(e)(1)(C) of such Code is
@@ -67762,8 +62956,6 @@ in taxable years beginning after December 31, 2008.
                section (b), and
                     (ii) by striking subsection (c).
 
-      HR 3590 EAS/PP
-                            2406
                (J) Section 137 of such Code is amended—
                     (i) by striking ‘‘section 23(d)’’ in sub-
                section (d) and inserting ‘‘section 36C(d)’’,
@@ -67790,8 +62982,6 @@ in taxable years beginning after December 31, 2008.
           nal Revenue Code of 1986, as amended by this
 
 
-      HR 3590 EAS/PP
-                           2407
           Act, is amended by inserting after the item relat-
           ing to section 36B the following new item:
     ‘‘Sec. 36C. Adoption expenses.’’.
@@ -67819,8 +63009,6 @@ ber 31, 2009.
 
 
 
-      HR 3590 EAS/PP
-                  111
                  1TH
                  ST
 Ordered to be priESSIONs passed

--- a/spec/processors/remove_headers_spec.rb
+++ b/spec/processors/remove_headers_spec.rb
@@ -1,6 +1,18 @@
 require "processors/remove_headers"
 
 describe Processors::RemoveHeaders do
+  it "can locate headers that don't appear on the first line" do
+    expect(Processors::RemoveHeaders.process(<<-DOC)).
+      Some text
+      FRA17032   S.L.C.
+      Some more text
+    DOC
+    to eq(<<-DOC)
+      Some text
+      Some more text
+    DOC
+  end
+
   it "removes exact matches for the header" do
     expect(Processors::RemoveHeaders.process(<<-DOC)).
       FRA17032   S.L.C.
@@ -41,21 +53,6 @@ describe Processors::RemoveHeaders do
     DOC
   end
 
-  it "Only identifies headers of the format AAA#####" do
-    expect(Processors::RemoveHeaders.process(<<-DOC)).
-      II
-      Some text
-      Section II
-      Some more text
-    DOC
-    to eq(<<-DOC)
-      II
-      Some text
-      Section II
-      Some more text
-    DOC
-  end
-
   it "removes page numbers on lines immediately following the headers" do
     expect(Processors::RemoveHeaders.process(<<-DOC)).
       FRA17032      S.L.C.
@@ -72,5 +69,38 @@ describe Processors::RemoveHeaders do
       Some more text
       Even more text
     DOC
+  end
+
+  describe "header formats" do
+    it "identifies senate-style headers, of the format ABC12345" do
+      expect(Processors::RemoveHeaders.process(<<-DOC)).
+        FRA17032   S.L.C.
+        Some text
+      DOC
+      to eq(<<-DOC)
+        Some text
+      DOC
+    end
+
+    it "does not remove arbitrary strings that appear on the first line" do
+      expect(Processors::RemoveHeaders.process(<<-DOC)).
+        II
+        Some text
+      DOC
+      to eq(<<-DOC)
+        II
+        Some text
+      DOC
+    end
+
+    it "identifies house-style headers, of the format HR 1234" do
+      expect(Processors::RemoveHeaders.process(<<-DOC)).
+        †HR 757 EAS
+        Some text
+      DOC
+      to eq(<<-DOC)
+        Some text
+      DOC
+    end
   end
 end


### PR DESCRIPTION
We had to change up the logic a bit,
because sometimes the House documents don't include the header
on the first page.

Our processor had assumed that a document's header would always be on
the first line - now it goes strictly by the specified header formats.